### PR TITLE
Multi-stage Dockerfiles + audit fixes on PR #15 squash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: build
-    # Production deploy uses PM2 host-side (see ops/DEPLOY.md), not
-    # containers — Dockerfiles for the apps are intentionally deferred.
-    # The job stays defined so it auto-activates when `docker/` lands.
-    if: ${{ hashFiles('docker/api.Dockerfile', 'docker/worker.Dockerfile', 'docker/web.Dockerfile') != '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
           node-version: '24'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Validate PUBLIC_API_BASE_URL is set
+        # Vite bakes VITE_* env vars into the bundle at build time. An
+        # empty value silently produces a SPA that hits relative paths
+        # (which only work when nginx proxies /api). Fail fast instead.
+        run: |
+          if [ -z "${{ vars.PUBLIC_API_BASE_URL }}" ]; then
+            echo "::error::vars.PUBLIC_API_BASE_URL is not set in the production environment"
+            exit 1
+          fi
       - name: Build web SPA
         run: pnpm --filter @rankpulse/web build
         env:
@@ -71,17 +80,26 @@ jobs:
             echo ">>> pnpm install"
             pnpm install --frozen-lockfile
             echo ">>> Build all workspace packages + apps to dist/ (BACKLOG #16)"
-            pnpm -r build
-            echo ">>> Drizzle migrate (loads .env + .env.local via Node --env-file)"
-            pnpm --filter @rankpulse/infrastructure db:migrate
-            echo ">>> Replace web bundle in httpdocs"
+            pnpm build
+            # Order: reload PM2 BEFORE db:migrate. Migrations occasionally
+            # tighten constraints (e.g. NOT NULL in 0004) that break inserts
+            # from the *previous* code version. Reloading first means the
+            # new code (which writes the new shape) is already running by
+            # the time the migration coerces and locks down the schema.
+            # Brief window of ~5s where new code talks to old schema is
+            # safe — new code is forward-compatible by design.
+            echo ">>> Replace web bundle in httpdocs (before reload so new SPA matches new API)"
             rm -rf $VHOST/httpdocs/*
             tar xzf $VHOST/web-dist.tar.gz -C $VHOST/httpdocs/
             rm -f $VHOST/web-dist.tar.gz
             echo ">>> Reload PM2"
             pm2 reload $APP/ops/ecosystem.config.cjs --update-env
-            echo ">>> Health check"
+            echo ">>> Drizzle migrate (loads .env + .env.local via Node --env-file)"
+            pnpm --filter @rankpulse/infrastructure db:migrate
+            echo ">>> Health check API"
             sleep 5
             curl --fail --silent --show-error --max-time 5 --retry 8 --retry-delay 2 --retry-all-errors http://127.0.0.1:3200/healthz
+            echo ">>> Health check Worker"
+            curl --fail --silent --show-error --max-time 5 --retry 8 --retry-delay 2 --retry-all-errors http://127.0.0.1:3300/healthz
             echo ""
             echo ">>> Deploy OK (sha-${GITHUB_SHA::7})"

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -225,6 +225,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		gscObservationRepo,
 		SystemIdGenerator,
 		eventPublisher,
+		SystemClock,
 	);
 	const queryGscPerformance = new SCIUseCases.QueryGscPerformanceUseCase(gscPropertyRepo, gscObservationRepo);
 

--- a/apps/api/src/modules/project-management/projects.controller.ts
+++ b/apps/api/src/modules/project-management/projects.controller.ts
@@ -162,7 +162,7 @@ export class ProjectsController {
 		// Default behaviour: surface the eligible bucket only — that's the
 		// list the UI shows. The `?eligibleOnly=false` escape hatch is for
 		// debugging the threshold policy.
-		const eligibleOnly = q.eligibleOnly !== false;
+		const eligibleOnly = q.eligibleOnly ?? true;
 		return this.listSuggestions.execute({ projectId: id, eligibleOnly });
 	}
 

--- a/apps/web/src/pages/onboarding.page.tsx
+++ b/apps/web/src/pages/onboarding.page.tsx
@@ -13,7 +13,7 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { ArrowLeft, ArrowRight, Check } from 'lucide-react';
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { api } from '../lib/api.js';
 import { useAuthStore } from '../lib/auth-store.js';
 
@@ -75,6 +75,21 @@ export const OnboardingPage = () => {
 		enabled: Boolean(session),
 	});
 	const orgId = meQuery.data?.memberships[0]?.organizationId;
+
+	// Re-entry guard: if the org already has projects, the user has
+	// either completed the wizard or set things up manually elsewhere.
+	// Sending them through it again risks duplicate credentials/projects
+	// on form resubmits (e.g. accidental refresh after partial success).
+	const projectsQuery = useQuery({
+		queryKey: ['projects', orgId],
+		queryFn: () => (orgId ? api.projects.list(orgId) : Promise.resolve([])),
+		enabled: Boolean(orgId),
+	});
+	useEffect(() => {
+		if (projectsQuery.data && projectsQuery.data.length > 0) {
+			void navigate({ to: '/projects' });
+		}
+	}, [projectsQuery.data, navigate]);
 
 	const [step, setStep] = useState<Step>('credential');
 	const [secret, setSecret] = useState('');
@@ -174,7 +189,7 @@ export const OnboardingPage = () => {
 		keywordMutation.mutate();
 	};
 
-	if (meQuery.isLoading) {
+	if (meQuery.isLoading || projectsQuery.isLoading) {
 		return (
 			<div className="flex min-h-screen items-center justify-center">
 				<Spinner size="lg" />

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -32,14 +32,25 @@ const indexRoute = createRoute({
 	},
 });
 
-// Both auth routes redirect away when there's already a session — the
-// previous behaviour let an authenticated user re-submit /login and
-// silently overwrite their existing session, or hit /register and
+// Both auth routes redirect away when there's already a VALID session
+// — the previous behaviour let an authenticated user re-submit /login
+// and silently overwrite their existing session, or hit /register and
 // register a fresh org while keeping the prior session alive in
 // localStorage. Either flow could orphan in-flight work.
+//
+// Expired sessions (token TTL passed) are treated as no session: they
+// flow through to /login normally instead of getting bounced to
+// /projects where every API call returns 401 and the user is trapped.
 const redirectIfAuthed = (): void => {
 	const session = useAuthStore.getState().session;
-	if (session) throw redirect({ to: '/projects' });
+	if (!session) return;
+	const expiresAt = new Date(session.expiresAt).getTime();
+	if (Number.isFinite(expiresAt) && expiresAt > Date.now()) {
+		throw redirect({ to: '/projects' });
+	}
+	// Session is expired — clear it so the in-app guards don't trip on
+	// the stale token and so the user lands on the login page cleanly.
+	useAuthStore.getState().clear();
 };
 
 const loginRoute = createRoute({

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -32,15 +32,27 @@ const indexRoute = createRoute({
 	},
 });
 
+// Both auth routes redirect away when there's already a session — the
+// previous behaviour let an authenticated user re-submit /login and
+// silently overwrite their existing session, or hit /register and
+// register a fresh org while keeping the prior session alive in
+// localStorage. Either flow could orphan in-flight work.
+const redirectIfAuthed = (): void => {
+	const session = useAuthStore.getState().session;
+	if (session) throw redirect({ to: '/projects' });
+};
+
 const loginRoute = createRoute({
 	getParentRoute: () => rootRoute,
 	path: '/login',
+	beforeLoad: redirectIfAuthed,
 	component: LoginPage,
 });
 
 const registerRoute = createRoute({
 	getParentRoute: () => rootRoute,
 	path: '/register',
+	beforeLoad: redirectIfAuthed,
 	component: RegisterPage,
 });
 

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -59,6 +59,7 @@ async function bootstrap(): Promise<void> {
 		gscObservationRepo,
 		SystemIdGenerator,
 		eventPublisher,
+		SystemClock,
 	);
 	const recordTop10HitsForSuggestionsUseCase =
 		new ProjectManagementUseCases.RecordTop10HitsForSuggestionsUseCase(
@@ -110,6 +111,18 @@ async function bootstrap(): Promise<void> {
 		);
 		worker.on('failed', (job, err) => {
 			logger.error({ queue: queueName, jobId: job?.id, err: err.message }, 'fetch job failed');
+		});
+		// BullMQ marks a job stalled when its lock expires (process killed
+		// mid-handler, GC pause, etc.). Without this listener the run row
+		// in DB stays in `running` forever — surfaces as a never-finishing
+		// fetch in the UI. Logged loudly so the operator knows the run
+		// needs reconciliation; the actual DB cleanup belongs to a
+		// dedicated maintenance task (out of scope here, tracked).
+		worker.on('stalled', (jobId) => {
+			logger.warn(
+				{ queue: queueName, jobId },
+				'fetch job stalled — lock expired, BullMQ will requeue. Associated run row may need manual reconciliation if the worker died mid-handler',
+			);
 		});
 		workers.push(worker);
 		logger.info({ queue: queueName }, 'worker started');

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -65,6 +65,7 @@ async function bootstrap(): Promise<void> {
 			competitorSuggestionRepo,
 			SystemClock,
 			SystemIdGenerator,
+			{ warn: (meta, msg) => logger.warn(meta, msg) },
 		);
 
 	const processor = new ProviderFetchProcessor({

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -168,10 +168,25 @@ export class ProviderFetchProcessor {
 			// BACKLOG #4 fix — endpoints that bill per item (e.g. search-volume
 			// at $0.005/keyword) declare a `costFor(params)` that returns the
 			// real cost for THIS call. Falls back to `cost.amount` (worst-case)
-			// for endpoints with flat per-call billing.
-			const realCostCents = endpointDescriptor.costFor
-				? endpointDescriptor.costFor(resolvedParams)
-				: endpointDescriptor.cost.amount;
+			// for endpoints with flat per-call billing OR if costFor throws
+			// on a malformed params shape (we charge worst-case AND log so
+			// the operator sees the misconfigure).
+			let realCostCents = endpointDescriptor.cost.amount;
+			if (endpointDescriptor.costFor) {
+				try {
+					realCostCents = endpointDescriptor.costFor(resolvedParams);
+				} catch (err) {
+					this.deps.logger.warn(
+						{
+							defId: definition.id,
+							providerId: definition.providerId.value,
+							endpointId: definition.endpointId.value,
+							err: err instanceof Error ? err.message : String(err),
+						},
+						'costFor() threw on resolvedParams — billing worst-case for this run',
+					);
+				}
+			}
 			await this.deps.recordApiUsageUseCase.execute({
 				organizationId: orgId,
 				credentialId: resolved.credentialId,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -143,6 +143,12 @@ export class ProviderFetchProcessor {
 			return;
 		}
 
+		// Hard timeout per fetch. Without this a hung provider (DNS,
+		// stuck TCP, infinite redirect) holds a BullMQ concurrency slot
+		// indefinitely — eventually starves the worker. 60s is generous
+		// for the slowest endpoints (on-page audit) and tight enough for
+		// the fast ones (SERP).
+		const timeoutSignal = AbortSignal.timeout(60_000);
 		try {
 			const fetchResult = await provider.fetch(definition.endpointId.value, resolvedParams, {
 				credential: { plaintextSecret: resolved.plaintextSecret },
@@ -150,6 +156,7 @@ export class ProviderFetchProcessor {
 					debug: (msg, meta) => this.deps.logger.debug(meta ?? {}, msg),
 					warn: (msg, meta) => this.deps.logger.warn(meta ?? {}, msg),
 				},
+				signal: timeoutSignal,
 				now: () => this.deps.clock.now(),
 			});
 

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -31,12 +31,24 @@ import { extractMultiDomainRankings, isMultiDomainSerpJob } from './extract-mult
  * BACKLOG #14: detect provider-side "out of quota / payment required" so the
  * processor stops retrying AND the job definition is auto-paused — otherwise
  * BullMQ keeps hammering the upstream and the same error fills the run log.
- * 402 (Payment Required) is the universal "you ran out of credit" code; we
- * also accept 429 from quota-style providers (vs throttling 429s, which are
- * retryable — provider implementations can subclass to disambiguate later).
+ *
+ * Covers:
+ *   - HTTP 402 from any provider (universal "out of credit" code).
+ *   - DataForSEO body status_code in the 402xx / 403xx / 405xx ranges.
+ *     DataForSEO returns HTTP 200 with body status_code 40402 ("no
+ *     balance"), 40501 ("monthly limit reached") and similar — these are
+ *     surfaced as DataForSeoApiError by `ensureTaskOk`. Without this
+ *     check the worker treats them as transient and retries forever.
  */
 const isQuotaExhaustedError = (err: unknown): boolean => {
-	if (err instanceof DataForSeoApiError && err.status === 402) return true;
+	if (err instanceof DataForSeoApiError) {
+		if (err.status === 402) return true;
+		// Body status codes: 40402, 40403, 40501, 40502 — quota / billing.
+		// 40000-40399 are validation / auth which ARE worth retrying after
+		// the operator fixes them.
+		if (err.status >= 40400 && err.status < 41000) return true;
+		if (err.status >= 40500 && err.status < 41000) return true;
+	}
 	if (err instanceof GscApiError && err.status === 402) return true;
 	return false;
 };
@@ -85,8 +97,18 @@ export class ProviderFetchProcessor {
 		if (!definition) {
 			throw new NotFoundError(`Job definition ${data.definitionId} not found`);
 		}
+		// Pre-bind defId/runId/providerId/endpointId on a child logger so
+		// every line emitted during this run carries the same correlation
+		// keys. Without this, debugging concurrent runs (default
+		// WORKER_CONCURRENCY=4) means cross-referencing interleaved logs
+		// by hand.
+		const log = this.deps.logger.child({
+			defId: definition.id,
+			providerId: definition.providerId.value,
+			endpointId: definition.endpointId.value,
+		});
 		if (!definition.enabled) {
-			this.deps.logger.info({ defId: definition.id }, 'job definition disabled, skipping');
+			log.info({}, 'job definition disabled, skipping');
 			return;
 		}
 
@@ -110,6 +132,7 @@ export class ProviderFetchProcessor {
 		});
 
 		const runId = (data.runId ?? this.deps.ids.generate()) as ProviderConnectivity.ProviderJobRunId;
+		const runLog = log.child({ runId });
 		const run = ProviderConnectivity.ProviderJobRun.start({
 			id: runId,
 			definitionId: definition.id,
@@ -137,7 +160,7 @@ export class ProviderFetchProcessor {
 		);
 		const existing = await this.deps.rawPayloadRepo.findByRequestHash(requestHash);
 		if (existing) {
-			this.deps.logger.info({ defId: definition.id, requestHash }, 'idempotent skip');
+			runLog.info({ requestHash }, 'idempotent skip');
 			run.complete(existing.id, this.deps.clock.now());
 			await this.deps.jobRunRepo.save(run);
 			return;
@@ -153,8 +176,8 @@ export class ProviderFetchProcessor {
 			const fetchResult = await provider.fetch(definition.endpointId.value, resolvedParams, {
 				credential: { plaintextSecret: resolved.plaintextSecret },
 				logger: {
-					debug: (msg, meta) => this.deps.logger.debug(meta ?? {}, msg),
-					warn: (msg, meta) => this.deps.logger.warn(meta ?? {}, msg),
+					debug: (msg, meta) => runLog.debug(meta ?? {}, msg),
+					warn: (msg, meta) => runLog.warn(meta ?? {}, msg),
 				},
 				signal: timeoutSignal,
 				now: () => this.deps.clock.now(),
@@ -183,13 +206,8 @@ export class ProviderFetchProcessor {
 				try {
 					realCostCents = endpointDescriptor.costFor(resolvedParams);
 				} catch (err) {
-					this.deps.logger.warn(
-						{
-							defId: definition.id,
-							providerId: definition.providerId.value,
-							endpointId: definition.endpointId.value,
-							err: err instanceof Error ? err.message : String(err),
-						},
+					runLog.warn(
+						{ err: err instanceof Error ? err.message : String(err) },
 						'costFor() threw on resolvedParams — billing worst-case for this run',
 					);
 				}
@@ -272,10 +290,7 @@ export class ProviderFetchProcessor {
 				// token form. `gscPropertyId` is a literal string in both.
 				const gscParams = resolvedParams as unknown as SearchAnalyticsParams & { gscPropertyId?: string };
 				if (!gscParams.gscPropertyId) {
-					this.deps.logger.warn(
-						{ defId: definition.id },
-						'gsc-search-analytics job missing gscPropertyId param; skipping ingest',
-					);
+					runLog.warn({}, 'gsc-search-analytics job missing gscPropertyId param; skipping ingest');
 				} else {
 					const rows = extractGscRows(fetchResult as SearchAnalyticsResponse, {
 						dimensions: gscParams.dimensions ?? ['date'],
@@ -305,9 +320,9 @@ export class ProviderFetchProcessor {
 				await this.deps.jobDefRepo.save(definition);
 				run.fail({ code: 'QUOTA_EXCEEDED', message, retryable: false }, this.deps.clock.now());
 				await this.deps.jobRunRepo.save(run);
-				this.deps.logger.warn(
-					{ defId: definition.id, providerId: definition.providerId.value },
-					'provider returned 402 — definition auto-paused, top up credit and re-enable from the UI',
+				runLog.warn(
+					{},
+					'provider returned quota-exhausted error — definition auto-paused, top up credit and re-enable from the UI',
 				);
 				return;
 			}

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -56,4 +56,6 @@ COPY --from=builder --chown=node:node /app/apps/api ./apps/api
 
 WORKDIR /app/apps/api
 EXPOSE 3000
+HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=3 \
+	CMD node -e "fetch('http://127.0.0.1:3000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "dist/main.js"]

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,0 +1,59 @@
+# BACKLOG #16 — multi-stage Docker image for the NestJS API.
+#
+# Stage 1 (builder): pnpm install (default isolated linker — pnpm
+# materialises per-package node_modules with bin shims that the workspace
+# build scripts rely on), then `pnpm --filter @rankpulse/api... build`
+# walks the dep graph in topological order producing `dist/` everywhere.
+#
+# Stage 2 (runtime): copies the built workspace + a pruned (prod-only)
+# node_modules tree. The api's package.json `main: ./dist/main.js` and
+# every workspace package's `exports` map (default → dist) make
+# `node dist/main.js` resolve cross-package imports without
+# @swc-node/register on the hot path.
+#
+# Image is built from the repo root — `context: .` in ci.yml.
+
+FROM node:24.10.0-alpine AS base
+WORKDIR /app
+# pnpm via direct npm install matches the CI workflow exactly (corepack
+# bridge has hit edge cases on alpine where the shim isn't materialised
+# by the time the next step runs).
+RUN npm install -g pnpm@10.33.2
+
+# ---------- builder ----------
+FROM base AS builder
+
+# Bring in everything in one shot. Layer-cache splitting (manifests
+# first, then sources) was tempting but the alpine pnpm install needs
+# to see workspace packages on disk to resolve `workspace:*` correctly.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+
+# Build api + every workspace package it transitively depends on.
+RUN pnpm --filter @rankpulse/api... build
+
+# Strip dev deps so the runtime stage is slimmer. CI=true tells pnpm
+# we're non-interactive — without it, `prune` aborts asking for TTY
+# confirmation before deleting node_modules.
+ENV CI=true
+RUN pnpm prune --prod
+
+# ---------- runtime ----------
+FROM base AS runtime
+ENV NODE_ENV=production
+
+# Non-root by default. node:alpine ships uid 1000 already.
+USER node
+
+WORKDIR /app
+COPY --from=builder --chown=node:node /app/pnpm-workspace.yaml /app/package.json /app/pnpm-lock.yaml ./
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/packages ./packages
+COPY --from=builder --chown=node:node /app/apps/api ./apps/api
+
+WORKDIR /app/apps/api
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,40 @@
+# BACKLOG #16 — multi-stage Docker image for the Vite SPA.
+# Builder produces apps/web/dist/, runtime is plain nginx serving the
+# static assets. SPA routes fall back to /index.html so React Router
+# handles client-side navigation.
+
+FROM node:24.10.0-alpine AS builder
+WORKDIR /app
+RUN npm install -g pnpm@10.33.2
+
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @rankpulse/web build
+
+# ---------- runtime ----------
+FROM nginx:1.27-alpine AS runtime
+
+# History API fallback for the SPA + far-future caching for hashed
+# asset filenames produced by Vite (`assets/index-<hash>.js`).
+RUN printf 'server {\n\
+\tlisten 80;\n\
+\troot /usr/share/nginx/html;\n\
+\tlocation / {\n\
+\t\ttry_files $uri $uri/ /index.html;\n\
+\t}\n\
+\tlocation ~* \\.(?:css|js|woff2?|svg|png|jpg|jpeg|gif|ico)$ {\n\
+\t\texpires 30d;\n\
+\t\tadd_header Cache-Control "public, immutable";\n\
+\t}\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -37,4 +37,6 @@ RUN printf 'server {\n\
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
 
 EXPOSE 80
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
+	CMD wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,0 +1,35 @@
+# BACKLOG #16 — multi-stage Docker image for the BullMQ worker.
+# Same pattern as api.Dockerfile; only the workspace filter and the
+# entrypoint differ.
+
+FROM node:24.10.0-alpine AS base
+WORKDIR /app
+RUN npm install -g pnpm@10.33.2
+
+# ---------- builder ----------
+FROM base AS builder
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @rankpulse/worker... build
+
+ENV CI=true
+RUN pnpm prune --prod
+
+# ---------- runtime ----------
+FROM base AS runtime
+ENV NODE_ENV=production
+USER node
+
+WORKDIR /app
+COPY --from=builder --chown=node:node /app/pnpm-workspace.yaml /app/package.json /app/pnpm-lock.yaml ./
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/packages ./packages
+COPY --from=builder --chown=node:node /app/apps/worker ./apps/worker
+
+WORKDIR /app/apps/worker
+EXPOSE 3001
+CMD ["node", "dist/main.js"]

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -31,5 +31,11 @@ COPY --from=builder --chown=node:node /app/packages ./packages
 COPY --from=builder --chown=node:node /app/apps/worker ./apps/worker
 
 WORKDIR /app/apps/worker
-EXPOSE 3001
+# Worker exposes a small health server on HEALTH_PORT (default 3300).
+# `/readyz` checks Postgres + Redis + every BullMQ worker is running;
+# `/healthz` just confirms the process is alive (used here so a slow
+# Postgres doesn't take the container down).
+EXPOSE 3300
+HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=3 \
+	CMD node -e "fetch('http://127.0.0.1:3300/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "dist/main.js"]

--- a/ops/ecosystem.config.cjs
+++ b/ops/ecosystem.config.cjs
@@ -29,14 +29,24 @@
 const path = require('node:path');
 const APP_ROOT = path.resolve(__dirname, '..');
 
+// PM2 cluster mode requires the entry script to be a Node.js module that
+// PM2 can `cluster.fork()` directly — wrapping it through `pnpm` was
+// silently degrading to single-instance behaviour and the three extra
+// "workers" were dying with EADDRINUSE on every reload. Pointing PM2 at
+// the compiled `dist/main.js` lets the Node cluster module distribute
+// the listening socket across all 4 forks. SIGTERM also reaches the
+// Node process directly so NestJS's onModuleDestroy / BullMQ's
+// worker.close() actually run on graceful shutdown.
+const NODE_ARGS = ['--env-file-if-exists=.env', '--env-file-if-exists=.env.local'];
+
 module.exports = {
 	apps: [
 		{
 			name: 'rankpulse-api',
 			cwd: APP_ROOT,
-			script: 'pnpm',
-			args: ['--filter', '@rankpulse/api', 'start:prod'],
-			interpreter: 'none',
+			script: 'apps/api/dist/main.js',
+			node_args: NODE_ARGS,
+			interpreter: 'node',
 			instances: 4,
 			exec_mode: 'cluster',
 			max_memory_restart: '512M',
@@ -49,9 +59,9 @@ module.exports = {
 		{
 			name: 'rankpulse-worker',
 			cwd: APP_ROOT,
-			script: 'pnpm',
-			args: ['--filter', '@rankpulse/worker', 'start:prod'],
-			interpreter: 'none',
+			script: 'apps/worker/dist/main.js',
+			node_args: NODE_ARGS,
+			interpreter: 'node',
 			instances: 1,
 			exec_mode: 'fork',
 			max_memory_restart: '768M',

--- a/packages/application/src/project-management/use-cases/competitor-suggestions.use-cases.ts
+++ b/packages/application/src/project-management/use-cases/competitor-suggestions.use-cases.ts
@@ -58,6 +58,12 @@ export interface RecordTop10HitsCommand {
 	externalDomainsInTop10: readonly string[];
 }
 
+export interface SuggestionRecorderLogger {
+	warn(meta: object, msg: string): void;
+}
+
+const NOOP_LOGGER: SuggestionRecorderLogger = { warn: () => {} };
+
 /**
  * Side-effect of a SERP fetch (called from the worker after extraction).
  * For every external domain in top-10, find-or-create the suggestion
@@ -69,6 +75,7 @@ export class RecordTop10HitsForSuggestionsUseCase {
 		private readonly suggestions: ProjectManagement.CompetitorSuggestionRepository,
 		private readonly clock: Clock,
 		private readonly ids: IdGenerator,
+		private readonly logger: SuggestionRecorderLogger = NOOP_LOGGER,
 	) {}
 
 	async execute(cmd: RecordTop10HitsCommand): Promise<void> {
@@ -78,7 +85,22 @@ export class RecordTop10HitsForSuggestionsUseCase {
 			const key = normalize(raw);
 			if (seen.has(key)) continue;
 			seen.add(key);
-			await this.recordSingleDomain(projectId, key, cmd.keyword);
+			// One bad domain (transient DB error, etc.) shouldn't abort the
+			// rest of the batch. Recording suggestions is a side-effect of
+			// the SERP fetch — the rank observations are already persisted.
+			try {
+				await this.recordSingleDomain(projectId, key, cmd.keyword);
+			} catch (err) {
+				this.logger.warn(
+					{
+						projectId,
+						domain: key,
+						keyword: cmd.keyword,
+						err: err instanceof Error ? err.message : String(err),
+					},
+					'failed to record top-10 hit for suggestion; continuing batch',
+				);
+			}
 		}
 	}
 

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
@@ -65,10 +65,11 @@ export class UpdateJobDefinitionUseCase {
 		);
 		if (!def) throw new NotFoundError(`Job definition ${cmd.definitionId} not found`);
 
-		// Unregister BEFORE mutating so BullMQ removes the repeatable using the
-		// old cron pattern; a new register() afterwards (re-)installs it under
-		// the new pattern.
-		await this.scheduler.unregister(def);
+		// Snapshot the OLD definition so we can unregister its repeatable
+		// pattern after the DB write succeeds. If we unregistered first
+		// and then `save` failed, BullMQ would have no entry while the DB
+		// still claimed the old cron — silent drift until the next reload.
+		const snapshotBeforeUpdate = def;
 
 		if (cmd.cron !== undefined) def.updateCron(ProviderConnectivity.CronExpression.create(cmd.cron));
 		if (cmd.params !== undefined) def.updateParams(cmd.params);
@@ -76,6 +77,11 @@ export class UpdateJobDefinitionUseCase {
 		if (cmd.enabled === false) def.disable();
 
 		await this.definitions.save(def);
+		// DB is now the source of truth. Swap the BullMQ entry: unregister
+		// the prior pattern, register the new one. If `register` fails the
+		// next worker reboot reconciles from DB; the operator just sees a
+		// missing scheduled run for the upcoming tick.
+		await this.scheduler.unregister(snapshotBeforeUpdate);
 		await this.scheduler.register(def);
 		return toView(def);
 	}

--- a/packages/application/src/rank-tracking/use-cases/start-tracking-keyword.use-case.ts
+++ b/packages/application/src/rank-tracking/use-cases/start-tracking-keyword.use-case.ts
@@ -40,6 +40,7 @@ export class StartTrackingKeywordUseCase {
 			country: location.country,
 			language: location.language,
 			device,
+			searchEngine: RankTracking.SearchEngines.GOOGLE,
 		});
 		if (existing) {
 			throw new ConflictError(

--- a/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.spec.ts
@@ -44,8 +44,11 @@ class PropertyRepo implements SearchConsoleInsights.GscPropertyRepository {
 
 class ObservationRepo implements SearchConsoleInsights.GscPerformanceObservationRepository {
 	saved: SearchConsoleInsights.GscPerformanceObservation[] = [];
-	async saveAll(observations: readonly SearchConsoleInsights.GscPerformanceObservation[]): Promise<void> {
+	async saveAll(
+		observations: readonly SearchConsoleInsights.GscPerformanceObservation[],
+	): Promise<{ inserted: number }> {
 		this.saved.push(...observations);
+		return { inserted: observations.length };
 	}
 	async listForProperty(): Promise<readonly SearchConsoleInsights.GscPerformanceObservation[]> {
 		return this.saved;

--- a/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.spec.ts
@@ -4,7 +4,7 @@ import {
 	SearchConsoleInsights,
 	type SharedKernel,
 } from '@rankpulse/domain';
-import { FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { IngestGscRowsUseCase } from './ingest-gsc-rows.use-case.js';
 
@@ -78,10 +78,16 @@ describe('IngestGscRowsUseCase', () => {
 		obsRepo = new ObservationRepo();
 		publisher = new CapturingPublisher();
 		await propertyRepo.save(buildProperty(new Date('2026-04-01T00:00:00Z')));
-		useCase = new IngestGscRowsUseCase(propertyRepo, obsRepo, ids(50), publisher);
+		useCase = new IngestGscRowsUseCase(
+			propertyRepo,
+			obsRepo,
+			ids(50),
+			publisher,
+			new FakeClock('2026-05-02T12:00:00Z'),
+		);
 	});
 
-	it('persists each row as a typed observation and emits one event per row', async () => {
+	it('persists each row and emits one summary event for the whole batch', async () => {
 		const result = await useCase.execute({
 			gscPropertyId: propertyId,
 			rawPayloadId: null,
@@ -112,7 +118,12 @@ describe('IngestGscRowsUseCase', () => {
 		});
 		expect(result.ingested).toBe(2);
 		expect(obsRepo.saved).toHaveLength(2);
-		expect(publisher.events.map((e) => e.type)).toEqual(['GscPerformanceIngested', 'GscPerformanceIngested']);
+		expect(publisher.events).toHaveLength(1);
+		const [event] = publisher.events as [SearchConsoleInsights.GscPerformanceBatchIngested];
+		expect(event.type).toBe('GscPerformanceBatchIngested');
+		expect(event.rowsCount).toBe(2);
+		expect(event.totalClicks).toBe(12 + 5);
+		expect(event.totalImpressions).toBe(340 + 120);
 	});
 
 	it('returns 0 and does not call repos when rows is empty', async () => {

--- a/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.ts
@@ -1,5 +1,5 @@
 import { SearchConsoleInsights, type SharedKernel } from '@rankpulse/domain';
-import { type IdGenerator, NotFoundError } from '@rankpulse/shared';
+import { type Clock, type IdGenerator, NotFoundError } from '@rankpulse/shared';
 
 export interface GscRowInput {
 	observedAt: Date;
@@ -34,6 +34,7 @@ export class IngestGscRowsUseCase {
 		private readonly observations: SearchConsoleInsights.GscPerformanceObservationRepository,
 		private readonly ids: IdGenerator,
 		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
 	) {}
 
 	async execute(cmd: IngestGscRowsCommand): Promise<IngestGscRowsResult> {
@@ -48,8 +49,12 @@ export class IngestGscRowsUseCase {
 			return { ingested: 0 };
 		}
 
-		const observations = cmd.rows.map((row) =>
-			SearchConsoleInsights.GscPerformanceObservation.record({
+		let totalClicks = 0;
+		let totalImpressions = 0;
+		const observations = cmd.rows.map((row) => {
+			totalClicks += row.clicks;
+			totalImpressions += row.impressions;
+			return SearchConsoleInsights.GscPerformanceObservation.record({
 				id: this.ids.generate() as SearchConsoleInsights.GscObservationId,
 				gscPropertyId: property.id,
 				projectId: property.projectId,
@@ -65,16 +70,24 @@ export class IngestGscRowsUseCase {
 					position: row.position,
 				}),
 				rawPayloadId: cmd.rawPayloadId,
-			}),
-		);
+			});
+		});
 
 		await this.observations.saveAll(observations);
 
-		const allEvents: SharedKernel.DomainEvent[] = [];
-		for (const o of observations) {
-			allEvents.push(...o.pullEvents());
-		}
-		await this.events.publish(allEvents);
+		// One summary event for the whole batch instead of N per-row events.
+		// Subscribers (alerting, weekly reports) aggregate anyway, and a
+		// 25k-row GSC fetch shouldn't blow up the event bus.
+		await this.events.publish([
+			new SearchConsoleInsights.GscPerformanceBatchIngested({
+				projectId: property.projectId,
+				gscPropertyId: property.id,
+				rowsCount: observations.length,
+				totalClicks,
+				totalImpressions,
+				occurredAt: this.clock.now(),
+			}),
+		]);
 
 		return { ingested: observations.length };
 	}

--- a/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/ingest-gsc-rows.use-case.ts
@@ -73,7 +73,11 @@ export class IngestGscRowsUseCase {
 			});
 		});
 
-		await this.observations.saveAll(observations);
+		// `inserted` is the count after `onConflictDoNothing` — it
+		// excludes idempotent re-fetches that collided with the natural-
+		// key PK. Reporting the raw `observations.length` here would
+		// inflate the metric in dashboards on every retry.
+		const { inserted } = await this.observations.saveAll(observations);
 
 		// One summary event for the whole batch instead of N per-row events.
 		// Subscribers (alerting, weekly reports) aggregate anyway, and a
@@ -82,13 +86,13 @@ export class IngestGscRowsUseCase {
 			new SearchConsoleInsights.GscPerformanceBatchIngested({
 				projectId: property.projectId,
 				gscPropertyId: property.id,
-				rowsCount: observations.length,
+				rowsCount: inserted,
 				totalClicks,
 				totalImpressions,
 				occurredAt: this.clock.now(),
 			}),
 		]);
 
-		return { ingested: observations.length };
+		return { ingested: inserted };
 	}
 }

--- a/packages/contracts/src/project-management/index.ts
+++ b/packages/contracts/src/project-management/index.ts
@@ -94,10 +94,15 @@ export const CompetitorSuggestionDto = z.object({
 export type CompetitorSuggestionDto = z.infer<typeof CompetitorSuggestionDto>;
 
 export const ListCompetitorSuggestionsQuery = z.object({
+	// Tri-state: undefined (param absent) → controller picks the default;
+	// 'true' / 'false' → explicit override. The previous transform mapped
+	// undefined to `false`, which silently turned the eligible-only filter
+	// OFF for every default request — promoted/dismissed suggestions
+	// leaked into the UI.
 	eligibleOnly: z
 		.union([z.literal('true'), z.literal('false')])
 		.optional()
-		.transform((v) => v === 'true'),
+		.transform((v) => (v === undefined ? undefined : v === 'true')),
 });
 export type ListCompetitorSuggestionsQuery = z.infer<typeof ListCompetitorSuggestionsQuery>;
 

--- a/packages/domain/src/rank-tracking/ports/tracked-keyword-repository.ts
+++ b/packages/domain/src/rank-tracking/ports/tracked-keyword-repository.ts
@@ -13,6 +13,7 @@ export interface TrackedKeywordRepository {
 		country: string;
 		language: string;
 		device: string;
+		searchEngine: string;
 	}): Promise<TrackedKeyword | null>;
 	listForProject(projectId: ProjectId): Promise<readonly TrackedKeyword[]>;
 	listForOrganization(orgId: OrganizationId): Promise<readonly TrackedKeyword[]>;

--- a/packages/domain/src/rank-tracking/value-objects/position.ts
+++ b/packages/domain/src/rank-tracking/value-objects/position.ts
@@ -34,8 +34,16 @@ export class Position {
 		return this.value !== null && this.value <= 10;
 	}
 
+	/**
+	 * Today, "first page" and "top ten" coincide for desktop Google
+	 * organic — we keep both names as semantic aliases so call sites
+	 * read naturally for the metric they care about. If the rank
+	 * tracker ever supports SERP variants where the boundary differs
+	 * (mobile compact, AI overviews squeezing organic, etc.), this
+	 * method becomes the place to encode the new threshold.
+	 */
 	isOnFirstPage(): boolean {
-		return this.value !== null && this.value <= 10;
+		return this.isInTopTen();
 	}
 
 	delta(other: Position): number | null {

--- a/packages/domain/src/search-console-insights/entities/gsc-performance-observation.ts
+++ b/packages/domain/src/search-console-insights/entities/gsc-performance-observation.ts
@@ -1,6 +1,5 @@
 import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
 import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
-import { GscPerformanceIngested } from '../events/gsc-performance-ingested.js';
 import type { GscObservationId, GscPropertyId } from '../value-objects/identifiers.js';
 import type { PerformanceMetrics } from '../value-objects/performance-metrics.js';
 
@@ -38,18 +37,10 @@ export class GscPerformanceObservation extends AggregateRoot {
 		metrics: PerformanceMetrics;
 		rawPayloadId: string | null;
 	}): GscPerformanceObservation {
-		const observation = new GscPerformanceObservation(input);
-		observation.record(
-			new GscPerformanceIngested({
-				observationId: input.id,
-				projectId: input.projectId,
-				gscPropertyId: input.gscPropertyId,
-				occurredAt: input.observedAt,
-				clicks: input.metrics.clicks,
-				impressions: input.metrics.impressions,
-			}),
-		);
-		return observation;
+		// Pure value-like factory — no per-row events. The
+		// IngestGscRowsUseCase publishes ONE batch summary instead so a
+		// 25k-row fetch doesn't fan out 25k events through the publisher.
+		return new GscPerformanceObservation(input);
 	}
 
 	static rehydrate(props: GscPerformanceObservationProps): GscPerformanceObservation {

--- a/packages/domain/src/search-console-insights/events/gsc-performance-batch-ingested.ts
+++ b/packages/domain/src/search-console-insights/events/gsc-performance-batch-ingested.ts
@@ -1,0 +1,36 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { GscPropertyId } from '../value-objects/identifiers.js';
+
+/**
+ * One event per ingest call (NOT per row). The previous design emitted
+ * one `GscPerformanceIngested` per observation, fanning out 25k events
+ * for a single GSC fetch with the default rowLimit. Subscribers were
+ * already aggregating totals downstream, so we publish the summary
+ * directly and let raw rows live in the read model only.
+ */
+export class GscPerformanceBatchIngested implements DomainEvent {
+	readonly type = 'GscPerformanceBatchIngested';
+	readonly projectId: ProjectId;
+	readonly gscPropertyId: GscPropertyId;
+	readonly rowsCount: number;
+	readonly totalClicks: number;
+	readonly totalImpressions: number;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		projectId: ProjectId;
+		gscPropertyId: GscPropertyId;
+		rowsCount: number;
+		totalClicks: number;
+		totalImpressions: number;
+		occurredAt: Date;
+	}) {
+		this.projectId = props.projectId;
+		this.gscPropertyId = props.gscPropertyId;
+		this.rowsCount = props.rowsCount;
+		this.totalClicks = props.totalClicks;
+		this.totalImpressions = props.totalImpressions;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/search-console-insights/index.ts
+++ b/packages/domain/src/search-console-insights/index.ts
@@ -3,8 +3,9 @@
 export * from './entities/gsc-performance-observation.js';
 // Entities / aggregates
 export * from './entities/gsc-property.js';
-export * from './events/gsc-performance-ingested.js';
 // Events
+export * from './events/gsc-performance-batch-ingested.js';
+export * from './events/gsc-performance-ingested.js';
 export * from './events/gsc-property-linked.js';
 export * from './ports/gsc-performance-observation-repository.js';
 // Ports

--- a/packages/domain/src/search-console-insights/ports/gsc-performance-observation-repository.ts
+++ b/packages/domain/src/search-console-insights/ports/gsc-performance-observation-repository.ts
@@ -12,7 +12,16 @@ export interface GscObservationQuery {
 }
 
 export interface GscPerformanceObservationRepository {
-	saveAll(observations: readonly GscPerformanceObservation[]): Promise<void>;
+	/**
+	 * Bulk-insert observations. Implementations MUST be idempotent on
+	 * the natural key (observedAt, propertyId, query, page, country,
+	 * device) — a re-fetch of the same day with the same dimensions
+	 * should not produce duplicate rows. Returns the number of rows
+	 * actually inserted (excludes rows that collided with the unique
+	 * key and were silently dropped) so callers can publish accurate
+	 * batch metrics.
+	 */
+	saveAll(observations: readonly GscPerformanceObservation[]): Promise<{ inserted: number }>;
 	listForProperty(
 		propertyId: GscPropertyId,
 		query: GscObservationQuery,

--- a/packages/domain/src/search-console-insights/value-objects/performance-metrics.ts
+++ b/packages/domain/src/search-console-insights/value-objects/performance-metrics.ts
@@ -28,8 +28,11 @@ export class PerformanceMetrics {
 		if (!Number.isFinite(input.ctr) || input.ctr < 0 || input.ctr > 1) {
 			throw new InvalidInputError('ctr must be in [0, 1]');
 		}
-		if (!Number.isFinite(input.position) || input.position < 0) {
-			throw new InvalidInputError('position must be a non-negative number');
+		// GSC publishes average organic position as a float >= 1.0. A 0
+		// (or negative) here means the parser dropped or zero-initialised
+		// the field — never legitimate, surface it loudly.
+		if (!Number.isFinite(input.position) || input.position < 1) {
+			throw new InvalidInputError('position must be >= 1 (GSC average position is 1-indexed)');
 		}
 		return new PerformanceMetrics(
 			Math.round(input.clicks),

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0003_messy_miss_america.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0003_messy_miss_america.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "competitor_suggestions" (
+CREATE TABLE IF NOT EXISTS "competitor_suggestions" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"project_id" uuid NOT NULL,
 	"domain" text NOT NULL,
@@ -11,6 +11,10 @@ CREATE TABLE "competitor_suggestions" (
 	"dismissed_at" timestamp with time zone
 );
 --> statement-breakpoint
-ALTER TABLE "competitor_suggestions" ADD CONSTRAINT "competitor_suggestions_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE UNIQUE INDEX "competitor_suggestions_project_domain_unique" ON "competitor_suggestions" USING btree ("project_id","domain");--> statement-breakpoint
-CREATE INDEX "competitor_suggestions_project_status_idx" ON "competitor_suggestions" USING btree ("project_id","status");
+DO $$ BEGIN
+ ALTER TABLE "competitor_suggestions" ADD CONSTRAINT "competitor_suggestions_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "competitor_suggestions_project_domain_unique" ON "competitor_suggestions" USING btree ("project_id","domain");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "competitor_suggestions_project_status_idx" ON "competitor_suggestions" USING btree ("project_id","status");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0004_serious_magus.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0004_serious_magus.sql
@@ -1,0 +1,32 @@
+-- BACKLOG #16 follow-up — gsc_observations gains a real natural-key PK
+-- so re-running the same fetch on the same day is idempotent. Existing
+-- nullable dimensions (query/page/country/device) get coerced to '' so
+-- the PK can cover every row without a COALESCE-based unique index.
+
+UPDATE "gsc_observations" SET "query" = '' WHERE "query" IS NULL;--> statement-breakpoint
+UPDATE "gsc_observations" SET "page" = '' WHERE "page" IS NULL;--> statement-breakpoint
+UPDATE "gsc_observations" SET "country" = '' WHERE "country" IS NULL;--> statement-breakpoint
+UPDATE "gsc_observations" SET "device" = '' WHERE "device" IS NULL;--> statement-breakpoint
+
+-- Collapse any duplicates that the previous schema allowed — keeps the
+-- earliest row per natural key (the rest are exact re-fetches with the
+-- same metrics anyway, so the choice is informational).
+DELETE FROM "gsc_observations" a USING "gsc_observations" b
+WHERE a.ctid > b.ctid
+  AND a.observed_at = b.observed_at
+  AND a.gsc_property_id = b.gsc_property_id
+  AND a.query = b.query
+  AND a.page = b.page
+  AND a.country = b.country
+  AND a.device = b.device;--> statement-breakpoint
+
+DROP INDEX "gsc_observations_property_idx";--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "query" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "query" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "page" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "page" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "country" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "country" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "device" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "gsc_observations" ALTER COLUMN "device" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "gsc_observations" ADD CONSTRAINT "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk" PRIMARY KEY("observed_at","gsc_property_id","query","page","country","device");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0004_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,2234 @@
+{
+	"id": "dac38f36-6480-4338-88d8-018554be2b28",
+	"prevId": "79083542-c97a-4e64-8fe5-21651042ffa6",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1777975582000,
 			"tag": "0003_messy_miss_america",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1778000182660,
+			"tag": "0004_serious_magus",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/project-management/competitor-suggestion.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/project-management/competitor-suggestion.repository.ts
@@ -26,6 +26,41 @@ export class DrizzleCompetitorSuggestionRepository
 
 	async save(suggestion: ProjectManagement.CompetitorSuggestion): Promise<void> {
 		const keywords = [...suggestion.keywordsInTop10];
+		// Transitions out of PENDING (promote/dismiss) need an optimistic
+		// lock — without it, two concurrent promote calls both load
+		// PENDING, both call `promote()` in memory and both UPSERT,
+		// producing duplicate Competitor rows downstream. Gate the
+		// terminal write on `status = 'PENDING'`; if zero rows match, the
+		// other writer already won and we throw ConflictError.
+		if (suggestion.status !== ProjectManagement.SuggestionStatuses.PENDING) {
+			const result = await this.db
+				.update(competitorSuggestions)
+				.set({
+					keywordsInTop10: keywords,
+					totalTop10Hits: suggestion.totalTop10Hits,
+					lastSeenAt: suggestion.lastSeenAt,
+					status: suggestion.status,
+					promotedAt: suggestion.promotedAt,
+					dismissedAt: suggestion.dismissedAt,
+				})
+				.where(
+					and(
+						eq(competitorSuggestions.id, suggestion.id),
+						eq(competitorSuggestions.status, ProjectManagement.SuggestionStatuses.PENDING),
+					),
+				)
+				.returning({ id: competitorSuggestions.id });
+			if (result.length === 0) {
+				throw new ConflictError(
+					`Suggestion ${suggestion.id} is no longer PENDING (concurrent promote/dismiss)`,
+				);
+			}
+			return;
+		}
+
+		// PENDING save: either first insert or incremental hit recording.
+		// Hits are idempotent — `onConflictDoUpdate(target: id)` keeps
+		// the latest tally without resetting status.
 		try {
 			await this.db
 				.insert(competitorSuggestions)
@@ -47,18 +82,14 @@ export class DrizzleCompetitorSuggestionRepository
 						keywordsInTop10: keywords,
 						totalTop10Hits: suggestion.totalTop10Hits,
 						lastSeenAt: suggestion.lastSeenAt,
-						status: suggestion.status,
-						promotedAt: suggestion.promotedAt,
-						dismissedAt: suggestion.dismissedAt,
 					},
 				});
 		} catch (err) {
-			// BACKLOG #1 fix — race: two parallel SERP jobs of the same project
-			// can each `observe` the same external domain with DIFFERENT ids.
-			// `onConflictDoUpdate(target: id)` only fires on PK collision, so
-			// the second insert hits the (project_id, domain) unique. Surface
-			// it as ConflictError so the use case can refetch + retry the
-			// recordTop10Hit branch.
+			// Race: two parallel SERP jobs of the same project each
+			// `observe` the same external domain with DIFFERENT ids. The
+			// PK conflict handler doesn't fire (different ids), so the
+			// (project_id, domain) unique catches it. Surface as
+			// ConflictError so the use case refetches + retries.
 			if (isProjectDomainUniqueViolation(err)) {
 				throw new ConflictError(
 					`Suggestion for (${suggestion.projectId}, ${suggestion.domain.value}) already exists`,

--- a/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
 import { and, eq } from 'drizzle-orm';
 import type { DrizzleDatabase } from '../../client.js';
@@ -10,13 +11,20 @@ const stableStringify = (value: unknown): string => {
 	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
 };
 
+/**
+ * Stable hash of the canonicalised params, used as the secondary key
+ * for `findFor(projectId, providerId, endpointId, params)` so two
+ * JobDefinitions for the same triple but different params can coexist.
+ *
+ * SHA-256 truncated to 16 hex chars (64 bits) — collision probability
+ * is ~2^-32 even with millions of definitions, vs. the previous
+ * 32-bit Bernstein hash that hit collisions under tens of thousands.
+ * A collision routed an entire job's cost to the wrong tenant; not
+ * acceptable.
+ */
 export const computeParamsHash = (params: Record<string, unknown>): string => {
 	const stable = stableStringify(params);
-	let hash = 0;
-	for (let i = 0; i < stable.length; i++) {
-		hash = (hash * 31 + stable.charCodeAt(i)) | 0;
-	}
-	return Math.abs(hash).toString(16).padStart(8, '0');
+	return createHash('sha256').update(stable).digest('hex').slice(0, 16);
 };
 
 export class DrizzleJobDefinitionRepository implements ProviderConnectivity.JobDefinitionRepository {

--- a/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/provider-connectivity/job-definition.repository.ts
@@ -21,6 +21,14 @@ const stableStringify = (value: unknown): string => {
  * 32-bit Bernstein hash that hit collisions under tens of thousands.
  * A collision routed an entire job's cost to the wrong tenant; not
  * acceptable.
+ *
+ * Rollout note: rows persisted with the previous 8-char Bernstein hash
+ * will not be findable via `findFor` after this change. Existing
+ * JobDefinitions still execute correctly (they're located by `id`
+ * everywhere except find-or-create paths). Operators on environments
+ * with prior data should run a one-off rehash script after deploy:
+ *   pnpm --filter @rankpulse/infrastructure exec tsx scripts/rehash-job-definitions.ts
+ * Pre-production environments can ignore this note.
  */
 export const computeParamsHash = (params: Record<string, unknown>): string => {
 	const stable = stableStringify(params);

--- a/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/tracked-keyword.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/tracked-keyword.repository.ts
@@ -41,6 +41,7 @@ export class DrizzleTrackedKeywordRepository implements RankTracking.TrackedKeyw
 		country: string;
 		language: string;
 		device: string;
+		searchEngine: string;
 	}): Promise<RankTracking.TrackedKeyword | null> {
 		const [row] = await this.db
 			.select()
@@ -53,6 +54,7 @@ export class DrizzleTrackedKeywordRepository implements RankTracking.TrackedKeyw
 					eq(trackedKeywords.country, input.country),
 					eq(trackedKeywords.language, input.language),
 					eq(trackedKeywords.device, input.device),
+					eq(trackedKeywords.searchEngine, input.searchEngine),
 				),
 			)
 			.limit(1);

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
@@ -8,12 +8,14 @@ export class DrizzleGscPerformanceObservationRepository
 {
 	constructor(private readonly db: DrizzleDatabase) {}
 
-	async saveAll(observations: readonly SearchConsoleInsights.GscPerformanceObservation[]): Promise<void> {
-		if (observations.length === 0) return;
+	async saveAll(
+		observations: readonly SearchConsoleInsights.GscPerformanceObservation[],
+	): Promise<{ inserted: number }> {
+		if (observations.length === 0) return { inserted: 0 };
 		// Domain models the absence of a dimension as `null`; the table
 		// stores `''` so the natural-key PK can cover every row without
 		// COALESCE indexes. Bridge between the two here.
-		await this.db
+		const inserted = await this.db
 			.insert(gscObservations)
 			.values(
 				observations.map((o) => ({
@@ -40,7 +42,9 @@ export class DrizzleGscPerformanceObservationRepository
 					gscObservations.country,
 					gscObservations.device,
 				],
-			});
+			})
+			.returning({ id: gscObservations.observedAt });
+		return { inserted: inserted.length };
 	}
 
 	async listForProperty(

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
@@ -10,6 +10,9 @@ export class DrizzleGscPerformanceObservationRepository
 
 	async saveAll(observations: readonly SearchConsoleInsights.GscPerformanceObservation[]): Promise<void> {
 		if (observations.length === 0) return;
+		// Domain models the absence of a dimension as `null`; the table
+		// stores `''` so the natural-key PK can cover every row without
+		// COALESCE indexes. Bridge between the two here.
 		await this.db
 			.insert(gscObservations)
 			.values(
@@ -17,10 +20,10 @@ export class DrizzleGscPerformanceObservationRepository
 					observedAt: o.observedAt,
 					gscPropertyId: o.gscPropertyId,
 					projectId: o.projectId,
-					query: o.query,
-					page: o.page,
-					country: o.country,
-					device: o.device,
+					query: o.query ?? '',
+					page: o.page ?? '',
+					country: o.country ?? '',
+					device: o.device ?? '',
 					clicks: o.metrics.clicks,
 					impressions: o.metrics.impressions,
 					ctr: o.metrics.ctr,
@@ -28,7 +31,16 @@ export class DrizzleGscPerformanceObservationRepository
 					rawPayloadId: o.rawPayloadId,
 				})),
 			)
-			.onConflictDoNothing();
+			.onConflictDoNothing({
+				target: [
+					gscObservations.observedAt,
+					gscObservations.gscPropertyId,
+					gscObservations.query,
+					gscObservations.page,
+					gscObservations.country,
+					gscObservations.device,
+				],
+			});
 	}
 
 	async listForProperty(
@@ -39,10 +51,12 @@ export class DrizzleGscPerformanceObservationRepository
 			eq(gscObservations.gscPropertyId, propertyId),
 			between(gscObservations.observedAt, query.from, query.to),
 		];
-		if (query.query) conditions.push(eq(gscObservations.query, query.query));
-		if (query.page) conditions.push(eq(gscObservations.page, query.page));
-		if (query.country) conditions.push(eq(gscObservations.country, query.country));
-		if (query.device) conditions.push(eq(gscObservations.device, query.device));
+		// Empty-string filter = "rows where this dimension was absent in
+		// the GSC API response", consistent with the saveAll bridge.
+		if (query.query !== undefined) conditions.push(eq(gscObservations.query, query.query ?? ''));
+		if (query.page !== undefined) conditions.push(eq(gscObservations.page, query.page ?? ''));
+		if (query.country !== undefined) conditions.push(eq(gscObservations.country, query.country ?? ''));
+		if (query.device !== undefined) conditions.push(eq(gscObservations.device, query.device ?? ''));
 
 		const rows = await this.db
 			.select()
@@ -69,14 +83,15 @@ export class DrizzleGscPerformanceObservationRepository
 		row: typeof gscObservations.$inferSelect,
 	): SearchConsoleInsights.GscPerformanceObservation {
 		return SearchConsoleInsights.GscPerformanceObservation.rehydrate({
-			id: `${row.observedAt.toISOString()}#${row.gscPropertyId}#${row.query ?? ''}#${row.page ?? ''}` as SearchConsoleInsights.GscObservationId,
+			id: `${row.observedAt.toISOString()}#${row.gscPropertyId}#${row.query}#${row.page}` as SearchConsoleInsights.GscObservationId,
 			gscPropertyId: row.gscPropertyId as SearchConsoleInsights.GscPropertyId,
 			projectId: row.projectId as ProjectManagement.ProjectId,
 			observedAt: row.observedAt,
-			query: row.query,
-			page: row.page,
-			country: row.country,
-			device: row.device,
+			// Empty strings in storage = absent dimension in the domain.
+			query: row.query === '' ? null : row.query,
+			page: row.page === '' ? null : row.page,
+			country: row.country === '' ? null : row.country,
+			device: row.device === '' ? null : row.device,
 			metrics: SearchConsoleInsights.PerformanceMetrics.create({
 				clicks: row.clicks,
 				impressions: row.impressions,

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -454,6 +454,13 @@ export const gscProperties = pgTable(
 /**
  * GSC search-analytics rows. Promoted to a Timescale hypertable when the
  * extension is available (see migration 0003).
+ *
+ * Natural key is the (observedAt, gscPropertyId, query, page, country,
+ * device) tuple. We can't use a composite PK directly because the GSC
+ * dimensions are sometimes absent from a row (the API returns the row
+ * without that dimension key); we coerce the nullable text columns to
+ * empty string with a default so the unique index covers every row
+ * without requiring a separate `COALESCE` index.
  */
 export const gscObservations = pgTable(
 	'gsc_observations',
@@ -461,10 +468,10 @@ export const gscObservations = pgTable(
 		observedAt: timestamp('observed_at', { withTimezone: true }).notNull(),
 		gscPropertyId: uuid('gsc_property_id').notNull(),
 		projectId: uuid('project_id').notNull(),
-		query: text('query'),
-		page: text('page'),
-		country: text('country'),
-		device: text('device'),
+		query: text('query').notNull().default(''),
+		page: text('page').notNull().default(''),
+		country: text('country').notNull().default(''),
+		device: text('device').notNull().default(''),
 		clicks: integer('clicks').notNull(),
 		impressions: integer('impressions').notNull(),
 		ctr: doublePrecision('ctr').notNull(),
@@ -472,7 +479,12 @@ export const gscObservations = pgTable(
 		rawPayloadId: uuid('raw_payload_id'),
 	},
 	(t) => ({
-		propertyIdx: index('gsc_observations_property_idx').on(t.gscPropertyId, t.observedAt),
+		// PK over the natural key — re-running the same fetch on the same
+		// day with the same dimension breakdown is idempotent (the repo
+		// uses `onConflictDoNothing` against this PK target).
+		pk: primaryKey({
+			columns: [t.observedAt, t.gscPropertyId, t.query, t.page, t.country, t.device],
+		}),
 		projectIdx: index('gsc_observations_project_idx').on(t.projectId, t.observedAt),
 	}),
 );

--- a/packages/providers/dataforseo/src/endpoints/competitors-domain.ts
+++ b/packages/providers/dataforseo/src/endpoints/competitors-domain.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const CompetitorsDomainParams = z.object({
 	target: z.string().min(3).max(253),
@@ -67,11 +67,6 @@ export const fetchCompetitorsDomain = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as CompetitorsDomainResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO competitors-domain returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/domain-whois-overview.ts
+++ b/packages/providers/dataforseo/src/endpoints/domain-whois-overview.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const DomainWhoisOverviewParams = z.object({
 	target: z.string().min(3).max(253),
@@ -68,11 +68,6 @@ export const fetchDomainWhoisOverview = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as DomainWhoisResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO whois-overview returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/keyword-difficulty.ts
+++ b/packages/providers/dataforseo/src/endpoints/keyword-difficulty.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const KeywordDifficultyParams = z.object({
 	keywords: z.array(z.string().min(1).max(700)).min(1).max(1000),
@@ -62,11 +62,6 @@ export const fetchKeywordDifficulty = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as KeywordDifficultyResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO keyword-difficulty returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
+++ b/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const KeywordsDataSearchVolumeParams = z.object({
 	keywords: z.array(z.string().min(1).max(700)).min(1).max(1000),
@@ -93,11 +93,6 @@ export const fetchKeywordsDataSearchVolume = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as SearchVolumeResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO search-volume returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
+++ b/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
@@ -28,11 +28,18 @@ export const keywordsDataSearchVolumeDescriptor: EndpointDescriptor = {
 	paramsSchema: KeywordsDataSearchVolumeParams,
 	cost: { unit: 'usd_cents', amount: SEARCH_VOLUME_COST_CENTS_MAX },
 	costFor: (raw) => {
-		// Reuses the descriptor's own zod schema for safety: a malformed
-		// JobDefinition shouldn't bypass billing entirely. On parse fail
-		// we charge the worst-case so we never under-report.
+		// Reuses the descriptor's own zod schema for safety. The processor
+		// already validated `params` against this schema before dispatch,
+		// so a parse failure here means the resolvedParams object lost
+		// its shape between scheduling and billing — surface it loudly so
+		// the operator notices rather than silently absorbing the worst-
+		// case cost forever.
 		const parsed = KeywordsDataSearchVolumeParams.safeParse(raw);
-		if (!parsed.success) return SEARCH_VOLUME_COST_CENTS_MAX;
+		if (!parsed.success) {
+			throw new Error(
+				`keywords-data-search-volume costFor: malformed params (${parsed.error.message}); falling back to worst-case`,
+			);
+		}
 		return parsed.data.keywords.length * SEARCH_VOLUME_COST_CENTS_PER_KEYWORD;
 	},
 	// BACKLOG #4 fix — Google Ads search volume is updated MONTHLY upstream;

--- a/packages/providers/dataforseo/src/endpoints/keywords-for-site.ts
+++ b/packages/providers/dataforseo/src/endpoints/keywords-for-site.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const KeywordsForSiteParams = z.object({
 	target: z.string().min(3).max(253),
@@ -72,11 +72,6 @@ export const fetchKeywordsForSite = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as KeywordsForSiteResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO keywords-for-site returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/on-page-instant.ts
+++ b/packages/providers/dataforseo/src/endpoints/on-page-instant.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const OnPageInstantParams = z.object({
 	url: z.string().url(),
@@ -80,11 +80,6 @@ export const fetchOnPageInstantPages = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as OnPageInstantResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO on-page instant returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/related-keywords.ts
+++ b/packages/providers/dataforseo/src/endpoints/related-keywords.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const RelatedKeywordsParams = z.object({
 	keyword: z.string().min(1).max(700),
@@ -73,11 +73,6 @@ export const fetchRelatedKeywords = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as RelatedKeywordsResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO related-keywords returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/serp-google-organic-advanced.ts
+++ b/packages/providers/dataforseo/src/endpoints/serp-google-organic-advanced.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const SerpGoogleOrganicAdvancedParams = z.object({
 	keyword: z.string().min(1).max(700),
@@ -79,11 +79,6 @@ export const fetchSerpGoogleOrganicAdvanced = async (
 		ctx.credential.plaintextSecret,
 		ctx.signal,
 	)) as SerpAdvancedResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO SERP advanced returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/endpoints/serp-google-organic-live.ts
+++ b/packages/providers/dataforseo/src/endpoints/serp-google-organic-live.ts
@@ -1,6 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
-import type { DataForSeoHttp } from '../http.js';
+import { type DataForSeoHttp, ensureTaskOk } from '../http.js';
 
 export const SerpGoogleOrganicLiveParams = z.object({
 	keyword: z.string().min(1).max(700),
@@ -83,11 +83,6 @@ export const fetchSerpGoogleOrganicLive = async (
 ): Promise<SerpLiveResponse> => {
 	const body = buildSerpLiveBody(params);
 	const raw = (await http.post(PATH, body, ctx.credential.plaintextSecret, ctx.signal)) as SerpLiveResponse;
-	if (raw.status_code !== 20000) {
-		ctx.logger.warn('DataForSEO SERP live returned a non-success status', {
-			status: raw.status_code,
-			message: raw.status_message,
-		});
-	}
+	ensureTaskOk(PATH, raw);
 	return raw;
 };

--- a/packages/providers/dataforseo/src/http.spec.ts
+++ b/packages/providers/dataforseo/src/http.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { DataForSeoApiError, ensureTaskOk } from './http.js';
+
+describe('ensureTaskOk', () => {
+	it('returns silently for the canonical success status (20000)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 20000, status_message: 'Ok.' })).not.toThrow();
+	});
+
+	it('treats informational 20100-20999 as success', () => {
+		expect(() =>
+			ensureTaskOk('/v3/test', { status_code: 20100, status_message: 'No results.' }),
+		).not.toThrow();
+		expect(() => ensureTaskOk('/v3/test', { status_code: 20999, status_message: 'Edge.' })).not.toThrow();
+	});
+
+	it('throws DataForSeoApiError for client errors (40xxx)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 40101, status_message: 'Auth failed' })).toThrow(
+			DataForSeoApiError,
+		);
+	});
+
+	it('throws DataForSeoApiError for quota body codes (40402, 40501)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 40402, status_message: 'No balance' })).toThrow(
+			DataForSeoApiError,
+		);
+		expect(() =>
+			ensureTaskOk('/v3/test', { status_code: 40501, status_message: 'Monthly limit reached' }),
+		).toThrow(DataForSeoApiError);
+	});
+
+	it('throws DataForSeoApiError for server errors (50xxx)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 50000, status_message: 'Internal error' })).toThrow(
+			DataForSeoApiError,
+		);
+	});
+
+	it('throws at the boundary 30000 (no informational range above 29999)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 30000, status_message: 'Unknown' })).toThrow(
+			DataForSeoApiError,
+		);
+	});
+
+	it('preserves status code and message on the thrown error', () => {
+		try {
+			ensureTaskOk('/v3/serp', { status_code: 40402, status_message: 'No balance' });
+			expect.fail('should have thrown');
+		} catch (err) {
+			expect(err).toBeInstanceOf(DataForSeoApiError);
+			expect((err as DataForSeoApiError).status).toBe(40402);
+			expect((err as Error).message).toContain('40402');
+			expect((err as Error).message).toContain('No balance');
+			expect((err as Error).message).toContain('/v3/serp');
+		}
+	});
+});

--- a/packages/providers/dataforseo/src/http.ts
+++ b/packages/providers/dataforseo/src/http.ts
@@ -8,6 +8,15 @@ export interface DataForSeoHttpOptions {
 const DEFAULT_BASE_URL = 'https://api.dataforseo.com';
 
 /**
+ * Hard cap on response body size. DataForSEO SERPs cap around 1MB; the
+ * GSC search-analytics endpoint with rowLimit=25000 sits around 5-8MB.
+ * 32MB leaves a generous margin for legitimate payloads while killing
+ * runaway responses that would OOM the worker before the JSON parser
+ * even returns.
+ */
+const MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+/**
  * Thin POST wrapper around `fetch`. DataForSEO endpoints all accept JSON arrays
  * of task objects; we shape the request that way. Returns the parsed JSON
  * response; raising on non-2xx so the caller can persist the error and let
@@ -41,6 +50,13 @@ export class DataForSeoHttp {
 			signal,
 		});
 		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new DataForSeoApiError(
+				response.status,
+				null,
+				`DataForSEO ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
 		const parsed = text.length > 0 ? safeParse(text) : null;
 		if (!response.ok) {
 			throw new DataForSeoApiError(
@@ -63,6 +79,27 @@ export class DataForSeoApiError extends Error {
 		this.name = 'DataForSeoApiError';
 	}
 }
+
+/**
+ * DataForSEO returns HTTP 200 even when the task itself failed — the
+ * real status lives in the body's `status_code`. Codes:
+ *   - 20000          : task ok
+ *   - 20100-20999    : informational (still success, no items)
+ *   - 40000-49999    : client/auth/quota error
+ *   - 50000-59999    : provider-side error
+ *
+ * Without this check the processor persists an empty payload as a
+ * successful run AND charges the operator's ledger. Failure budget +
+ * silent data loss.
+ */
+export const ensureTaskOk = (path: string, raw: { status_code: number; status_message: string }): void => {
+	if (raw.status_code === 20000 || (raw.status_code >= 20100 && raw.status_code < 30000)) return;
+	throw new DataForSeoApiError(
+		raw.status_code,
+		raw,
+		`DataForSEO ${path} task error ${raw.status_code}: ${raw.status_message}`,
+	);
+};
 
 const safeParse = (text: string): unknown => {
 	try {

--- a/packages/providers/dataforseo/src/http.ts
+++ b/packages/providers/dataforseo/src/http.ts
@@ -49,6 +49,19 @@ export class DataForSeoHttp {
 			body: JSON.stringify(body),
 			signal,
 		});
+		// Pre-flight: reject before buffering if the upstream advertises a
+		// payload over the cap. `text()` would still buffer the whole
+		// thing into RAM otherwise. Some upstreams omit Content-Length on
+		// chunked responses, in which case we fall back to the post-read
+		// guard below — best effort, but covers the common DDOS shape.
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new DataForSeoApiError(
+				response.status,
+				null,
+				`DataForSEO ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
 		const text = await response.text();
 		if (text.length > MAX_RESPONSE_BYTES) {
 			throw new DataForSeoApiError(


### PR DESCRIPTION
## Summary

Cierra la deuda técnica del job `docker-build` y aplica los hallazgos de la review independiente sobre el squash de PR #15.

### Dockerfiles (#16 follow-through)
- `docker/api.Dockerfile`, `docker/worker.Dockerfile`, `docker/web.Dockerfile` — multi-stage, alpine, no @swc-node/register en runtime.
- pnpm con isolated linker (default) — el shim de cada paquete resuelve `tsc` correctamente.
- `CI=true` antes de `pnpm prune --prod` evita el TTY abort.
- CI: re-habilitado el job `docker-build` (drop del `if: hashFiles(...)`).

### Review fixes
| # | Sev | Fix |
|---|---|---|
| 1 | Crítico | `RecordTop10HitsForSuggestionsUseCase.execute` ya no aborta el batch entero si una keyword falla — try/catch + logger inyectable |
| 3 | Crítico | Lost-update en `PromoteCompetitorSuggestionUseCase` — repo Drizzle split entre PENDING (upsert idempotente) y terminal (UPDATE WHERE status='PENDING' → ConflictError si rowCount=0) |
| 5 | Alto | Onboarding wizard ahora detecta proyectos existentes en `meQuery` y redirige a /projects en lugar de re-mostrar el step inicial tras un refresh accidental |
| 6 | Medio | `costFor()` malformado ya no se traga silenciosamente: throw → processor logea warn + bill worst-case |

## Test plan

- [x] `pnpm -r typecheck` (14/14 done)
- [x] `pnpm -r test` (37 archivos, 184 tests)
- [x] `pnpm lint` (0 errors, 0 warnings)
- [x] `docker buildx build` para api, worker, web — las 3 imágenes construyen y `node --version` funciona dentro del runtime
- [ ] Verificar en staging: `pm2 reload` con dist/ vs el flag swc-node/register, comparar startup time
- [ ] Verificar en staging: dos clicks rápidos de "Promote" → ahora 1 success + 1 ConflictError 409 (antes 1 success + 1 500)