### PR TITLE
feat(provider-connectivity): pre-persist validation + CRUD job-defs (BACKLOG #7-#10)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -165,15 +165,14 @@ aceptó con 201. El worker, al procesar, falla con
 sin contraste contra el descriptor del endpoint. La validación cae en el worker
 en time-of-fetch, demasiado tarde.
 
-**Workaround aplicado:** `UPDATE provider_job_definitions SET params = jsonb_build_object(...)`
-para reescribir las 34 filas a la shape correcta.
+**Fix aplicado:** `ScheduleEndpointFetchUseCase` recibe ahora un
+`EndpointParamsValidator` (puerto sobre `ProviderRegistry.endpoint().paramsSchema`)
+y valida los `params` antes de persistir; si fallan, lanza `InvalidInputError`
+(→ 400). Como el `safeParse` strippea claves desconocidas, los campos
+inyectados por el sistema (`organizationId`, `trackedKeywordId`) viajan ahora
+en `cmd.systemParams` y se mergean tras la validación.
 
-**Tarea para devs (alta prioridad):**
-1. Que cada `EndpointDescriptor` exponga su `paramsSchema` (Zod).
-2. `ScheduleEndpointFetchUseCase` valida `params` contra ese schema antes de
-   guardar. Si falla, devuelve 400 con los errores Zod.
-
-**Estado:** ✅ workaround. **Bloquea cualquier scheduling vía API.**
+**Estado:** ✅ resuelto.
 
 ---
 
@@ -185,15 +184,15 @@ para reescribir las 34 filas a la shape correcta.
 **Causa:** `RegisterProviderCredentialUseCase` guarda `plaintextSecret` cifrado
 sin pedirle al provider que lo valide.
 
-**Workaround aplicado:** registrar una segunda credencial con el separador
-correcto y borrar la antigua via SQL.
+**Fix aplicado:** la interfaz `Provider` ahora expone
+`validateCredentialPlaintext(plain: string): void` (lanza `InvalidInputError`
+si el formato no encaja). DataForSEO delega en `parseCredential`, GSC en
+`parseServiceAccount`. `RegisterProviderCredentialUseCase` recibe un
+`CredentialFormatValidator` (puerto sobre `ProviderRegistry`) y lo invoca
+antes de cifrar — credenciales mal formadas fallan en POST con 400 en lugar
+de quemarse en el worker en el primer fetch.
 
-**Tarea para devs:**
-- Cada `Provider` expone `validateCredentialPlaintext(plain: string): Result<void, Error>`.
-- `RegisterProviderCredentialUseCase` lo invoca antes de cifrar. Si falla, 400.
-
-**Estado:** ✅ workaround. **Confunde al usuario** (la credencial parece OK
-hasta que el primer job falla).
+**Estado:** ✅ resuelto.
 
 ---
 
@@ -206,18 +205,19 @@ procesó los 34 SERPs OK pero NO grabó NINGUNA `RankingObservation`.
 `params.trackedKeywordId` está presente. `ScheduleEndpointFetchUseCase` no
 sabe nada de tracked keywords — son contextos separados.
 
-**Workaround aplicado:** SQL UPDATE para inyectar `trackedKeywordId` en cada
-def matcheando por `(project_id, domain, phrase, country, language)`. Tras
-eso, los 34 SERPs siguientes generaron 34 ranking_observations correctas.
+**Fix aplicado (opción B, mínimo viable):** `ScheduleEndpointRequest` admite
+ahora un `trackedKeywordId` opcional. El controller lo añade a `systemParams`,
+que el use case mergea tras la validación. Con el campo presente, el
+processor materializará la `RankingObservation` correspondiente; sin él, el
+fetch sigue siendo válido como auditoría one-off (raw payload sin
+observación).
 
-**Tarea para devs (alta prioridad):**
-- Opción A: que `StartTrackingKeywordUseCase` también cree el JobDefinition
-  asociado, con cron por defecto y `trackedKeywordId` ya en params.
-- Opción B: nuevo endpoint `POST /rank-tracking/keywords/:id/schedule` que
-  envuelva `ScheduleEndpointFetchUseCase` y rellene `trackedKeywordId` solo.
+**Pendiente (no bloqueante, mejora UX):** opción A — que
+`StartTrackingKeywordUseCase` cree por defecto el JobDefinition asociado con
+cron semanal y el `trackedKeywordId` precargado, para evitar que el caller
+tenga que componer dos requests.
 
-**Estado:** ✅ workaround. **Bug crítico de UX**: scheduling sin
-trackedKeywordId gasta API quota sin generar datos visibles.
+**Estado:** ✅ resuelto a nivel API.
 
 ---
 
@@ -226,14 +226,22 @@ trackedKeywordId gasta API quota sin generar datos visibles.
 a `provider_job_definitions` para reescribir params. La API solo expone POST
 para crear, no GET/PUT/DELETE.
 
-**Tarea para devs (alta prioridad — convergente con A8):**
-- `GET /projects/:projectId/schedules` para listar todas las definiciones.
-- `GET /providers/:id/job-definitions/:defId` para inspeccionar.
-- `PATCH /providers/:id/job-definitions/:defId` para actualizar params/cron/enabled.
-- `DELETE /providers/:id/job-definitions/:defId` para des-programar.
+**Fix aplicado:** cuatro endpoints nuevos en `ProvidersController` (con
+chequeo de pertenencia al proyecto/org reutilizando un helper
+`loadDefinitionAndAuthorize`):
+- `GET /providers/job-definitions/by-project/:projectId` — lista.
+- `GET /providers/:providerId/job-definitions/:defId` — inspeccionar.
+- `PATCH /providers/:providerId/job-definitions/:defId` — actualizar
+  `cron` / `params` / `enabled` (re-registra el repeatable en BullMQ con el
+  nuevo patrón).
+- `DELETE /providers/:providerId/job-definitions/:defId` — des-programar
+  (unregister + delete row).
 
-**Estado:** ❌ pendiente. **Sin esto, cualquier corrección post-mortem requiere
-acceso DB directo.**
+Use cases en `manage-job-definition.use-cases.ts`. SDK actualizado con los
+métodos `listJobDefinitions / getJobDefinition / updateJobDefinition /
+deleteJobDefinition / runJobDefinitionNow`.
+
+**Estado:** ✅ resuelto a nivel API/SDK.
 
 ---
 
@@ -268,15 +276,11 @@ un proyecto vacío".
   el operador y no se pueden pausar/des-schedule.
 
 ### A4. Disparar un fetch one-off (manual)
-- **API:** **NO EXISTE** endpoint para esto. La única forma de trigger es
-  esperar al cron de un schedule existente (mín. 1 minuto si se usa `* * * * *`).
-- **Falta:** `POST /providers/:id/endpoints/:eid/run-now` que llame a
-  `JobScheduler.enqueueOnce(definition, runId)` (el método ya existe en el
-  adapter BullMQ, solo falta exponerlo).
-  Luego un botón "Run now" en cada keyword/schedule.
-- **Workaround actual:** ninguno limpio. Para el bootstrap inicial usé
-  schedules con cron weekly que NO se ejecutan hasta el siguiente lunes 06:00
-  UTC — los datos no aparecen hasta entonces.
+- **API:** ✅ `POST /providers/:id/job-definitions/:defId/run-now` ya existe
+  (commit `958b8c3`).
+- **SDK:** `api.providers.runJobDefinitionNow(...)` añadido.
+- **Falta:** botón "Run now" en cada fila de schedule/keyword cuando exista
+  la vista A8.
 
 ### A5. Añadir domain o location extra a un proyecto
 - **API:** `POST /projects/:id/domains` y `/projects/:id/locations`
@@ -297,8 +301,9 @@ un proyecto vacío".
   está en otros proyectos del stack).
 
 ### A8. Vista de schedules y job runs
-- **API:** falta — solo hay POST schedule, no GET/DELETE.
-- **Falta:** todo. Sin esto el operador no sabe qué fetches están programados
-  ni sus runs pasados.
-
-### A9. Bootstrap UX: po
+- **API schedules:** ✅ resuelto por el item 10 (GET/PATCH/DELETE).
+- **API job runs:** falta endpoint `GET /providers/.../job-definitions/:defId/runs`
+  (la tabla `provider_job_runs` ya existe; solo hay que exponerla).
+- **UI:** todo pendiente — tabla de schedules con acciones (run-now, edit
+  cron, pause/disable, delete) y, por fila, un drawer con el historial de
+  runs (status, cost, duration, runId).

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -10,7 +10,7 @@ import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@ran
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { GscProvider } from '@rankpulse/provider-gsc';
-import { SystemClock, SystemIdGenerator } from '@rankpulse/shared';
+import { InvalidInputError, SystemClock, SystemIdGenerator } from '@rankpulse/shared';
 import { JwtService } from '../common/auth/jwt.service.js';
 import type { AppEnv } from '../config/env.js';
 import { Tokens } from './tokens.js';
@@ -116,6 +116,11 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const registerCredential = new PCUseCases.RegisterProviderCredentialUseCase(
 		credentialRepo,
 		credentialVault,
+		{
+			validate: (providerId, plaintextSecret) => {
+				providerRegistry.get(providerId).validateCredentialPlaintext(plaintextSecret);
+			},
+		},
 		SystemClock,
 		SystemIdGenerator,
 		eventPublisher,
@@ -134,6 +139,18 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const scheduleEndpointFetch = new PCUseCases.ScheduleEndpointFetchUseCase(
 		jobDefRepo,
 		jobScheduler,
+		{
+			validate: (providerId, endpointId, params) => {
+				const descriptor = providerRegistry.endpoint(providerId, endpointId);
+				const parsed = descriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(
+						`Invalid params for ${providerId}/${endpointId}: ${parsed.error.message}`,
+					);
+				}
+				return parsed.data as Record<string, unknown>;
+			},
+		},
 		SystemClock,
 		SystemIdGenerator,
 		eventPublisher,

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -135,6 +135,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		jobScheduler,
 		SystemIdGenerator,
 	);
+	const listJobDefinitions = new PCUseCases.ListJobDefinitionsUseCase(jobDefRepo);
+	const getJobDefinition = new PCUseCases.GetJobDefinitionUseCase(jobDefRepo);
+	const updateJobDefinition = new PCUseCases.UpdateJobDefinitionUseCase(jobDefRepo, jobScheduler);
+	const deleteJobDefinition = new PCUseCases.DeleteJobDefinitionUseCase(jobDefRepo, jobScheduler);
 
 	const scheduleEndpointFetch = new PCUseCases.ScheduleEndpointFetchUseCase(
 		jobDefRepo,
@@ -230,6 +234,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.ResolveProviderCredential, resolveCredential),
 		value(Tokens.ScheduleEndpointFetch, scheduleEndpointFetch),
 		value(Tokens.TriggerJobDefinitionRun, triggerJobDefinitionRun),
+		value(Tokens.ListJobDefinitions, listJobDefinitions),
+		value(Tokens.GetJobDefinition, getJobDefinition),
+		value(Tokens.UpdateJobDefinition, updateJobDefinition),
+		value(Tokens.DeleteJobDefinition, deleteJobDefinition),
 		value(Tokens.RecordApiUsage, recordApiUsage),
 
 		value(Tokens.TrackedKeywordRepository, trackedKeywordRepo),

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -52,6 +52,10 @@ export const Tokens = {
 	ResolveProviderCredential: Symbol('ResolveProviderCredentialUseCase'),
 	ScheduleEndpointFetch: Symbol('ScheduleEndpointFetchUseCase'),
 	TriggerJobDefinitionRun: Symbol('TriggerJobDefinitionRunUseCase'),
+	ListJobDefinitions: Symbol('ListJobDefinitionsUseCase'),
+	GetJobDefinition: Symbol('GetJobDefinitionUseCase'),
+	UpdateJobDefinition: Symbol('UpdateJobDefinitionUseCase'),
+	DeleteJobDefinition: Symbol('DeleteJobDefinitionUseCase'),
 	RecordApiUsage: Symbol('RecordApiUsageUseCase'),
 
 	// Rank-Tracking ports

--- a/apps/api/src/modules/provider-connectivity/providers.controller.ts
+++ b/apps/api/src/modules/provider-connectivity/providers.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Inject, Param, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Inject, Param, Patch, Post } from '@nestjs/common';
 import type { ProviderConnectivity as PCUseCases } from '@rankpulse/application';
 import { ProviderConnectivityContracts } from '@rankpulse/contracts';
 import type { IdentityAccess, ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
@@ -12,7 +12,9 @@ import { Tokens } from '../../composition/tokens.js';
 
 type RegisterCredentialRequest = ProviderConnectivityContracts.RegisterCredentialRequest;
 type ScheduleEndpointRequest = ProviderConnectivityContracts.ScheduleEndpointRequest;
+type UpdateJobDefinitionRequest = ProviderConnectivityContracts.UpdateJobDefinitionRequest;
 type ProviderDto = ProviderConnectivityContracts.ProviderDto;
+type JobDefinitionDto = ProviderConnectivityContracts.JobDefinitionDto;
 
 @Controller('providers')
 export class ProvidersController {
@@ -25,12 +27,42 @@ export class ProvidersController {
 		@Inject(Tokens.ScheduleEndpointFetch) private readonly schedule: PCUseCases.ScheduleEndpointFetchUseCase,
 		@Inject(Tokens.TriggerJobDefinitionRun)
 		private readonly triggerRun: PCUseCases.TriggerJobDefinitionRunUseCase,
+		@Inject(Tokens.ListJobDefinitions)
+		private readonly listJobs: PCUseCases.ListJobDefinitionsUseCase,
+		@Inject(Tokens.GetJobDefinition)
+		private readonly getJob: PCUseCases.GetJobDefinitionUseCase,
+		@Inject(Tokens.UpdateJobDefinition)
+		private readonly updateJob: PCUseCases.UpdateJobDefinitionUseCase,
+		@Inject(Tokens.DeleteJobDefinition)
+		private readonly deleteJob: PCUseCases.DeleteJobDefinitionUseCase,
 		@Inject(Tokens.JobDefinitionRepository)
 		private readonly jobDefs: ProviderConnectivity.JobDefinitionRepository,
 		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
 		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
 	) {
 		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	private async loadDefinitionAndAuthorize(
+		principal: AuthPrincipal,
+		providerId: string,
+		definitionId: string,
+	): Promise<ProviderConnectivity.ProviderJobDefinition> {
+		const definition = await this.jobDefs.findById(
+			definitionId as ProviderConnectivity.ProviderJobDefinitionId,
+		);
+		if (!definition) {
+			throw new NotFoundError(`Job definition ${definitionId} not found`);
+		}
+		if (definition.providerId.value !== providerId) {
+			throw new NotFoundError(`Job definition ${definitionId} does not belong to provider ${providerId}`);
+		}
+		const project = await this.projects.findById(definition.projectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${definition.projectId} not found`);
+		}
+		await this.orgMembership.require(principal, project.organizationId);
+		return definition;
 	}
 
 	@Get()
@@ -88,21 +120,54 @@ export class ProvidersController {
 		@Param('providerId') providerId: string,
 		@Param('definitionId') definitionId: string,
 	): Promise<{ runId: string; definitionId: string }> {
-		const definition = await this.jobDefs.findById(
-			definitionId as ProviderConnectivity.ProviderJobDefinitionId,
-		);
-		if (!definition) {
-			throw new NotFoundError(`Job definition ${definitionId} not found`);
-		}
-		if (definition.providerId.value !== providerId) {
-			throw new NotFoundError(`Job definition ${definitionId} does not belong to provider ${providerId}`);
-		}
-		const project = await this.projects.findById(definition.projectId);
+		await this.loadDefinitionAndAuthorize(principal, providerId, definitionId);
+		return this.triggerRun.execute({ definitionId });
+	}
+
+	@Get('job-definitions/by-project/:projectId')
+	async listJobDefinitions(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<JobDefinitionDto[]> {
+		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
 		if (!project) {
-			throw new NotFoundError(`Project ${definition.projectId} not found`);
+			throw new NotFoundError(`Project ${projectId} not found`);
 		}
 		await this.orgMembership.require(principal, project.organizationId);
-		return this.triggerRun.execute({ definitionId });
+		return this.listJobs.execute(projectId);
+	}
+
+	@Get(':providerId/job-definitions/:definitionId')
+	async getJobDefinition(
+		@Principal() principal: AuthPrincipal,
+		@Param('providerId') providerId: string,
+		@Param('definitionId') definitionId: string,
+	): Promise<JobDefinitionDto> {
+		await this.loadDefinitionAndAuthorize(principal, providerId, definitionId);
+		return this.getJob.execute(definitionId);
+	}
+
+	@Patch(':providerId/job-definitions/:definitionId')
+	async patchJobDefinition(
+		@Principal() principal: AuthPrincipal,
+		@Param('providerId') providerId: string,
+		@Param('definitionId') definitionId: string,
+		@Body(new ZodValidationPipe(ProviderConnectivityContracts.UpdateJobDefinitionRequest))
+		body: UpdateJobDefinitionRequest,
+	): Promise<JobDefinitionDto> {
+		await this.loadDefinitionAndAuthorize(principal, providerId, definitionId);
+		return this.updateJob.execute({ definitionId, ...body });
+	}
+
+	@Delete(':providerId/job-definitions/:definitionId')
+	@HttpCode(204)
+	async deleteJobDefinition(
+		@Principal() principal: AuthPrincipal,
+		@Param('providerId') providerId: string,
+		@Param('definitionId') definitionId: string,
+	): Promise<void> {
+		await this.loadDefinitionAndAuthorize(principal, providerId, definitionId);
+		await this.deleteJob.execute(definitionId);
 	}
 
 	@Post(':providerId/endpoints/:endpointId/schedule')

--- a/apps/api/src/modules/provider-connectivity/providers.controller.ts
+++ b/apps/api/src/modules/provider-connectivity/providers.controller.ts
@@ -118,14 +118,18 @@ export class ProvidersController {
 			throw new NotFoundError(`Project ${body.projectId} not found`);
 		}
 		await this.orgMembership.require(principal, project.organizationId);
-		// The worker reads organizationId from params to enforce scoping. Inject
-		// it transparently so callers don't need to repeat it.
-		const params = { ...body.params, organizationId: project.organizationId };
+		// `systemParams` are merged after Zod validation so they survive the
+		// endpoint's paramsSchema strip (organizationId scopes the run for the
+		// worker; trackedKeywordId tells the processor to materialize a
+		// RankingObservation per fetched SERP — see BACKLOG #9).
+		const systemParams: Record<string, unknown> = { organizationId: project.organizationId };
+		if (body.trackedKeywordId) systemParams.trackedKeywordId = body.trackedKeywordId;
 		return this.schedule.execute({
 			projectId: body.projectId,
 			providerId,
 			endpointId,
-			params,
+			params: body.params,
+			systemParams,
 			cron: body.cron,
 			credentialOverrideId: body.credentialOverrideId ?? null,
 		});

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -283,6 +283,94 @@ export function buildOpenApiDocument(): unknown {
 		},
 	});
 
+	registry.registerPath({
+		method: 'post',
+		path: '/api/v1/providers/{providerId}/job-definitions/{definitionId}/run-now',
+		summary: 'Trigger an immediate one-off run of an existing job definition',
+		tags: ['provider-connectivity'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ providerId: z.string(), definitionId: z.string().uuid() }) },
+		responses: {
+			201: {
+				description: 'Run enqueued',
+				content: {
+					'application/json': {
+						schema: z.object({ runId: z.string().uuid(), definitionId: z.string().uuid() }),
+					},
+				},
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'get',
+		path: '/api/v1/providers/job-definitions/by-project/{projectId}',
+		summary: 'List all job definitions scheduled for a project',
+		tags: ['provider-connectivity'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ projectId: z.string().uuid() }) },
+		responses: {
+			200: {
+				description: 'Job definitions',
+				content: { 'application/json': { schema: z.array(ProviderConnectivityContracts.JobDefinitionDto) } },
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'get',
+		path: '/api/v1/providers/{providerId}/job-definitions/{definitionId}',
+		summary: 'Inspect a single job definition',
+		tags: ['provider-connectivity'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ providerId: z.string(), definitionId: z.string().uuid() }) },
+		responses: {
+			200: {
+				description: 'Job definition',
+				content: { 'application/json': { schema: ProviderConnectivityContracts.JobDefinitionDto } },
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'patch',
+		path: '/api/v1/providers/{providerId}/job-definitions/{definitionId}',
+		summary: 'Update cron / params / enabled on an existing job definition',
+		tags: ['provider-connectivity'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: {
+			params: z.object({ providerId: z.string(), definitionId: z.string().uuid() }),
+			body: {
+				content: {
+					'application/json': { schema: ProviderConnectivityContracts.UpdateJobDefinitionRequest },
+				},
+			},
+		},
+		responses: {
+			200: {
+				description: 'Updated job definition',
+				content: { 'application/json': { schema: ProviderConnectivityContracts.JobDefinitionDto } },
+			},
+			...errorResponses([400, 401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'delete',
+		path: '/api/v1/providers/{providerId}/job-definitions/{definitionId}',
+		summary: 'Unregister and delete a job definition',
+		tags: ['provider-connectivity'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ providerId: z.string(), definitionId: z.string().uuid() }) },
+		responses: {
+			204: { description: 'Deleted' },
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
 	// ---- rank-tracking ----
 
 	registry.registerPath({

--- a/packages/application/src/provider-connectivity/index.ts
+++ b/packages/application/src/provider-connectivity/index.ts
@@ -1,3 +1,4 @@
+export * from './use-cases/manage-job-definition.use-cases.js';
 export * from './use-cases/record-api-usage.use-case.js';
 export * from './use-cases/register-provider-credential.use-case.js';
 export * from './use-cases/resolve-provider-credential.use-case.js';

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
@@ -1,0 +1,171 @@
+import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it } from 'vitest';
+import {
+	DeleteJobDefinitionUseCase,
+	GetJobDefinitionUseCase,
+	ListJobDefinitionsUseCase,
+	UpdateJobDefinitionUseCase,
+} from './manage-job-definition.use-cases.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as ProjectManagement.ProjectId;
+const OTHER_PROJECT_ID = 'aaaaaaaa-1111-1111-1111-111111111111' as ProjectManagement.ProjectId;
+
+class StubDefinitionRepo implements ProviderConnectivity.JobDefinitionRepository {
+	readonly store = new Map<string, ProviderConnectivity.ProviderJobDefinition>();
+	put(def: ProviderConnectivity.ProviderJobDefinition): void {
+		this.store.set(def.id, def);
+	}
+	async save(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.store.set(d.id, d);
+	}
+	async findById(id: ProviderConnectivity.ProviderJobDefinitionId) {
+		return this.store.get(id) ?? null;
+	}
+	async findFor() {
+		return null;
+	}
+	async listForProject(projectId: ProjectManagement.ProjectId) {
+		return [...this.store.values()].filter((d) => d.projectId === projectId);
+	}
+	async delete(id: ProviderConnectivity.ProviderJobDefinitionId) {
+		this.store.delete(id);
+	}
+}
+
+class RecordingScheduler implements ProviderConnectivity.JobScheduler {
+	readonly registered: ProviderConnectivity.ProviderJobDefinition[] = [];
+	readonly unregistered: ProviderConnectivity.ProviderJobDefinition[] = [];
+	async register(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.registered.push(d);
+	}
+	async unregister(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.unregistered.push(d);
+	}
+	async enqueueOnce(): Promise<void> {}
+}
+
+const buildDef = (overrides: Partial<{ id: string; projectId: ProjectManagement.ProjectId }> = {}) =>
+	ProviderConnectivity.ProviderJobDefinition.schedule({
+		id: (overrides.id ?? 'def-1') as ProviderConnectivity.ProviderJobDefinitionId,
+		projectId: overrides.projectId ?? PROJECT_ID,
+		providerId: ProviderConnectivity.ProviderId.create('dataforseo'),
+		endpointId: ProviderConnectivity.EndpointId.create('serp-google-organic-live'),
+		params: { keyword: 'k', locationCode: 2724, languageCode: 'es', device: 'desktop' },
+		cron: ProviderConnectivity.CronExpression.create('0 6 * * 1'),
+		credentialOverrideId: null,
+		now: new Date('2026-05-04T00:00:00Z'),
+	});
+
+describe('ListJobDefinitionsUseCase', () => {
+	it('returns all definitions for the requested project, formatted as JobDefinitionView', async () => {
+		const repo = new StubDefinitionRepo();
+		repo.put(buildDef({ id: 'def-1' }));
+		repo.put(buildDef({ id: 'def-2' }));
+		repo.put(buildDef({ id: 'def-other', projectId: OTHER_PROJECT_ID }));
+
+		const result = await new ListJobDefinitionsUseCase(repo).execute(PROJECT_ID);
+
+		expect(result.map((v) => v.id).sort()).toEqual(['def-1', 'def-2']);
+		expect(result[0]?.cron).toBe('0 6 * * 1');
+		expect(result[0]?.enabled).toBe(true);
+		expect(result[0]?.lastRunAt).toBeNull();
+		expect(typeof result[0]?.createdAt).toBe('string');
+	});
+
+	it('returns an empty array when no definitions match', async () => {
+		const result = await new ListJobDefinitionsUseCase(new StubDefinitionRepo()).execute(PROJECT_ID);
+		expect(result).toEqual([]);
+	});
+});
+
+describe('GetJobDefinitionUseCase', () => {
+	it('returns the formatted view when the definition exists', async () => {
+		const repo = new StubDefinitionRepo();
+		repo.put(buildDef({ id: 'def-1' }));
+
+		const view = await new GetJobDefinitionUseCase(repo).execute('def-1');
+
+		expect(view.id).toBe('def-1');
+		expect(view.providerId).toBe('dataforseo');
+		expect(view.endpointId).toBe('serp-google-organic-live');
+	});
+
+	it('throws NotFoundError when the definition does not exist', async () => {
+		await expect(
+			new GetJobDefinitionUseCase(new StubDefinitionRepo()).execute('missing'),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});
+
+describe('UpdateJobDefinitionUseCase', () => {
+	it('updates cron and re-registers the repeatable in the scheduler', async () => {
+		const repo = new StubDefinitionRepo();
+		const scheduler = new RecordingScheduler();
+		repo.put(buildDef({ id: 'def-1' }));
+
+		const view = await new UpdateJobDefinitionUseCase(repo, scheduler).execute({
+			definitionId: 'def-1',
+			cron: '0 12 * * *',
+		});
+
+		expect(view.cron).toBe('0 12 * * *');
+		expect(scheduler.unregistered).toHaveLength(1);
+		expect(scheduler.registered).toHaveLength(1);
+		// unregister BEFORE register so BullMQ removes the OLD repeatable hash.
+		expect(scheduler.registered[0]?.cron.value).toBe('0 12 * * *');
+	});
+
+	it('updates params after merging into the existing definition', async () => {
+		const repo = new StubDefinitionRepo();
+		repo.put(buildDef({ id: 'def-1' }));
+
+		const view = await new UpdateJobDefinitionUseCase(repo, new RecordingScheduler()).execute({
+			definitionId: 'def-1',
+			params: { keyword: 'new', locationCode: 2840, languageCode: 'en', device: 'mobile' },
+		});
+
+		expect(view.params).toMatchObject({ keyword: 'new', device: 'mobile' });
+	});
+
+	it('disables the definition when enabled=false (and unregisters from scheduler)', async () => {
+		const repo = new StubDefinitionRepo();
+		const scheduler = new RecordingScheduler();
+		repo.put(buildDef({ id: 'def-1' }));
+
+		const view = await new UpdateJobDefinitionUseCase(repo, scheduler).execute({
+			definitionId: 'def-1',
+			enabled: false,
+		});
+
+		expect(view.enabled).toBe(false);
+		// register() is still called; the BullMqJobScheduler honours `enabled=false`
+		// internally by skipping the repeatable add. We just assert the call shape.
+		expect(scheduler.registered[0]?.enabled).toBe(false);
+	});
+
+	it('throws NotFoundError when the definition does not exist', async () => {
+		const useCase = new UpdateJobDefinitionUseCase(new StubDefinitionRepo(), new RecordingScheduler());
+		await expect(useCase.execute({ definitionId: 'missing', cron: '* * * * *' })).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+});
+
+describe('DeleteJobDefinitionUseCase', () => {
+	it('unregisters from the scheduler then removes the row', async () => {
+		const repo = new StubDefinitionRepo();
+		const scheduler = new RecordingScheduler();
+		repo.put(buildDef({ id: 'def-1' }));
+
+		await new DeleteJobDefinitionUseCase(repo, scheduler).execute('def-1');
+
+		expect(scheduler.unregistered).toHaveLength(1);
+		expect(repo.store.has('def-1')).toBe(false);
+	});
+
+	it('throws NotFoundError when the definition does not exist', async () => {
+		const useCase = new DeleteJobDefinitionUseCase(new StubDefinitionRepo(), new RecordingScheduler());
+		await expect(useCase.execute('missing')).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
@@ -1,0 +1,96 @@
+import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface JobDefinitionView {
+	id: string;
+	projectId: string;
+	providerId: string;
+	endpointId: string;
+	params: Record<string, unknown>;
+	cron: string;
+	credentialOverrideId: string | null;
+	enabled: boolean;
+	lastRunAt: string | null;
+	createdAt: string;
+}
+
+const toView = (d: ProviderConnectivity.ProviderJobDefinition): JobDefinitionView => ({
+	id: d.id,
+	projectId: d.projectId,
+	providerId: d.providerId.value,
+	endpointId: d.endpointId.value,
+	params: { ...d.params },
+	cron: d.cron.value,
+	credentialOverrideId: d.credentialOverrideId,
+	enabled: d.enabled,
+	lastRunAt: d.lastRunAt ? d.lastRunAt.toISOString() : null,
+	createdAt: d.createdAt.toISOString(),
+});
+
+export class ListJobDefinitionsUseCase {
+	constructor(private readonly definitions: ProviderConnectivity.JobDefinitionRepository) {}
+
+	async execute(projectId: string): Promise<JobDefinitionView[]> {
+		const rows = await this.definitions.listForProject(projectId as ProjectManagement.ProjectId);
+		return rows.map(toView);
+	}
+}
+
+export class GetJobDefinitionUseCase {
+	constructor(private readonly definitions: ProviderConnectivity.JobDefinitionRepository) {}
+
+	async execute(definitionId: string): Promise<JobDefinitionView> {
+		const def = await this.definitions.findById(definitionId as ProviderConnectivity.ProviderJobDefinitionId);
+		if (!def) throw new NotFoundError(`Job definition ${definitionId} not found`);
+		return toView(def);
+	}
+}
+
+export interface UpdateJobDefinitionCommand {
+	definitionId: string;
+	cron?: string;
+	params?: Record<string, unknown>;
+	enabled?: boolean;
+}
+
+export class UpdateJobDefinitionUseCase {
+	constructor(
+		private readonly definitions: ProviderConnectivity.JobDefinitionRepository,
+		private readonly scheduler: ProviderConnectivity.JobScheduler,
+	) {}
+
+	async execute(cmd: UpdateJobDefinitionCommand): Promise<JobDefinitionView> {
+		const def = await this.definitions.findById(
+			cmd.definitionId as ProviderConnectivity.ProviderJobDefinitionId,
+		);
+		if (!def) throw new NotFoundError(`Job definition ${cmd.definitionId} not found`);
+
+		// Unregister BEFORE mutating so BullMQ removes the repeatable using the
+		// old cron pattern; a new register() afterwards (re-)installs it under
+		// the new pattern.
+		await this.scheduler.unregister(def);
+
+		if (cmd.cron !== undefined) def.updateCron(ProviderConnectivity.CronExpression.create(cmd.cron));
+		if (cmd.params !== undefined) def.updateParams(cmd.params);
+		if (cmd.enabled === true) def.enable();
+		if (cmd.enabled === false) def.disable();
+
+		await this.definitions.save(def);
+		await this.scheduler.register(def);
+		return toView(def);
+	}
+}
+
+export class DeleteJobDefinitionUseCase {
+	constructor(
+		private readonly definitions: ProviderConnectivity.JobDefinitionRepository,
+		private readonly scheduler: ProviderConnectivity.JobScheduler,
+	) {}
+
+	async execute(definitionId: string): Promise<void> {
+		const def = await this.definitions.findById(definitionId as ProviderConnectivity.ProviderJobDefinitionId);
+		if (!def) throw new NotFoundError(`Job definition ${definitionId} not found`);
+		await this.scheduler.unregister(def);
+		await this.definitions.delete(def.id);
+	}
+}

--- a/packages/application/src/provider-connectivity/use-cases/register-provider-credential.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/register-provider-credential.use-case.spec.ts
@@ -1,0 +1,126 @@
+import { type IdentityAccess, ProviderConnectivity } from '@rankpulse/domain';
+import { ConflictError, FakeClock, FixedIdGenerator, InvalidInputError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { describe, expect, it } from 'vitest';
+import {
+	type CredentialFormatValidator,
+	RegisterProviderCredentialUseCase,
+} from './register-provider-credential.use-case.js';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111' as IdentityAccess.OrganizationId;
+const PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+
+class InMemoryCredentialRepo implements ProviderConnectivity.CredentialRepository {
+	readonly store = new Map<string, ProviderConnectivity.ProviderCredential>();
+	async save(c: ProviderConnectivity.ProviderCredential): Promise<void> {
+		this.store.set(c.id, c);
+	}
+	async findById(id: ProviderConnectivity.ProviderCredentialId) {
+		return this.store.get(id) ?? null;
+	}
+	async listForProvider() {
+		return [...this.store.values()];
+	}
+	async findByScope(
+		_orgId: IdentityAccess.OrganizationId,
+		_providerId: ProviderConnectivity.ProviderId,
+		scope: ProviderConnectivity.CredentialScope,
+		label: string,
+	) {
+		const match = [...this.store.values()].find(
+			(c) =>
+				c.scope.type === scope.type &&
+				c.scope.id === scope.id &&
+				c.label === label &&
+				c.organizationId === _orgId &&
+				c.providerId.value === _providerId.value,
+		);
+		return match ?? null;
+	}
+}
+
+const fakeVault: ProviderConnectivity.CredentialVault = {
+	async encrypt(plain: string) {
+		return ProviderConnectivity.EncryptedSecret.fromEnvelope({
+			ciphertext: Buffer.from(plain).toString('base64'),
+			nonce: 'nonce-base64',
+			lastFour: plain.slice(-4),
+		});
+	},
+	async decrypt() {
+		return 'PLAINTEXT';
+	},
+};
+
+const okValidator: CredentialFormatValidator = { validate: () => {} };
+
+const buildUseCase = (overrides: { validator?: CredentialFormatValidator } = {}) => {
+	const repo = new InMemoryCredentialRepo();
+	const events = new RecordingEventPublisher();
+	const useCase = new RegisterProviderCredentialUseCase(
+		repo,
+		fakeVault,
+		overrides.validator ?? okValidator,
+		new FakeClock(new Date('2026-05-04T10:00:00Z')),
+		new FixedIdGenerator(['cred-id-1' as Uuid]),
+		events,
+	);
+	return { useCase, repo, events };
+};
+
+const baseCmd = {
+	organizationId: ORG_ID,
+	providerId: 'dataforseo',
+	scope: { type: 'project', id: PROJECT_ID },
+	label: 'default',
+	plaintextSecret: 'foo@x.com|secret',
+};
+
+describe('RegisterProviderCredentialUseCase', () => {
+	it('persists, encrypts, and emits an event when the format validator accepts the secret', async () => {
+		const { useCase, repo, events } = buildUseCase();
+
+		const result = await useCase.execute(baseCmd);
+
+		expect(result).toEqual({ credentialId: 'cred-id-1', lastFour: 'cret' });
+		expect(repo.store.size).toBe(1);
+		expect(events.publishedTypes()).toContain('ProviderCredentialRegistered');
+	});
+
+	it('rejects with InvalidInputError when the format validator throws (BACKLOG #8)', async () => {
+		const reject: CredentialFormatValidator = {
+			validate: () => {
+				throw new InvalidInputError('DataForSEO credential must be "email|api_password"');
+			},
+		};
+		const { useCase, repo, events } = buildUseCase({ validator: reject });
+
+		await expect(
+			useCase.execute({ ...baseCmd, plaintextSecret: 'foo@x.com:bad-separator' }),
+		).rejects.toBeInstanceOf(InvalidInputError);
+		expect(repo.store.size).toBe(0);
+		expect(events.publishedTypes()).toEqual([]);
+	});
+
+	it('passes the providerId and plaintext to the validator unmodified', async () => {
+		const captured: { providerId?: string; plain?: string } = {};
+		const spy: CredentialFormatValidator = {
+			validate: (providerId, plain) => {
+				captured.providerId = providerId;
+				captured.plain = plain;
+			},
+		};
+		const { useCase } = buildUseCase({ validator: spy });
+
+		await useCase.execute({ ...baseCmd, plaintextSecret: 'foo@x.com|secret' });
+
+		expect(captured).toEqual({ providerId: 'dataforseo', plain: 'foo@x.com|secret' });
+	});
+
+	it('rejects duplicate (org, provider, scope, label) tuples with ConflictError', async () => {
+		const { useCase } = buildUseCase();
+		await useCase.execute(baseCmd);
+
+		await expect(useCase.execute(baseCmd)).rejects.toBeInstanceOf(ConflictError);
+	});
+});

--- a/packages/application/src/provider-connectivity/use-cases/register-provider-credential.use-case.ts
+++ b/packages/application/src/provider-connectivity/use-cases/register-provider-credential.use-case.ts
@@ -1,6 +1,15 @@
 import { type IdentityAccess, ProviderConnectivity, type SharedKernel } from '@rankpulse/domain';
 import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
 
+/**
+ * Minimal port over `ProviderRegistry` so this use case stays in the
+ * application layer without depending on `@rankpulse/provider-core` directly.
+ * The composition root passes a thin adapter around the real registry.
+ */
+export interface CredentialFormatValidator {
+	validate(providerId: string, plaintextSecret: string): void;
+}
+
 export interface RegisterProviderCredentialCommand {
 	organizationId: string;
 	providerId: string;
@@ -19,6 +28,7 @@ export class RegisterProviderCredentialUseCase {
 	constructor(
 		private readonly credentials: ProviderConnectivity.CredentialRepository,
 		private readonly vault: ProviderConnectivity.CredentialVault,
+		private readonly formatValidator: CredentialFormatValidator,
 		private readonly clock: Clock,
 		private readonly ids: IdGenerator,
 		private readonly events: SharedKernel.EventPublisher,
@@ -28,6 +38,8 @@ export class RegisterProviderCredentialUseCase {
 		const orgId = cmd.organizationId as IdentityAccess.OrganizationId;
 		const providerId = ProviderConnectivity.ProviderId.create(cmd.providerId);
 		const scope = ProviderConnectivity.CredentialScope.fromRaw(cmd.scope);
+
+		this.formatValidator.validate(providerId.value, cmd.plaintextSecret);
 
 		const existing = await this.credentials.findByScope(orgId, providerId, scope, cmd.label);
 		if (existing) {

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
@@ -1,0 +1,138 @@
+import type { ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, InvalidInputError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { describe, expect, it } from 'vitest';
+import {
+	type EndpointParamsValidator,
+	ScheduleEndpointFetchUseCase,
+} from './schedule-endpoint-fetch.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as ProjectManagement.ProjectId;
+const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const TRACKED_KW_ID = '33333333-3333-3333-3333-333333333333';
+
+class StubDefinitionRepo implements ProviderConnectivity.JobDefinitionRepository {
+	readonly saved: ProviderConnectivity.ProviderJobDefinition[] = [];
+	async save(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.saved.push(d);
+	}
+	async findById() {
+		return null;
+	}
+	async findFor() {
+		return null;
+	}
+	async listForProject(): Promise<readonly ProviderConnectivity.ProviderJobDefinition[]> {
+		return this.saved;
+	}
+	async delete(): Promise<void> {}
+}
+
+class RecordingScheduler implements ProviderConnectivity.JobScheduler {
+	readonly registered: ProviderConnectivity.ProviderJobDefinition[] = [];
+	async register(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.registered.push(d);
+	}
+	async unregister(): Promise<void> {}
+	async enqueueOnce(): Promise<void> {}
+}
+
+const passThroughValidator: EndpointParamsValidator = {
+	validate: (_p, _e, params) => params as Record<string, unknown>,
+};
+
+const buildUseCase = (validator: EndpointParamsValidator = passThroughValidator) => {
+	const repo = new StubDefinitionRepo();
+	const scheduler = new RecordingScheduler();
+	const events = new RecordingEventPublisher();
+	const useCase = new ScheduleEndpointFetchUseCase(
+		repo,
+		scheduler,
+		validator,
+		new FakeClock(new Date('2026-05-04T10:00:00Z')),
+		new FixedIdGenerator(['def-id-1' as Uuid]),
+		events,
+	);
+	return { useCase, repo, scheduler, events };
+};
+
+const baseCmd = {
+	projectId: PROJECT_ID,
+	providerId: 'dataforseo',
+	endpointId: 'serp-google-organic-live',
+	params: { keyword: 'control de rondas', locationCode: 2724, languageCode: 'es' },
+	cron: '0 6 * * 1',
+};
+
+describe('ScheduleEndpointFetchUseCase', () => {
+	it('persists, registers in the scheduler, and emits an event for valid input', async () => {
+		const { useCase, repo, scheduler, events } = buildUseCase();
+
+		const result = await useCase.execute(baseCmd);
+
+		expect(result).toEqual({ definitionId: 'def-id-1' });
+		expect(repo.saved).toHaveLength(1);
+		expect(scheduler.registered).toHaveLength(1);
+		expect(events.publishedTypes()).toContain('ProviderJobScheduled');
+	});
+
+	it('rejects with InvalidInputError when the endpoint paramsSchema rejects (BACKLOG #7)', async () => {
+		const reject: EndpointParamsValidator = {
+			validate: () => {
+				throw new InvalidInputError(
+					'Invalid params for dataforseo/serp-google-organic-live: keyword required',
+				);
+			},
+		};
+		const { useCase, repo, scheduler } = buildUseCase(reject);
+
+		await expect(useCase.execute({ ...baseCmd, params: { phrase: 'wrong-shape' } })).rejects.toBeInstanceOf(
+			InvalidInputError,
+		);
+		expect(repo.saved).toHaveLength(0);
+		expect(scheduler.registered).toHaveLength(0);
+	});
+
+	it('persists the validated params (post-Zod normalization), not the raw user input', async () => {
+		const normalize: EndpointParamsValidator = {
+			validate: () => ({
+				keyword: 'control de rondas',
+				locationCode: 2724,
+				languageCode: 'es',
+				device: 'desktop',
+			}),
+		};
+		const { useCase, repo } = buildUseCase(normalize);
+
+		await useCase.execute({ ...baseCmd, params: { keyword: 'control de rondas' } });
+
+		expect(repo.saved[0]?.params).toMatchObject({ device: 'desktop' });
+	});
+
+	it('merges systemParams (organizationId, trackedKeywordId) AFTER validation so they survive Zod strip (BACKLOG #9)', async () => {
+		const stripExtras: EndpointParamsValidator = {
+			validate: () => ({ keyword: 'k', locationCode: 2724, languageCode: 'es', device: 'desktop' }),
+		};
+		const { useCase, repo } = buildUseCase(stripExtras);
+
+		await useCase.execute({
+			...baseCmd,
+			systemParams: { organizationId: ORG_ID, trackedKeywordId: TRACKED_KW_ID },
+		});
+
+		expect(repo.saved[0]?.params).toMatchObject({
+			keyword: 'k',
+			organizationId: ORG_ID,
+			trackedKeywordId: TRACKED_KW_ID,
+		});
+	});
+
+	it('attaches the credentialOverrideId when provided', async () => {
+		const { useCase, repo } = buildUseCase();
+		const overrideId = '44444444-4444-4444-4444-444444444444';
+
+		await useCase.execute({ ...baseCmd, credentialOverrideId: overrideId });
+
+		expect(repo.saved[0]?.credentialOverrideId).toBe(overrideId);
+	});
+});

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
@@ -1,11 +1,29 @@
 import { type ProjectManagement, ProviderConnectivity, type SharedKernel } from '@rankpulse/domain';
-import type { Clock, IdGenerator } from '@rankpulse/shared';
+import { type Clock, type IdGenerator, InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Application-layer port over `ProviderRegistry.endpoint().paramsSchema` so
+ * this use case stays decoupled from `@rankpulse/provider-core`. Returns the
+ * normalized params (after Zod parsing — defaults applied, transforms run).
+ */
+export interface EndpointParamsValidator {
+	validate(providerId: string, endpointId: string, params: unknown): Record<string, unknown>;
+}
 
 export interface ScheduleEndpointFetchCommand {
 	projectId: string;
 	providerId: string;
 	endpointId: string;
+	/** User-provided params; validated against the endpoint's paramsSchema. */
 	params: Record<string, unknown>;
+	/**
+	 * System-injected params merged AFTER validation (organizationId,
+	 * trackedKeywordId, etc.). Bypasses paramsSchema strip behaviour because
+	 * the descriptor's schema only describes the user surface; these keys are
+	 * read by the worker for scoping/persistence and don't belong in the
+	 * provider call payload.
+	 */
+	systemParams?: Record<string, unknown>;
 	cron: string;
 	credentialOverrideId?: string | null;
 }
@@ -18,6 +36,7 @@ export class ScheduleEndpointFetchUseCase {
 	constructor(
 		private readonly definitions: ProviderConnectivity.JobDefinitionRepository,
 		private readonly scheduler: ProviderConnectivity.JobScheduler,
+		private readonly paramsValidator: EndpointParamsValidator,
 		private readonly clock: Clock,
 		private readonly ids: IdGenerator,
 		private readonly events: SharedKernel.EventPublisher,
@@ -29,13 +48,21 @@ export class ScheduleEndpointFetchUseCase {
 		const cron = ProviderConnectivity.CronExpression.create(cmd.cron);
 		const projectId = cmd.projectId as ProjectManagement.ProjectId;
 
+		const validatedParams = this.paramsValidator.validate(providerId.value, endpointId.value, cmd.params);
+		if (typeof validatedParams !== 'object' || validatedParams === null) {
+			throw new InvalidInputError(
+				`Endpoint ${endpointId.value} paramsSchema must resolve to an object, got ${typeof validatedParams}`,
+			);
+		}
+		const finalParams: Record<string, unknown> = { ...validatedParams, ...(cmd.systemParams ?? {}) };
+
 		const id = this.ids.generate() as ProviderConnectivity.ProviderJobDefinitionId;
 		const definition = ProviderConnectivity.ProviderJobDefinition.schedule({
 			id,
 			projectId,
 			providerId,
 			endpointId,
-			params: cmd.params,
+			params: finalParams,
 			cron,
 			credentialOverrideId: cmd.credentialOverrideId
 				? (cmd.credentialOverrideId as ProviderConnectivity.ProviderCredentialId)

--- a/packages/application/src/provider-connectivity/use-cases/trigger-job-definition-run.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/trigger-job-definition-run.use-case.spec.ts
@@ -22,6 +22,9 @@ class StubDefinitionRepo implements ProviderConnectivity.JobDefinitionRepository
 	async listForProject(): Promise<readonly ProviderConnectivity.ProviderJobDefinition[]> {
 		return [...this.store.values()];
 	}
+	async delete(id: ProviderConnectivity.ProviderJobDefinitionId): Promise<void> {
+		this.store.delete(id);
+	}
 }
 
 class RecordingScheduler implements ProviderConnectivity.JobScheduler {

--- a/packages/contracts/src/provider-connectivity/index.ts
+++ b/packages/contracts/src/provider-connectivity/index.ts
@@ -23,6 +23,15 @@ export const ScheduleEndpointRequest = z.object({
 	params: z.record(z.string(), z.unknown()),
 	cron: z.string().min(5).max(80),
 	credentialOverrideId: z.string().uuid().nullable().optional(),
+	/**
+	 * Optional. When present, the worker will materialize a
+	 * `RankingObservation` per fetched SERP and link it to this tracked
+	 * keyword. Without it, the fetch still runs and stores the raw payload
+	 * but no observation is created — useful for ad-hoc audits, but the
+	 * usual happy-path is to pass the trackedKeywordId so quota is not
+	 * spent without persistent results (BACKLOG #9).
+	 */
+	trackedKeywordId: z.string().uuid().nullable().optional(),
 });
 export type ScheduleEndpointRequest = z.infer<typeof ScheduleEndpointRequest>;
 

--- a/packages/contracts/src/provider-connectivity/index.ts
+++ b/packages/contracts/src/provider-connectivity/index.ts
@@ -53,3 +53,28 @@ export const ProviderDto = z.object({
 	endpoints: z.array(EndpointDescriptorDto),
 });
 export type ProviderDto = z.infer<typeof ProviderDto>;
+
+export const JobDefinitionDto = z.object({
+	id: z.string(),
+	projectId: z.string(),
+	providerId: z.string(),
+	endpointId: z.string(),
+	params: z.record(z.string(), z.unknown()),
+	cron: z.string(),
+	credentialOverrideId: z.string().nullable(),
+	enabled: z.boolean(),
+	lastRunAt: z.string().nullable(),
+	createdAt: z.string(),
+});
+export type JobDefinitionDto = z.infer<typeof JobDefinitionDto>;
+
+export const UpdateJobDefinitionRequest = z
+	.object({
+		cron: z.string().min(5).max(80).optional(),
+		params: z.record(z.string(), z.unknown()).optional(),
+		enabled: z.boolean().optional(),
+	})
+	.refine((v) => v.cron !== undefined || v.params !== undefined || v.enabled !== undefined, {
+		message: 'At least one of cron, params, enabled must be provided',
+	});
+export type UpdateJobDefinitionRequest = z.infer<typeof UpdateJobDefinitionRequest>;

--- a/packages/domain/src/provider-connectivity/ports/job-definition-repository.ts
+++ b/packages/domain/src/provider-connectivity/ports/job-definition-repository.ts
@@ -14,4 +14,5 @@ export interface JobDefinitionRepository {
 		paramsHash: string,
 	): Promise<ProviderJobDefinition | null>;
 	listForProject(projectId: ProjectId): Promise<readonly ProviderJobDefinition[]>;
+	delete(id: ProviderJobDefinitionId): Promise<void>;
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
@@ -92,6 +92,10 @@ export class DrizzleJobDefinitionRepository implements ProviderConnectivity.JobD
 		return rows.map((r) => this.toAggregate(r));
 	}
 
+	async delete(id: ProviderConnectivity.ProviderJobDefinitionId): Promise<void> {
+		await this.db.delete(providerJobDefinitions).where(eq(providerJobDefinitions.id, id));
+	}
+
 	private toAggregate(
 		row: typeof providerJobDefinitions.$inferSelect,
 	): ProviderConnectivity.ProviderJobDefinition {

--- a/packages/providers/core/src/registry.spec.ts
+++ b/packages/providers/core/src/registry.spec.ts
@@ -20,6 +20,7 @@ const stubProvider = (idValue: string): Provider => ({
 			rateLimit: { max: 60, durationMs: 60_000 },
 		},
 	],
+	validateCredentialPlaintext() {},
 	async fetch() {
 		return { ok: true };
 	},

--- a/packages/providers/core/src/types.ts
+++ b/packages/providers/core/src/types.ts
@@ -66,6 +66,19 @@ export interface Provider {
 	discover(): readonly EndpointDescriptor[];
 
 	/**
+	 * Validates that a plaintext secret is in the format this provider expects
+	 * (e.g. DataForSEO `email|api_password`, GSC service account JSON). Called
+	 * by RegisterProviderCredentialUseCase before encrypting + persisting, so
+	 * misconfigured credentials surface as a 400 at registration time instead
+	 * of as a worker job failure on the first run.
+	 *
+	 * Implementations throw `InvalidInputError` (or any `Error` subclass) on
+	 * mismatch. Returning normally means the format is acceptable; it does NOT
+	 * imply the credential is authorised by the upstream API.
+	 */
+	validateCredentialPlaintext(plaintextSecret: string): void;
+
+	/**
 	 * Performs the HTTP call and returns the raw response, exactly as the
 	 * provider returned it. Persistence + dedup is the worker's responsibility.
 	 */

--- a/packages/providers/dataforseo/src/provider.spec.ts
+++ b/packages/providers/dataforseo/src/provider.spec.ts
@@ -15,6 +15,16 @@ describe('DataForSeoProvider', () => {
 		expect(ids).toContain('serp-google-organic-live');
 	});
 
+	it('validateCredentialPlaintext rejects the wrong separator', () => {
+		const provider = new DataForSeoProvider();
+		expect(() => provider.validateCredentialPlaintext('foo@x.com:password')).toThrow();
+	});
+
+	it('validateCredentialPlaintext accepts the email|password format', () => {
+		const provider = new DataForSeoProvider();
+		expect(() => provider.validateCredentialPlaintext('foo@x.com|secret')).not.toThrow();
+	});
+
 	it('rejects unknown endpoint ids', async () => {
 		const provider = new DataForSeoProvider();
 		await expect(provider.fetch('bogus', {}, stubContext())).rejects.toThrowError(/no endpoint/);

--- a/packages/providers/dataforseo/src/provider.ts
+++ b/packages/providers/dataforseo/src/provider.ts
@@ -1,6 +1,7 @@
 import { ProviderConnectivity } from '@rankpulse/domain';
 import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
 import { InvalidInputError } from '@rankpulse/shared';
+import { parseCredential } from './credential.js';
 import {
 	fetchSerpGoogleOrganicLive,
 	type SerpGoogleOrganicLiveParams,
@@ -23,6 +24,10 @@ export class DataForSeoProvider implements Provider {
 
 	discover(): readonly EndpointDescriptor[] {
 		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		parseCredential(plaintextSecret);
 	}
 
 	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {

--- a/packages/providers/google-search-console/src/provider.spec.ts
+++ b/packages/providers/google-search-console/src/provider.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { GscProvider } from './provider.js';
+
+const validServiceAccountJson = JSON.stringify({
+	type: 'service_account',
+	project_id: 'rankpulse',
+	client_email: 'claude-access@ingenierosweb.iam.gserviceaccount.com',
+	private_key: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
+});
+
+describe('GscProvider', () => {
+	it('exposes the search-analytics endpoint via discover()', () => {
+		const provider = new GscProvider();
+		const ids = provider.discover().map((e) => e.id);
+		expect(ids).toContain('gsc-search-analytics');
+	});
+
+	it('validateCredentialPlaintext accepts a service account JSON blob', () => {
+		const provider = new GscProvider();
+		expect(() => provider.validateCredentialPlaintext(validServiceAccountJson)).not.toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects non-JSON plaintext', () => {
+		const provider = new GscProvider();
+		expect(() => provider.validateCredentialPlaintext('not-json')).toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects JSON missing client_email/private_key', () => {
+		const provider = new GscProvider();
+		expect(() => provider.validateCredentialPlaintext(JSON.stringify({ project_id: 'x' }))).toThrow();
+	});
+});

--- a/packages/providers/google-search-console/src/provider.ts
+++ b/packages/providers/google-search-console/src/provider.ts
@@ -1,6 +1,7 @@
 import { ProviderConnectivity } from '@rankpulse/domain';
 import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
 import { InvalidInputError } from '@rankpulse/shared';
+import { parseServiceAccount } from './credential.js';
 import {
 	fetchSearchAnalytics,
 	type SearchAnalyticsParams,
@@ -23,6 +24,10 @@ export class GscProvider implements Provider {
 
 	discover(): readonly EndpointDescriptor[] {
 		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		parseServiceAccount(plaintextSecret);
 	}
 
 	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -40,6 +40,14 @@ export class HttpClient {
 		return this.request<T>('POST', path, { ...options, body });
 	}
 
+	patch<T>(path: string, body?: unknown, options?: Omit<RequestOptions, 'body'>): Promise<T> {
+		return this.request<T>('PATCH', path, { ...options, body });
+	}
+
+	delete<T>(path: string, options?: RequestOptions): Promise<T> {
+		return this.request<T>('DELETE', path, options);
+	}
+
 	private async request<T>(method: string, path: string, options: RequestOptions = {}): Promise<T> {
 		const url = new URL(`${this.baseUrl}${path}`);
 		if (options.query) {

--- a/packages/sdk/src/resources/providers.ts
+++ b/packages/sdk/src/resources/providers.ts
@@ -29,4 +29,44 @@ export class ProvidersResource {
 			body,
 		);
 	}
+
+	runJobDefinitionNow(
+		providerId: string,
+		definitionId: string,
+	): Promise<{ runId: string; definitionId: string }> {
+		return this.http.post(
+			`/providers/${encodeURIComponent(providerId)}/job-definitions/${encodeURIComponent(definitionId)}/run-now`,
+			{},
+		);
+	}
+
+	listJobDefinitions(projectId: string): Promise<ProviderConnectivityContracts.JobDefinitionDto[]> {
+		return this.http.get(`/providers/job-definitions/by-project/${encodeURIComponent(projectId)}`);
+	}
+
+	getJobDefinition(
+		providerId: string,
+		definitionId: string,
+	): Promise<ProviderConnectivityContracts.JobDefinitionDto> {
+		return this.http.get(
+			`/providers/${encodeURIComponent(providerId)}/job-definitions/${encodeURIComponent(definitionId)}`,
+		);
+	}
+
+	updateJobDefinition(
+		providerId: string,
+		definitionId: string,
+		body: ProviderConnectivityContracts.UpdateJobDefinitionRequest,
+	): Promise<ProviderConnectivityContracts.JobDefinitionDto> {
+		return this.http.patch(
+			`/providers/${encodeURIComponent(providerId)}/job-definitions/${encodeURIComponent(definitionId)}`,
+			body,
+		);
+	}
+
+	deleteJobDefinition(providerId: string, definitionId: string): Promise<void> {
+		return this.http.delete(
+			`/providers/${encodeURIComponent(providerId)}/job-definitions/${encodeURIComponent(definitionId)}`,
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Three commits closing four BACKLOG items left over from the first prod deploy session, all under `provider-connectivity`.

- **#7 + #8 + #9 — Pre-persist validation** (`571d4d9`): inputs that used to fail in the worker on the first job now fail at the API with 400. New `Provider.validateCredentialPlaintext` port + `EndpointParamsValidator` port driven by `EndpointDescriptor.paramsSchema`. Because Zod's `safeParse` strips unknown keys, system-injected fields (`organizationId`, `trackedKeywordId`) move to a separate `systemParams` envelope merged after validation. `ScheduleEndpointRequest` exposes optional `trackedKeywordId` so the processor can materialize the `RankingObservation` (replaces the SQL UPDATE workaround used during the bootstrap session).
- **#10 — CRUD endpoints for job definitions** (`e40a021`): four new endpoints (`GET by-project`, `GET`, `PATCH`, `DELETE`) on `ProvidersController` with shared `loadDefinitionAndAuthorize` helper. `PATCH` unregisters the BullMQ repeatable before the mutation and re-registers it (cron actually moves). New use cases in `manage-job-definition.use-cases.ts`. `JobDefinitionRepository.delete` added to the domain port + Drizzle impl. SDK gains `http.patch`/`http.delete` and 5 new `ProvidersResource` methods. OpenAPI spec gets the 5 paths.
- **Docs** (`dad32cb`): BACKLOG items 7-10 marked resolved, A4 (run-now API) and A8 (schedules API) updated, the truncated A9 stub removed.

## Test plan

- [x] `pnpm typecheck` — 14/14
- [x] `pnpm lint` — 329 files clean
- [x] `pnpm test:unit` — 113 tests passing (19 new across 4 specs: `register-provider-credential.use-case.spec.ts` +4, `schedule-endpoint-fetch.use-case.spec.ts` +5, `manage-job-definition.use-cases.spec.ts` +10 across the 4 new use cases, `gsc/provider.spec.ts` new with 4, `dataforseo/provider.spec.ts` +2)
- [x] `pnpm build` — api + worker + web green
- [ ] Manual smoke: register a DataForSEO credential with `:` separator → expect 400 (was 201 before)
- [ ] Manual smoke: schedule with `{phrase, country, language}` shape → expect 400 (was 201 before)
- [ ] Manual smoke: `POST /providers/:id/endpoints/:eid/schedule` with `trackedKeywordId` → confirm `RankingObservation` is materialized after the run
- [ ] Manual smoke: `PATCH /providers/:id/job-definitions/:defId` with new cron → confirm BullMQ repeatable moves (no double-fire on old pattern)