### PR TITLE
Wikipedia Pageviews provider + entity-awareness context (closes #33)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from './common/auth/jwt-auth.guard.js';
 import { DomainExceptionFilter } from './common/domain-exception.filter.js';
 import { Tokens } from './composition/tokens.js';
 import type { AppEnv } from './config/env.js';
+import { EntityAwarenessModule } from './modules/entity-awareness/entity-awareness.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { IdentityAccessModule } from './modules/identity-access/identity-access.module.js';
 import { ProjectManagementModule } from './modules/project-management/project-management.module.js';
@@ -42,6 +43,7 @@ export class AppModule {
 			ProviderConnectivityModule,
 			RankTrackingModule,
 			SearchConsoleInsightsModule,
+			EntityAwarenessModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -1,5 +1,6 @@
 import type { Provider, ValueProvider } from '@nestjs/common';
 import {
+	EntityAwareness as EAUseCases,
 	IdentityAccess as IAUseCases,
 	ProviderConnectivity as PCUseCases,
 	ProjectManagement as PMUseCases,
@@ -58,6 +59,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const observationRepo = new DrizzlePersistence.DrizzleRankingObservationRepository(drizzle.db);
 	const gscPropertyRepo = new DrizzlePersistence.DrizzleGscPropertyRepository(drizzle.db);
 	const gscObservationRepo = new DrizzlePersistence.DrizzleGscPerformanceObservationRepository(drizzle.db);
+	const wikipediaArticleRepo = new DrizzlePersistence.DrizzleWikipediaArticleRepository(drizzle.db);
+	const wikipediaPageviewRepo = new DrizzlePersistence.DrizzleWikipediaPageviewObservationRepository(
+		drizzle.db,
+	);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -229,6 +234,23 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	);
 	const queryGscPerformance = new SCIUseCases.QueryGscPerformanceUseCase(gscPropertyRepo, gscObservationRepo);
 
+	// Issue #33 — entity-awareness use cases
+	const linkWikipediaArticle = new EAUseCases.LinkWikipediaArticleUseCase(
+		wikipediaArticleRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const unlinkWikipediaArticle = new EAUseCases.UnlinkWikipediaArticleUseCase(
+		wikipediaArticleRepo,
+		SystemClock,
+		eventPublisher,
+	);
+	const queryWikipediaPageviews = new EAUseCases.QueryWikipediaPageviewsUseCase(
+		wikipediaArticleRepo,
+		wikipediaPageviewRepo,
+	);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -316,6 +338,12 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.LinkGscProperty, linkGscProperty),
 		value(Tokens.IngestGscRows, ingestGscRows),
 		value(Tokens.QueryGscPerformance, queryGscPerformance),
+
+		value(Tokens.WikipediaArticleRepository, wikipediaArticleRepo),
+		value(Tokens.WikipediaPageviewObservationRepository, wikipediaPageviewRepo),
+		value(Tokens.LinkWikipediaArticle, linkWikipediaArticle),
+		value(Tokens.UnlinkWikipediaArticle, unlinkWikipediaArticle),
+		value(Tokens.QueryWikipediaPageviews, queryWikipediaPageviews),
 	];
 
 	return {

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -86,6 +86,15 @@ export const Tokens = {
 	IngestGscRows: Symbol('IngestGscRowsUseCase'),
 	QueryGscPerformance: Symbol('QueryGscPerformanceUseCase'),
 
+	// Entity-Awareness ports
+	WikipediaArticleRepository: Symbol('WikipediaArticleRepository'),
+	WikipediaPageviewObservationRepository: Symbol('WikipediaPageviewObservationRepository'),
+
+	// Entity-Awareness use cases
+	LinkWikipediaArticle: Symbol('LinkWikipediaArticleUseCase'),
+	UnlinkWikipediaArticle: Symbol('UnlinkWikipediaArticleUseCase'),
+	QueryWikipediaPageviews: Symbol('QueryWikipediaPageviewsUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/entity-awareness/entity-awareness.module.ts
+++ b/apps/api/src/modules/entity-awareness/entity-awareness.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { WikipediaController } from './wikipedia.controller.js';
+
+@Module({
+	controllers: [WikipediaController],
+})
+export class EntityAwarenessModule {}

--- a/apps/api/src/modules/entity-awareness/wikipedia.controller.ts
+++ b/apps/api/src/modules/entity-awareness/wikipedia.controller.ts
@@ -1,0 +1,133 @@
+import { Body, Controller, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { EntityAwareness as EAUseCases } from '@rankpulse/application';
+import { EntityAwarenessContracts } from '@rankpulse/contracts';
+import type { EntityAwareness, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+/**
+ * Issue #33 — entity-awareness via Wikipedia pageviews.
+ *
+ * Routes nested under /projects/:id for the link/list flows (resource
+ * lives within a project), and flat /wikipedia/articles/:id/* for
+ * actions on an existing article. Org membership is enforced via the
+ * project the article belongs to; the unlink/pageviews paths re-load
+ * the article and walk to its project for the membership check.
+ */
+@Controller()
+export class WikipediaController {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.LinkWikipediaArticle)
+		private readonly linkArticle: EAUseCases.LinkWikipediaArticleUseCase,
+		@Inject(Tokens.UnlinkWikipediaArticle)
+		private readonly unlinkArticle: EAUseCases.UnlinkWikipediaArticleUseCase,
+		@Inject(Tokens.QueryWikipediaPageviews)
+		private readonly queryPageviews: EAUseCases.QueryWikipediaPageviewsUseCase,
+		@Inject(Tokens.WikipediaArticleRepository)
+		private readonly articles: EntityAwareness.WikipediaArticleRepository,
+		@Inject(Tokens.ProjectRepository)
+		private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/wikipedia/articles')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<EntityAwarenessContracts.WikipediaArticleDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.articles.listForProject(project.id);
+		return list.map((a) => this.serialize(a));
+	}
+
+	@Post('projects/:projectId/wikipedia/articles')
+	async link(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(EntityAwarenessContracts.LinkWikipediaArticleRequest))
+		body: EntityAwarenessContracts.LinkWikipediaArticleRequest,
+	): Promise<{ articleId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.linkArticle.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			wikipediaProject: body.wikipediaProject,
+			slug: body.slug,
+			label: body.label,
+		});
+	}
+
+	@Post('wikipedia/articles/:articleId/unlink')
+	async unlink(
+		@Principal() principal: AuthPrincipal,
+		@Param('articleId') articleId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToArticle(principal, articleId);
+		await this.unlinkArticle.execute(articleId);
+		return { ok: true };
+	}
+
+	@Get('wikipedia/articles/:articleId/pageviews')
+	async pageviews(
+		@Principal() principal: AuthPrincipal,
+		@Param('articleId') articleId: string,
+		@Query(new ZodValidationPipe(EntityAwarenessContracts.WikipediaPageviewQuery))
+		q: EntityAwarenessContracts.WikipediaPageviewQuery,
+	): Promise<EntityAwarenessContracts.WikipediaPageviewDto[]> {
+		await this.requireAccessToArticle(principal, articleId);
+		const to = q.to ? new Date(q.to) : new Date();
+		const from = q.from ? new Date(q.from) : new Date(to.getTime() - 90 * 24 * 60 * 60 * 1000);
+		const result = await this.queryPageviews.execute({ articleId, from, to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	/**
+	 * Mirrors the IDOR-safe pattern used in projects.controller — a
+	 * caller from a different tenant gets the SAME 404 whether the
+	 * article doesn't exist or exists in another org. Membership errors
+	 * are re-mapped to NotFoundError so timing / status oracles can't
+	 * enumerate IDs.
+	 */
+	private async requireAccessToArticle(principal: AuthPrincipal, articleId: string): Promise<void> {
+		const article = await this.articles.findById(articleId as EntityAwareness.WikipediaArticleId);
+		if (!article) throw new NotFoundError(`Wikipedia article ${articleId} not found`);
+		const project = await this.projects.findById(article.projectId);
+		if (!project) throw new NotFoundError(`Wikipedia article ${articleId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`Wikipedia article ${articleId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(a: EntityAwareness.WikipediaArticle): EntityAwarenessContracts.WikipediaArticleDto {
+		return {
+			id: a.id,
+			projectId: a.projectId,
+			wikipediaProject: a.wikipediaProject.value,
+			slug: a.slug.value,
+			label: a.label,
+			linkedAt: a.linkedAt.toISOString(),
+			unlinkedAt: a.unlinkedAt ? a.unlinkedAt.toISOString() : null,
+		};
+	}
+}

--- a/apps/web/src/components/link-wikipedia-drawer.tsx
+++ b/apps/web/src/components/link-wikipedia-drawer.tsx
@@ -1,0 +1,140 @@
+import { Button, Drawer, FormField, Input, Select } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface LinkWikipediaDrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #33 — atomic-design organism. Mobile-first drawer with three
+ * inputs (Wikipedia language project + URL slug + optional label).
+ * The Wikipedia project picker is a `<Select>` (atom) populated with
+ * the languages we currently auto-handle; future work can swap it for
+ * a free-form input or a fuller catalogue.
+ */
+
+const WIKIPEDIA_PROJECTS: ReadonlyArray<{ value: string; label: string }> = [
+	{ value: 'en.wikipedia.org', label: 'English (en.wikipedia.org)' },
+	{ value: 'es.wikipedia.org', label: 'Spanish (es.wikipedia.org)' },
+	{ value: 'fr.wikipedia.org', label: 'French (fr.wikipedia.org)' },
+	{ value: 'de.wikipedia.org', label: 'German (de.wikipedia.org)' },
+	{ value: 'it.wikipedia.org', label: 'Italian (it.wikipedia.org)' },
+	{ value: 'pt.wikipedia.org', label: 'Portuguese (pt.wikipedia.org)' },
+];
+
+export const LinkWikipediaDrawer = ({ projectId, open, onClose }: LinkWikipediaDrawerProps) => {
+	const qc = useQueryClient();
+	const [wikipediaProject, setWikipediaProject] = useState('en.wikipedia.org');
+	const [slug, setSlug] = useState('');
+	const [label, setLabel] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setSlug('');
+		setLabel('');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			api.wikipedia.link(projectId, {
+				wikipediaProject,
+				slug,
+				label: label || undefined,
+			}),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'wikipedia'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to link article'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	// Strip the host part if the operator pasted a full URL —
+	// `https://en.wikipedia.org/wiki/Eiffel_Tower` → `Eiffel_Tower`.
+	const normaliseSlug = (raw: string): string => {
+		const m = raw.match(/\/wiki\/([^?#]+)/);
+		const slugPart = m?.[1] ?? raw;
+		try {
+			return decodeURIComponent(slugPart);
+		} catch {
+			return slugPart;
+		}
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Link Wikipedia article"
+			description="Track this article's daily pageviews as an entity-awareness signal."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="link-wikipedia-form" disabled={mutation.isPending || !slug}>
+						{mutation.isPending ? 'Linking…' : 'Link article'}
+					</Button>
+				</>
+			}
+		>
+			<form id="link-wikipedia-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField label="Wikipedia language" hint="The Wikipedia project where the article lives.">
+					{(id) => (
+						<Select id={id} value={wikipediaProject} onChange={(e) => setWikipediaProject(e.target.value)}>
+							{WIKIPEDIA_PROJECTS.map((p) => (
+								<option key={p.value} value={p.value}>
+									{p.label}
+								</option>
+							))}
+						</Select>
+					)}
+				</FormField>
+				<FormField
+					label="Article slug or URL"
+					hint="Paste the Wikipedia URL or the slug (e.g. Eiffel_Tower)."
+				>
+					{(id) => (
+						<Input
+							id={id}
+							value={slug}
+							onChange={(e) => setSlug(normaliseSlug(e.target.value.trim()))}
+							placeholder="Eiffel_Tower"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<FormField label="Label (optional)" hint="Defaults to the slug if omitted.">
+					{(id) => (
+						<Input
+							id={id}
+							value={label}
+							onChange={(e) => setLabel(e.target.value)}
+							placeholder="Our brand on Wikipedia"
+						/>
+					)}
+				</FormField>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -1,20 +1,21 @@
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle, EmptyState, Spinner } from '@rankpulse/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
-import { CalendarClock, Check, LineChart, MapPin, Plus, Search, Sparkles, X } from 'lucide-react';
+import { BookOpen, CalendarClock, Check, LineChart, MapPin, Plus, Search, Sparkles, X } from 'lucide-react';
 import { useState } from 'react';
 import { AddCompetitorDrawer } from '../components/add-competitor-drawer.js';
 import { AddDomainDrawer } from '../components/add-domain-drawer.js';
 import { AddLocationDrawer } from '../components/add-location-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
+import { LinkWikipediaDrawer } from '../components/link-wikipedia-drawer.js';
 import { api } from '../lib/api.js';
 
 export const ProjectDetailPage = () => {
 	const { id } = useParams({ from: '/projects/$id' });
-	const [openDrawer, setOpenDrawer] = useState<'competitor' | 'keywords' | 'domain' | 'location' | null>(
-		null,
-	);
+	const [openDrawer, setOpenDrawer] = useState<
+		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | null
+	>(null);
 
 	const projectQuery = useQuery({
 		queryKey: ['project', id],
@@ -36,6 +37,12 @@ export const ProjectDetailPage = () => {
 	const suggestionsQuery = useQuery({
 		queryKey: ['project', id, 'competitor-suggestions'],
 		queryFn: () => api.projects.listCompetitorSuggestions(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const wikipediaQuery = useQuery({
+		queryKey: ['project', id, 'wikipedia'],
+		queryFn: () => api.wikipedia.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -255,6 +262,46 @@ export const ProjectDetailPage = () => {
 
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
+								<BookOpen size={14} className="text-primary" />
+								Wikipedia entities ({wikipediaQuery.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('wikipedia')}>
+								<Plus size={14} />
+								Link
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{wikipediaQuery.isLoading ? (
+								<Spinner />
+							) : wikipediaQuery.data && wikipediaQuery.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{wikipediaQuery.data.map((a) => (
+										<li key={a.id} className="break-words">
+											<span className="font-medium">{a.label}</span>{' '}
+											<span className="text-muted-foreground">
+												· {a.slug} on {a.wikipediaProject}
+											</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No Wikipedia entities tracked"
+									description="Link an article (yours, a competitor's, or an industry topic) to monitor pageviews as a brand-awareness signal."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('wikipedia')}>
+											<Plus size={14} />
+											Link article
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="text-base">
 								Keyword lists ({keywordsQuery.data?.reduce((acc, l) => acc + l.keywords.length, 0) ?? '…'})
 							</CardTitle>
@@ -306,6 +353,11 @@ export const ProjectDetailPage = () => {
 			<AddLocationDrawer
 				projectId={id}
 				open={openDrawer === 'location'}
+				onClose={() => setOpenDrawer(null)}
+			/>
+			<LinkWikipediaDrawer
+				projectId={id}
+				open={openDrawer === 'wikipedia'}
 				onClose={() => setOpenDrawer(null)}
 			/>
 		</AppShell>

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
+		"@rankpulse/provider-wikipedia": "workspace:*",
 		"@rankpulse/shared": "workspace:*",
 		"bullmq": "5.76.5",
 		"ioredis": "5.10.1",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,4 +1,5 @@
 import {
+	EntityAwareness as EntityAwarenessUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
@@ -30,6 +31,10 @@ async function bootstrap(): Promise<void> {
 	const competitorSuggestionRepo = new DrizzlePersistence.DrizzleCompetitorSuggestionRepository(drizzle.db);
 	const gscPropertyRepo = new DrizzlePersistence.DrizzleGscPropertyRepository(drizzle.db);
 	const gscObservationRepo = new DrizzlePersistence.DrizzleGscPerformanceObservationRepository(drizzle.db);
+	const wikipediaArticleRepo = new DrizzlePersistence.DrizzleWikipediaArticleRepository(drizzle.db);
+	const wikipediaPageviewRepo = new DrizzlePersistence.DrizzleWikipediaPageviewObservationRepository(
+		drizzle.db,
+	);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -68,6 +73,12 @@ async function bootstrap(): Promise<void> {
 			SystemIdGenerator,
 			{ warn: (meta, msg) => logger.warn(meta, msg) },
 		);
+	const ingestWikipediaPageviewsUseCase = new EntityAwarenessUseCases.IngestWikipediaPageviewsUseCase(
+		wikipediaArticleRepo,
+		wikipediaPageviewRepo,
+		eventPublisher,
+		SystemClock,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -79,12 +90,14 @@ async function bootstrap(): Promise<void> {
 		trackedKeywordRepo,
 		competitorRepo,
 		gscPropertyRepo,
+		wikipediaArticleRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
 		recordRankingObservationUseCase,
 		recordTop10HitsForSuggestionsUseCase,
 		ingestGscRowsUseCase,
+		ingestWikipediaPageviewsUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -1,10 +1,12 @@
 import type {
+	EntityAwareness as EntityAwarenessUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
 	SearchConsoleInsights as SearchConsoleInsightsUseCases,
 } from '@rankpulse/application';
 import {
+	type EntityAwareness as EntityAwarenessDomain,
 	type ProjectManagement,
 	ProviderConnectivity,
 	type RankTracking as RankTrackingDomain,
@@ -23,6 +25,11 @@ import {
 	type SearchAnalyticsParams,
 	type SearchAnalyticsResponse,
 } from '@rankpulse/provider-gsc';
+import {
+	extractPageviews,
+	type PageviewsPerArticleResponse,
+	WikipediaApiError,
+} from '@rankpulse/provider-wikipedia';
 import { type Clock, type IdGenerator, NotFoundError, resolveDateTokens } from '@rankpulse/shared';
 import type { Logger } from 'pino';
 import { extractMultiDomainRankings, isMultiDomainSerpJob } from './extract-multi-domain-rankings.js';
@@ -50,6 +57,8 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 		if (err.status >= 40500 && err.status < 41000) return true;
 	}
 	if (err instanceof GscApiError && err.status === 402) return true;
+	// Wikipedia is a public API, no quota; included for symmetry.
+	if (err instanceof WikipediaApiError && err.status === 402) return true;
 	return false;
 };
 
@@ -69,12 +78,14 @@ export interface ProviderFetchProcessorDeps {
 	trackedKeywordRepo: RankTrackingDomain.TrackedKeywordRepository;
 	competitorRepo: ProjectManagement.CompetitorRepository;
 	gscPropertyRepo: SearchConsoleInsightsDomain.GscPropertyRepository;
+	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
 	recordRankingObservationUseCase: RankTrackingUseCases.RecordRankingObservationUseCase;
 	recordTop10HitsForSuggestionsUseCase: ProjectManagementUseCases.RecordTop10HitsForSuggestionsUseCase;
 	ingestGscRowsUseCase: SearchConsoleInsightsUseCases.IngestGscRowsUseCase;
+	ingestWikipediaPageviewsUseCase: EntityAwarenessUseCases.IngestWikipediaPageviewsUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -278,6 +289,35 @@ export class ProviderFetchProcessor {
 							externalDomainsInTop10: external,
 						});
 					}
+				}
+			}
+
+			if (
+				definition.providerId.value === 'wikipedia' &&
+				definition.endpointId.value === 'wikipedia-pageviews-per-article'
+			) {
+				// Issue #33 — entity-awareness ingest. The job's
+				// systemParams must carry `wikipediaArticleId` (set by
+				// LinkWikipediaArticleUseCase via auto-schedule on link;
+				// for now the schedule API caller is responsible for it).
+				const wpParams = resolvedParams as { wikipediaArticleId?: string };
+				if (!wpParams.wikipediaArticleId) {
+					runLog.warn(
+						{},
+						'wikipedia-pageviews job missing wikipediaArticleId in systemParams; skipping ingest',
+					);
+				} else {
+					const observations = extractPageviews(fetchResult as PageviewsPerArticleResponse);
+					await this.deps.ingestWikipediaPageviewsUseCase.execute({
+						articleId: wpParams.wikipediaArticleId,
+						rows: observations.map((o) => ({
+							observedAt: o.observedAt,
+							views: o.views,
+							access: o.access,
+							agent: o.agent,
+							granularity: o.granularity,
+						})),
+					});
 				}
 			}
 

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { GscProvider } from '@rankpulse/provider-gsc';
+import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
 
 /**
  * Composition root for provider plug-ins active in this deployment. Adding a
@@ -10,5 +11,6 @@ export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): P
 	const registry = new ProviderRegistry();
 	registry.register(new DataForSeoProvider({ baseUrl: options.dataforseoBaseUrl }));
 	registry.register(new GscProvider());
+	registry.register(new WikipediaProvider());
 	return registry;
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -11,6 +11,11 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
 		},
+		"./entity-awareness": {
+			"development": "./src/entity-awareness/index.ts",
+			"types": "./dist/entity-awareness/index.d.ts",
+			"default": "./dist/entity-awareness/index.js"
+		},
 		"./identity-access": {
 			"development": "./src/identity-access/index.ts",
 			"types": "./dist/identity-access/index.d.ts",

--- a/packages/application/src/entity-awareness/index.ts
+++ b/packages/application/src/entity-awareness/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/ingest-wikipedia-pageviews.use-case.js';
+export * from './use-cases/link-wikipedia-article.use-case.js';
+export * from './use-cases/query-wikipedia-pageviews.use-case.js';
+export * from './use-cases/unlink-wikipedia-article.use-case.js';

--- a/packages/application/src/entity-awareness/use-cases/ingest-wikipedia-pageviews.use-case.ts
+++ b/packages/application/src/entity-awareness/use-cases/ingest-wikipedia-pageviews.use-case.ts
@@ -1,0 +1,75 @@
+import { EntityAwareness, type SharedKernel } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface WikipediaPageviewRowInput {
+	observedAt: Date;
+	views: number;
+	access: string;
+	agent: string;
+	granularity: string;
+}
+
+export interface IngestWikipediaPageviewsCommand {
+	articleId: string;
+	rows: readonly WikipediaPageviewRowInput[];
+}
+
+export interface IngestWikipediaPageviewsResult {
+	ingested: number;
+}
+
+/**
+ * Persists a batch of pageview rows for a previously-linked Wikipedia
+ * article. No-op if the article was unlinked between scheduling and
+ * fetch (the operator decided to stop tracking). One summary event
+ * per batch, mirroring GscPerformanceBatchIngested.
+ */
+export class IngestWikipediaPageviewsUseCase {
+	constructor(
+		private readonly articles: EntityAwareness.WikipediaArticleRepository,
+		private readonly observations: EntityAwareness.WikipediaPageviewObservationRepository,
+		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: IngestWikipediaPageviewsCommand): Promise<IngestWikipediaPageviewsResult> {
+		if (cmd.rows.length === 0) {
+			return { ingested: 0 };
+		}
+		const article = await this.articles.findById(cmd.articleId as EntityAwareness.WikipediaArticleId);
+		if (!article) {
+			throw new NotFoundError(`Wikipedia article ${cmd.articleId} not found`);
+		}
+		if (!article.isActive()) {
+			return { ingested: 0 };
+		}
+
+		let totalViews = 0;
+		const observations = cmd.rows.map((row) => {
+			totalViews += row.views;
+			return EntityAwareness.WikipediaPageviewObservation.record({
+				articleId: article.id,
+				projectId: article.projectId,
+				observedAt: row.observedAt,
+				views: row.views,
+				access: row.access,
+				agent: row.agent,
+				granularity: row.granularity,
+			});
+		});
+
+		const { inserted } = await this.observations.saveAll(observations);
+
+		await this.events.publish([
+			new EntityAwareness.WikipediaPageviewsBatchIngested({
+				articleId: article.id,
+				projectId: article.projectId,
+				rowsCount: inserted,
+				totalViews,
+				occurredAt: this.clock.now(),
+			}),
+		]);
+
+		return { ingested: inserted };
+	}
+}

--- a/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.spec.ts
+++ b/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.spec.ts
@@ -1,0 +1,147 @@
+import type { EntityAwareness, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ConflictError, FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { describe, expect, it } from 'vitest';
+import { LinkWikipediaArticleUseCase } from './link-wikipedia-article.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryArticleRepo implements EntityAwareness.WikipediaArticleRepository {
+	readonly store = new Map<string, EntityAwareness.WikipediaArticle>();
+	async save(a: EntityAwareness.WikipediaArticle): Promise<void> {
+		this.store.set(a.id, a);
+	}
+	async findById(id: EntityAwareness.WikipediaArticleId) {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndSlug(
+		projectId: ProjectManagement.ProjectId,
+		wpProject: EntityAwareness.WikipediaProject,
+		slug: EntityAwareness.ArticleSlug,
+	) {
+		for (const a of this.store.values()) {
+			if (
+				a.projectId === projectId &&
+				a.wikipediaProject.value === wpProject.value &&
+				a.slug.value === slug.value
+			)
+				return a;
+		}
+		return null;
+	}
+	async listForProject(projectId: ProjectManagement.ProjectId) {
+		return [...this.store.values()].filter((a) => a.projectId === projectId);
+	}
+	async listForOrganization(orgId: IdentityAccess.OrganizationId) {
+		return [...this.store.values()].filter((a) => a.organizationId === orgId);
+	}
+}
+
+const buildClock = () => new FakeClock('2026-05-04T10:00:00Z');
+const buildIds = (...uuids: string[]) => new FixedIdGenerator(uuids as Uuid[]);
+
+describe('LinkWikipediaArticleUseCase', () => {
+	it('persists a fresh article and publishes WikipediaArticleLinked', async () => {
+		const repo = new InMemoryArticleRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new LinkWikipediaArticleUseCase(repo, buildClock(), buildIds('art-1' as never), events);
+
+		const result = await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			wikipediaProject: 'es.wikipedia.org',
+			slug: 'Torre_Eiffel',
+		});
+
+		expect(result.articleId).toBe('art-1');
+		expect(repo.store.size).toBe(1);
+		const stored = [...repo.store.values()][0];
+		expect(stored?.label).toBe('Torre_Eiffel'); // defaults to slug when label omitted
+		expect(stored?.isActive()).toBe(true);
+		expect(events.publishedTypes()).toContain('WikipediaArticleLinked');
+	});
+
+	it('throws ConflictError when an active link already exists for the same (project, wp-project, slug)', async () => {
+		const repo = new InMemoryArticleRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new LinkWikipediaArticleUseCase(
+			repo,
+			buildClock(),
+			buildIds('art-1' as never, 'art-2' as never),
+			events,
+		);
+		await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			wikipediaProject: 'es.wikipedia.org',
+			slug: 'Torre_Eiffel',
+		});
+		await expect(
+			useCase.execute({
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				wikipediaProject: 'es.wikipedia.org',
+				slug: 'Torre_Eiffel',
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('allows re-linking after the previous link was unlinked (creates a NEW aggregate)', async () => {
+		const repo = new InMemoryArticleRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new LinkWikipediaArticleUseCase(
+			repo,
+			buildClock(),
+			buildIds('art-1' as never, 'art-2' as never),
+			events,
+		);
+		const first = await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			wikipediaProject: 'es.wikipedia.org',
+			slug: 'Torre_Eiffel',
+		});
+		const article = repo.store.get(first.articleId);
+		article?.unlink(new Date('2026-05-05T10:00:00Z'));
+		await repo.save(article as EntityAwareness.WikipediaArticle);
+
+		const second = await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			wikipediaProject: 'es.wikipedia.org',
+			slug: 'Torre_Eiffel',
+		});
+		expect(second.articleId).toBe('art-2');
+		expect(second.articleId).not.toBe(first.articleId);
+	});
+
+	it('rejects malformed wikipediaProject before touching the repo', async () => {
+		const repo = new InMemoryArticleRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new LinkWikipediaArticleUseCase(repo, buildClock(), buildIds('art-1' as never), events);
+		await expect(
+			useCase.execute({
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				wikipediaProject: 'wikipedia.org',
+				slug: 'Torre_Eiffel',
+			}),
+		).rejects.toThrow();
+		expect(repo.store.size).toBe(0);
+	});
+
+	it('rejects slug containing whitespace (operator must canonicalise)', async () => {
+		const repo = new InMemoryArticleRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new LinkWikipediaArticleUseCase(repo, buildClock(), buildIds('art-1' as never), events);
+		await expect(
+			useCase.execute({
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				wikipediaProject: 'es.wikipedia.org',
+				slug: 'Torre Eiffel',
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.ts
+++ b/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.ts
@@ -1,0 +1,63 @@
+import {
+	EntityAwareness,
+	type IdentityAccess,
+	type ProjectManagement,
+	type SharedKernel,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface LinkWikipediaArticleCommand {
+	organizationId: string;
+	projectId: string;
+	wikipediaProject: string;
+	slug: string;
+	label?: string;
+}
+
+export interface LinkWikipediaArticleResult {
+	articleId: string;
+}
+
+/**
+ * Operator action: track a Wikipedia article for a project. Idempotent
+ * on (project, wp-project, slug) — if the article was already linked
+ * AND is still active, returns 409. If it was previously linked and
+ * unlinked, this creates a NEW aggregate (fresh id) so the audit trail
+ * keeps both linkings as distinct events.
+ */
+export class LinkWikipediaArticleUseCase {
+	constructor(
+		private readonly articles: EntityAwareness.WikipediaArticleRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: LinkWikipediaArticleCommand): Promise<LinkWikipediaArticleResult> {
+		const wikipediaProject = EntityAwareness.WikipediaProject.create(cmd.wikipediaProject);
+		const slug = EntityAwareness.ArticleSlug.create(cmd.slug);
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+
+		const existing = await this.articles.findByProjectAndSlug(projectId, wikipediaProject, slug);
+		if (existing && existing.isActive()) {
+			throw new ConflictError(
+				`Wikipedia article "${slug.value}" on ${wikipediaProject.value} is already linked to this project`,
+			);
+		}
+
+		const articleId = this.ids.generate() as EntityAwareness.WikipediaArticleId;
+		const article = EntityAwareness.WikipediaArticle.link({
+			id: articleId,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			wikipediaProject,
+			slug,
+			label: cmd.label,
+			now: this.clock.now(),
+		});
+		await this.articles.save(article);
+		await this.events.publish(article.pullEvents());
+
+		return { articleId };
+	}
+}

--- a/packages/application/src/entity-awareness/use-cases/query-wikipedia-pageviews.use-case.ts
+++ b/packages/application/src/entity-awareness/use-cases/query-wikipedia-pageviews.use-case.ts
@@ -1,0 +1,41 @@
+import type { EntityAwareness } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface WikipediaPageviewView {
+	observedAt: string;
+	views: number;
+	access: string;
+	agent: string;
+	granularity: string;
+}
+
+export interface QueryWikipediaPageviewsQuery {
+	articleId: string;
+	from: Date;
+	to: Date;
+}
+
+/**
+ * Read-model query: pageviews of a linked article over a date range.
+ * Returns DTOs (ISO strings) so the controller can pass them straight
+ * to the response without leaking domain types.
+ */
+export class QueryWikipediaPageviewsUseCase {
+	constructor(
+		private readonly articles: EntityAwareness.WikipediaArticleRepository,
+		private readonly observations: EntityAwareness.WikipediaPageviewObservationRepository,
+	) {}
+
+	async execute(q: QueryWikipediaPageviewsQuery): Promise<readonly WikipediaPageviewView[]> {
+		const article = await this.articles.findById(q.articleId as EntityAwareness.WikipediaArticleId);
+		if (!article) throw new NotFoundError(`Wikipedia article ${q.articleId} not found`);
+		const observations = await this.observations.listForArticle(article.id, { from: q.from, to: q.to });
+		return observations.map((o) => ({
+			observedAt: o.observedAt.toISOString(),
+			views: o.views,
+			access: o.access,
+			agent: o.agent,
+			granularity: o.granularity,
+		}));
+	}
+}

--- a/packages/application/src/entity-awareness/use-cases/unlink-wikipedia-article.use-case.ts
+++ b/packages/application/src/entity-awareness/use-cases/unlink-wikipedia-article.use-case.ts
@@ -1,0 +1,18 @@
+import type { EntityAwareness, SharedKernel } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export class UnlinkWikipediaArticleUseCase {
+	constructor(
+		private readonly articles: EntityAwareness.WikipediaArticleRepository,
+		private readonly clock: Clock,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(articleId: string): Promise<void> {
+		const article = await this.articles.findById(articleId as EntityAwareness.WikipediaArticleId);
+		if (!article) throw new NotFoundError(`Wikipedia article ${articleId} not found`);
+		article.unlink(this.clock.now());
+		await this.articles.save(article);
+		await this.events.publish(article.pullEvents());
+	}
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,3 +1,4 @@
+export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';

--- a/packages/contracts/src/entity-awareness/index.ts
+++ b/packages/contracts/src/entity-awareness/index.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const LinkWikipediaArticleRequest = z.object({
+	wikipediaProject: z
+		.string()
+		.regex(/^[a-z]{2,3}(?:-[a-z]+)?\.wikipedia\.org$/, 'project must be like "en.wikipedia.org"'),
+	slug: z.string().min(1).max(255),
+	label: z.string().min(1).max(120).optional(),
+});
+export type LinkWikipediaArticleRequest = z.infer<typeof LinkWikipediaArticleRequest>;
+
+export const WikipediaArticleDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	wikipediaProject: z.string(),
+	slug: z.string(),
+	label: z.string(),
+	linkedAt: z.string().datetime(),
+	unlinkedAt: z.string().datetime().nullable(),
+});
+export type WikipediaArticleDto = z.infer<typeof WikipediaArticleDto>;
+
+export const WikipediaPageviewQuery = z.object({
+	from: z.string().datetime().optional(),
+	to: z.string().datetime().optional(),
+});
+export type WikipediaPageviewQuery = z.infer<typeof WikipediaPageviewQuery>;
+
+export const WikipediaPageviewDto = z.object({
+	observedAt: z.string().datetime(),
+	views: z.number().int().nonnegative(),
+	access: z.string(),
+	agent: z.string(),
+	granularity: z.string(),
+});
+export type WikipediaPageviewDto = z.infer<typeof WikipediaPageviewDto>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * as EntityAwarenessContracts from './entity-awareness/index.js';
 export * as IdentityAccessContracts from './identity-access/index.js';
 export * as ProjectManagementContracts from './project-management/index.js';
 export * as ProviderConnectivityContracts from './provider-connectivity/index.js';

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -11,6 +11,11 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
 		},
+		"./entity-awareness": {
+			"development": "./src/entity-awareness/index.ts",
+			"types": "./dist/entity-awareness/index.d.ts",
+			"default": "./dist/entity-awareness/index.js"
+		},
 		"./identity-access": {
 			"development": "./src/identity-access/index.ts",
 			"types": "./dist/identity-access/index.d.ts",

--- a/packages/domain/src/entity-awareness/entities/wikipedia-article.ts
+++ b/packages/domain/src/entity-awareness/entities/wikipedia-article.ts
@@ -1,0 +1,119 @@
+import { ConflictError } from '@rankpulse/shared';
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { WikipediaArticleLinked } from '../events/wikipedia-article-linked.js';
+import { WikipediaArticleUnlinked } from '../events/wikipedia-article-unlinked.js';
+import type { ArticleSlug } from '../value-objects/article-slug.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+import type { WikipediaProject } from '../value-objects/wikipedia-project.js';
+
+export interface WikipediaArticleProps {
+	id: WikipediaArticleId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	wikipediaProject: WikipediaProject;
+	slug: ArticleSlug;
+	/** Free-form label for the UI (e.g. "Our brand on en.wp"). */
+	label: string;
+	linkedAt: Date;
+	unlinkedAt: Date | null;
+}
+
+/**
+ * Aggregate: a Wikipedia article that an operator has linked to a
+ * RankPulse project as a brand / competitor / entity awareness signal.
+ * The article itself is identified by `(wikipediaProject, slug)`; we
+ * also persist the org + project context so multi-tenant isolation
+ * is enforced at the read model.
+ *
+ * State machine:
+ *   linked (active) → unlinked (terminal-ish; can be re-linked which
+ *     produces a NEW aggregate with a fresh id, since the operator
+ *     deciding to re-track is a distinct event we want in the audit
+ *     trail).
+ */
+export class WikipediaArticle extends AggregateRoot {
+	private constructor(private props: WikipediaArticleProps) {
+		super();
+	}
+
+	static link(input: {
+		id: WikipediaArticleId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		wikipediaProject: WikipediaProject;
+		slug: ArticleSlug;
+		label?: string;
+		now: Date;
+	}): WikipediaArticle {
+		const article = new WikipediaArticle({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			wikipediaProject: input.wikipediaProject,
+			slug: input.slug,
+			label: (input.label ?? input.slug.value).trim() || input.slug.value,
+			linkedAt: input.now,
+			unlinkedAt: null,
+		});
+		article.record(
+			new WikipediaArticleLinked({
+				articleId: input.id,
+				organizationId: input.organizationId,
+				projectId: input.projectId,
+				wikipediaProject: input.wikipediaProject.value,
+				slug: input.slug.value,
+				occurredAt: input.now,
+			}),
+		);
+		return article;
+	}
+
+	static rehydrate(props: WikipediaArticleProps): WikipediaArticle {
+		return new WikipediaArticle(props);
+	}
+
+	unlink(now: Date): void {
+		if (this.props.unlinkedAt !== null) {
+			throw new ConflictError(`Wikipedia article ${this.props.id} is already unlinked`);
+		}
+		this.props = { ...this.props, unlinkedAt: now };
+		this.record(
+			new WikipediaArticleUnlinked({
+				articleId: this.props.id,
+				projectId: this.props.projectId,
+				occurredAt: now,
+			}),
+		);
+	}
+
+	isActive(): boolean {
+		return this.props.unlinkedAt === null;
+	}
+
+	get id(): WikipediaArticleId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get wikipediaProject(): WikipediaProject {
+		return this.props.wikipediaProject;
+	}
+	get slug(): ArticleSlug {
+		return this.props.slug;
+	}
+	get label(): string {
+		return this.props.label;
+	}
+	get linkedAt(): Date {
+		return this.props.linkedAt;
+	}
+	get unlinkedAt(): Date | null {
+		return this.props.unlinkedAt;
+	}
+}

--- a/packages/domain/src/entity-awareness/entities/wikipedia-pageview-observation.ts
+++ b/packages/domain/src/entity-awareness/entities/wikipedia-pageview-observation.ts
@@ -1,0 +1,56 @@
+import { InvalidInputError } from '@rankpulse/shared';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+
+export interface WikipediaPageviewObservationProps {
+	articleId: WikipediaArticleId;
+	projectId: ProjectId;
+	observedAt: Date;
+	views: number;
+	access: string;
+	agent: string;
+	granularity: string;
+}
+
+/**
+ * Immutable value-like row in the time-series store. No domain events
+ * (per-row events would fan out massively for batches); the
+ * IngestWikipediaPageviewsUseCase publishes a single batch summary
+ * event instead.
+ */
+export class WikipediaPageviewObservation {
+	private constructor(private readonly props: WikipediaPageviewObservationProps) {}
+
+	static record(input: WikipediaPageviewObservationProps): WikipediaPageviewObservation {
+		if (!Number.isFinite(input.views) || input.views < 0) {
+			throw new InvalidInputError('views must be a non-negative finite number');
+		}
+		return new WikipediaPageviewObservation({ ...input, views: Math.round(input.views) });
+	}
+
+	static rehydrate(props: WikipediaPageviewObservationProps): WikipediaPageviewObservation {
+		return new WikipediaPageviewObservation(props);
+	}
+
+	get articleId(): WikipediaArticleId {
+		return this.props.articleId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedAt(): Date {
+		return this.props.observedAt;
+	}
+	get views(): number {
+		return this.props.views;
+	}
+	get access(): string {
+		return this.props.access;
+	}
+	get agent(): string {
+		return this.props.agent;
+	}
+	get granularity(): string {
+		return this.props.granularity;
+	}
+}

--- a/packages/domain/src/entity-awareness/events/wikipedia-article-linked.ts
+++ b/packages/domain/src/entity-awareness/events/wikipedia-article-linked.ts
@@ -1,0 +1,30 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+
+export class WikipediaArticleLinked implements DomainEvent {
+	readonly type = 'WikipediaArticleLinked';
+	readonly articleId: WikipediaArticleId;
+	readonly organizationId: OrganizationId;
+	readonly projectId: ProjectId;
+	readonly wikipediaProject: string;
+	readonly slug: string;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		articleId: WikipediaArticleId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		wikipediaProject: string;
+		slug: string;
+		occurredAt: Date;
+	}) {
+		this.articleId = props.articleId;
+		this.organizationId = props.organizationId;
+		this.projectId = props.projectId;
+		this.wikipediaProject = props.wikipediaProject;
+		this.slug = props.slug;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/entity-awareness/events/wikipedia-article-unlinked.ts
+++ b/packages/domain/src/entity-awareness/events/wikipedia-article-unlinked.ts
@@ -1,0 +1,16 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+
+export class WikipediaArticleUnlinked implements DomainEvent {
+	readonly type = 'WikipediaArticleUnlinked';
+	readonly articleId: WikipediaArticleId;
+	readonly projectId: ProjectId;
+	readonly occurredAt: Date;
+
+	constructor(props: { articleId: WikipediaArticleId; projectId: ProjectId; occurredAt: Date }) {
+		this.articleId = props.articleId;
+		this.projectId = props.projectId;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/entity-awareness/events/wikipedia-pageviews-batch-ingested.ts
+++ b/packages/domain/src/entity-awareness/events/wikipedia-pageviews-batch-ingested.ts
@@ -1,0 +1,32 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+
+/**
+ * One event per ingest call (NOT per row), mirroring the
+ * GscPerformanceBatchIngested pattern. Subscribers aggregate downstream
+ * — emitting per-row events would fan-out N×ingestcalls events with no
+ * additional information.
+ */
+export class WikipediaPageviewsBatchIngested implements DomainEvent {
+	readonly type = 'WikipediaPageviewsBatchIngested';
+	readonly articleId: WikipediaArticleId;
+	readonly projectId: ProjectId;
+	readonly rowsCount: number;
+	readonly totalViews: number;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		articleId: WikipediaArticleId;
+		projectId: ProjectId;
+		rowsCount: number;
+		totalViews: number;
+		occurredAt: Date;
+	}) {
+		this.articleId = props.articleId;
+		this.projectId = props.projectId;
+		this.rowsCount = props.rowsCount;
+		this.totalViews = props.totalViews;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/entity-awareness/index.ts
+++ b/packages/domain/src/entity-awareness/index.ts
@@ -1,0 +1,14 @@
+// Entities
+export * from './entities/wikipedia-article.js';
+export * from './entities/wikipedia-pageview-observation.js';
+// Events
+export * from './events/wikipedia-article-linked.js';
+export * from './events/wikipedia-article-unlinked.js';
+export * from './events/wikipedia-pageviews-batch-ingested.js';
+// Ports
+export * from './ports/wikipedia-article-repository.js';
+export * from './ports/wikipedia-pageview-observation-repository.js';
+// Value objects
+export * from './value-objects/article-slug.js';
+export * from './value-objects/identifiers.js';
+export * from './value-objects/wikipedia-project.js';

--- a/packages/domain/src/entity-awareness/ports/wikipedia-article-repository.ts
+++ b/packages/domain/src/entity-awareness/ports/wikipedia-article-repository.ts
@@ -1,0 +1,19 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { WikipediaArticle } from '../entities/wikipedia-article.js';
+import type { ArticleSlug } from '../value-objects/article-slug.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+import type { WikipediaProject } from '../value-objects/wikipedia-project.js';
+
+export interface WikipediaArticleRepository {
+	save(article: WikipediaArticle): Promise<void>;
+	findById(id: WikipediaArticleId): Promise<WikipediaArticle | null>;
+	/** Used by the link use case to enforce idempotency on (project, wp-project, slug). */
+	findByProjectAndSlug(
+		projectId: ProjectId,
+		wikipediaProject: WikipediaProject,
+		slug: ArticleSlug,
+	): Promise<WikipediaArticle | null>;
+	listForProject(projectId: ProjectId): Promise<readonly WikipediaArticle[]>;
+	listForOrganization(orgId: OrganizationId): Promise<readonly WikipediaArticle[]>;
+}

--- a/packages/domain/src/entity-awareness/ports/wikipedia-pageview-observation-repository.ts
+++ b/packages/domain/src/entity-awareness/ports/wikipedia-pageview-observation-repository.ts
@@ -1,0 +1,22 @@
+import type { WikipediaPageviewObservation } from '../entities/wikipedia-pageview-observation.js';
+import type { WikipediaArticleId } from '../value-objects/identifiers.js';
+
+export interface WikipediaPageviewQuery {
+	from: Date;
+	to: Date;
+}
+
+export interface WikipediaPageviewObservationRepository {
+	/**
+	 * Bulk-insert observations. Implementations MUST be idempotent on
+	 * (articleId, observedAt) — re-running the same fetch should not
+	 * duplicate rows. Returns the count actually inserted (excludes
+	 * conflicts dropped by `onConflictDoNothing`) so callers can
+	 * publish accurate batch metrics.
+	 */
+	saveAll(observations: readonly WikipediaPageviewObservation[]): Promise<{ inserted: number }>;
+	listForArticle(
+		articleId: WikipediaArticleId,
+		query: WikipediaPageviewQuery,
+	): Promise<readonly WikipediaPageviewObservation[]>;
+}

--- a/packages/domain/src/entity-awareness/value-objects/article-slug.ts
+++ b/packages/domain/src/entity-awareness/value-objects/article-slug.ts
@@ -1,0 +1,28 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Wikipedia article slug — the URL form with underscores replacing
+ * spaces (`Eiffel_Tower`, not `Eiffel Tower`). Length cap mirrors
+ * Wikipedia's own ~255-char limit. We do NOT URL-encode here; that's a
+ * provider/HTTP concern — domain stores the canonical decoded slug so
+ * it round-trips through events and reads cleanly.
+ */
+export class ArticleSlug {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): ArticleSlug {
+		const trimmed = raw.trim();
+		if (trimmed.length === 0 || trimmed.length > 255) {
+			throw new InvalidInputError(`ArticleSlug must be 1-255 chars (got "${raw}")`);
+		}
+		// Reject slugs containing whitespace — Wikipedia slugs use
+		// underscores. A space here is a sign the caller passed the
+		// human title; force them to canonicalise.
+		if (/\s/.test(trimmed)) {
+			throw new InvalidInputError(
+				`ArticleSlug must not contain whitespace; replace spaces with underscores (got "${raw}")`,
+			);
+		}
+		return new ArticleSlug(trimmed);
+	}
+}

--- a/packages/domain/src/entity-awareness/value-objects/identifiers.ts
+++ b/packages/domain/src/entity-awareness/value-objects/identifiers.ts
@@ -1,0 +1,3 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type WikipediaArticleId = Uuid & { readonly __kind: 'WikipediaArticleId' };

--- a/packages/domain/src/entity-awareness/value-objects/wikipedia-project.ts
+++ b/packages/domain/src/entity-awareness/value-objects/wikipedia-project.ts
@@ -1,0 +1,20 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+const PROJECT_REGEX = /^[a-z]{2,3}(?:-[a-z]+)?\.wikipedia\.org$/;
+
+/**
+ * `es.wikipedia.org`, `en.wikipedia.org`, `simple.wikipedia.org`, etc.
+ * Only Wikipedia variants are accepted — Wiktionary / Wikimedia Commons
+ * have different APIs and would land in their own provider eventually.
+ */
+export class WikipediaProject {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): WikipediaProject {
+		const normalized = raw.trim().toLowerCase();
+		if (!PROJECT_REGEX.test(normalized)) {
+			throw new InvalidInputError(`WikipediaProject must look like "<lang>.wikipedia.org" (got "${raw}")`);
+		}
+		return new WikipediaProject(normalized);
+	}
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,4 @@
+export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -1,4 +1,6 @@
 export * from './client.js';
+export { DrizzleWikipediaArticleRepository } from './repositories/entity-awareness/wikipedia-article.repository.js';
+export { DrizzleWikipediaPageviewObservationRepository } from './repositories/entity-awareness/wikipedia-pageview-observation.repository.js';
 export { DrizzleApiTokenRepository } from './repositories/identity-access/api-token.repository.js';
 export { DrizzleMembershipRepository } from './repositories/identity-access/membership.repository.js';
 export { DrizzleOrganizationRepository } from './repositories/identity-access/organization.repository.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0005_spooky_timeslip.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0005_spooky_timeslip.sql
@@ -1,0 +1,43 @@
+-- Issue #33 — Wikipedia entity-awareness tables. Idempotent (IF NOT EXISTS)
+-- so re-application after a partial restore doesn't error out.
+
+CREATE TABLE IF NOT EXISTS "wikipedia_articles" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"wikipedia_project" text NOT NULL,
+	"slug" text NOT NULL,
+	"label" text NOT NULL,
+	"linked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"unlinked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "wikipedia_pageviews" (
+	"article_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_at" timestamp with time zone NOT NULL,
+	"views" bigint NOT NULL,
+	"access" text NOT NULL,
+	"agent" text NOT NULL,
+	"granularity" text NOT NULL,
+	CONSTRAINT "wikipedia_pageviews_article_id_observed_at_pk" PRIMARY KEY("article_id","observed_at")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "wikipedia_articles" ADD CONSTRAINT "wikipedia_articles_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "wikipedia_articles" ADD CONSTRAINT "wikipedia_articles_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "wikipedia_pageviews" ADD CONSTRAINT "wikipedia_pageviews_article_id_wikipedia_articles_id_fk" FOREIGN KEY ("article_id") REFERENCES "public"."wikipedia_articles"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "wikipedia_articles_project_article_unique" ON "wikipedia_articles" USING btree ("project_id","wikipedia_project","slug");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "wikipedia_articles_project_idx" ON "wikipedia_articles" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "wikipedia_pageviews_project_idx" ON "wikipedia_pageviews" USING btree ("project_id","observed_at");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0005_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0005_snapshot.json
@@ -1,0 +1,2450 @@
+{
+	"id": "a8992533-50de-42c4-9ee3-d055c864108b",
+	"prevId": "dac38f36-6480-4338-88d8-018554be2b28",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1778000182660,
 			"tag": "0004_serious_magus",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1778009878203,
+			"tag": "0005_spooky_timeslip",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/entity-awareness/wikipedia-article.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/entity-awareness/wikipedia-article.repository.ts
@@ -1,0 +1,109 @@
+import { EntityAwareness, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { wikipediaArticles } from '../../schema/index.js';
+
+const UNIQUE_PROJECT_ARTICLE_CONSTRAINT = 'wikipedia_articles_project_article_unique';
+
+const isProjectArticleUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_PROJECT_ARTICLE_CONSTRAINT;
+};
+
+export class DrizzleWikipediaArticleRepository implements EntityAwareness.WikipediaArticleRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(article: EntityAwareness.WikipediaArticle): Promise<void> {
+		try {
+			await this.db
+				.insert(wikipediaArticles)
+				.values({
+					id: article.id,
+					organizationId: article.organizationId,
+					projectId: article.projectId,
+					wikipediaProject: article.wikipediaProject.value,
+					slug: article.slug.value,
+					label: article.label,
+					linkedAt: article.linkedAt,
+					unlinkedAt: article.unlinkedAt,
+				})
+				.onConflictDoUpdate({
+					target: wikipediaArticles.id,
+					set: {
+						label: article.label,
+						unlinkedAt: article.unlinkedAt,
+					},
+				});
+		} catch (err) {
+			if (isProjectArticleUniqueViolation(err)) {
+				throw new ConflictError(
+					`Wikipedia article ${article.slug.value} on ${article.wikipediaProject.value} is already linked to project ${article.projectId}`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(id: EntityAwareness.WikipediaArticleId): Promise<EntityAwareness.WikipediaArticle | null> {
+		const [row] = await this.db.select().from(wikipediaArticles).where(eq(wikipediaArticles.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByProjectAndSlug(
+		projectId: ProjectManagement.ProjectId,
+		wikipediaProject: EntityAwareness.WikipediaProject,
+		slug: EntityAwareness.ArticleSlug,
+	): Promise<EntityAwareness.WikipediaArticle | null> {
+		const [row] = await this.db
+			.select()
+			.from(wikipediaArticles)
+			.where(
+				and(
+					eq(wikipediaArticles.projectId, projectId),
+					eq(wikipediaArticles.wikipediaProject, wikipediaProject.value),
+					eq(wikipediaArticles.slug, slug.value),
+				),
+			)
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly EntityAwareness.WikipediaArticle[]> {
+		const rows = await this.db
+			.select()
+			.from(wikipediaArticles)
+			.where(eq(wikipediaArticles.projectId, projectId))
+			.orderBy(desc(wikipediaArticles.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listForOrganization(
+		orgId: IdentityAccess.OrganizationId,
+	): Promise<readonly EntityAwareness.WikipediaArticle[]> {
+		const rows = await this.db
+			.select()
+			.from(wikipediaArticles)
+			.where(eq(wikipediaArticles.organizationId, orgId))
+			.orderBy(desc(wikipediaArticles.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof wikipediaArticles.$inferSelect): EntityAwareness.WikipediaArticle {
+		return EntityAwareness.WikipediaArticle.rehydrate({
+			id: row.id as EntityAwareness.WikipediaArticleId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			wikipediaProject: EntityAwareness.WikipediaProject.create(row.wikipediaProject),
+			slug: EntityAwareness.ArticleSlug.create(row.slug),
+			label: row.label,
+			linkedAt: row.linkedAt,
+			unlinkedAt: row.unlinkedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/entity-awareness/wikipedia-pageview-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/entity-awareness/wikipedia-pageview-observation.repository.ts
@@ -1,0 +1,61 @@
+import { EntityAwareness, type ProjectManagement } from '@rankpulse/domain';
+import { and, between, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { wikipediaPageviews } from '../../schema/index.js';
+
+export class DrizzleWikipediaPageviewObservationRepository
+	implements EntityAwareness.WikipediaPageviewObservationRepository
+{
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async saveAll(
+		observations: readonly EntityAwareness.WikipediaPageviewObservation[],
+	): Promise<{ inserted: number }> {
+		if (observations.length === 0) return { inserted: 0 };
+		const inserted = await this.db
+			.insert(wikipediaPageviews)
+			.values(
+				observations.map((o) => ({
+					articleId: o.articleId,
+					projectId: o.projectId,
+					observedAt: o.observedAt,
+					views: o.views,
+					access: o.access,
+					agent: o.agent,
+					granularity: o.granularity,
+				})),
+			)
+			.onConflictDoNothing({
+				target: [wikipediaPageviews.articleId, wikipediaPageviews.observedAt],
+			})
+			.returning({ articleId: wikipediaPageviews.articleId });
+		return { inserted: inserted.length };
+	}
+
+	async listForArticle(
+		articleId: EntityAwareness.WikipediaArticleId,
+		query: EntityAwareness.WikipediaPageviewQuery,
+	): Promise<readonly EntityAwareness.WikipediaPageviewObservation[]> {
+		const rows = await this.db
+			.select()
+			.from(wikipediaPageviews)
+			.where(
+				and(
+					eq(wikipediaPageviews.articleId, articleId),
+					between(wikipediaPageviews.observedAt, query.from, query.to),
+				),
+			)
+			.orderBy(wikipediaPageviews.observedAt);
+		return rows.map((r) =>
+			EntityAwareness.WikipediaPageviewObservation.rehydrate({
+				articleId: r.articleId as EntityAwareness.WikipediaArticleId,
+				projectId: r.projectId as ProjectManagement.ProjectId,
+				observedAt: r.observedAt,
+				views: r.views,
+				access: r.access,
+				agent: r.agent,
+				granularity: r.granularity,
+			}),
+		);
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -510,3 +510,65 @@ export type TrackedKeywordRow = typeof trackedKeywords.$inferSelect;
 export type RankingObservationRow = typeof rankingObservations.$inferSelect;
 export type GscPropertyRow = typeof gscProperties.$inferSelect;
 export type GscObservationRow = typeof gscObservations.$inferSelect;
+
+// ---- entity-awareness ----
+
+/**
+ * Issue #33 — Wikipedia articles linked to a project as brand /
+ * competitor / entity-awareness signals. Soft-delete via `unlinkedAt`
+ * so historical observations remain queryable after the operator
+ * stops tracking the article.
+ */
+export const wikipediaArticles = pgTable(
+	'wikipedia_articles',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		wikipediaProject: text('wikipedia_project').notNull(),
+		slug: text('slug').notNull(),
+		label: text('label').notNull(),
+		linkedAt: timestamp('linked_at', { withTimezone: true }).notNull().defaultNow(),
+		unlinkedAt: timestamp('unlinked_at', { withTimezone: true }),
+	},
+	(t) => ({
+		uniqueByProjectArticle: uniqueIndex('wikipedia_articles_project_article_unique').on(
+			t.projectId,
+			t.wikipediaProject,
+			t.slug,
+		),
+		projectIdx: index('wikipedia_articles_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of Wikipedia pageviews per linked article. PK is the
+ * natural key (articleId, observedAt) so re-running the same fetch is
+ * idempotent. `views` is bigint because article totals can run into
+ * the billions over multi-year ranges.
+ */
+export const wikipediaPageviews = pgTable(
+	'wikipedia_pageviews',
+	{
+		articleId: uuid('article_id')
+			.notNull()
+			.references(() => wikipediaArticles.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedAt: timestamp('observed_at', { withTimezone: true }).notNull(),
+		views: bigint('views', { mode: 'number' }).notNull(),
+		access: text('access').notNull(),
+		agent: text('agent').notNull(),
+		granularity: text('granularity').notNull(),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.articleId, t.observedAt] }),
+		projectIdx: index('wikipedia_pageviews_project_idx').on(t.projectId, t.observedAt),
+	}),
+);
+
+export type WikipediaArticleRow = typeof wikipediaArticles.$inferSelect;
+export type WikipediaPageviewRow = typeof wikipediaPageviews.$inferSelect;

--- a/packages/providers/wikipedia/package.json
+++ b/packages/providers/wikipedia/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rankpulse/provider-wikipedia",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/wikipedia/src/acl/pageviews-to-observations.acl.spec.ts
+++ b/packages/providers/wikipedia/src/acl/pageviews-to-observations.acl.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { PageviewsPerArticleResponse } from '../endpoints/pageviews-per-article.js';
+import { extractPageviews } from './pageviews-to-observations.acl.js';
+
+const baseItem = {
+	project: 'es.wikipedia.org',
+	article: 'Torre_Eiffel',
+	access: 'all-access',
+	agent: 'user',
+	granularity: 'daily',
+};
+
+describe('extractPageviews', () => {
+	it('parses YYYYMMDDHH timestamps to UTC midnight Date instances', () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [
+				{ ...baseItem, timestamp: '2026010100', views: 1234 },
+				{ ...baseItem, timestamp: '2026010200', views: 1100 },
+			],
+		};
+		const out = extractPageviews(payload);
+		expect(out).toHaveLength(2);
+		expect(out[0]?.observedAt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+		expect(out[1]?.observedAt.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+		expect(out[0]?.views).toBe(1234);
+	});
+
+	it('returns empty array when payload has no items', () => {
+		expect(extractPageviews({})).toEqual([]);
+		expect(extractPageviews({ items: [] })).toEqual([]);
+	});
+
+	it('drops items with malformed timestamp without throwing', () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [
+				{ ...baseItem, timestamp: 'bogus', views: 100 },
+				{ ...baseItem, timestamp: '20260101', views: 200 }, // 8 chars, also invalid
+				{ ...baseItem, timestamp: '2026010100', views: 300 },
+			],
+		};
+		expect(extractPageviews(payload).map((o) => o.views)).toEqual([300]);
+	});
+
+	it('drops items with negative or non-numeric views', () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [
+				{ ...baseItem, timestamp: '2026010100', views: -5 },
+				{ ...baseItem, timestamp: '2026010200', views: Number.NaN },
+				{ ...baseItem, timestamp: '2026010300', views: 50 },
+			],
+		};
+		expect(extractPageviews(payload).map((o) => o.views)).toEqual([50]);
+	});
+
+	it('rounds fractional view counts (some informational endpoints return non-integer)', () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [{ ...baseItem, timestamp: '2026010100', views: 100.7 }],
+		};
+		expect(extractPageviews(payload)[0]?.views).toBe(101);
+	});
+
+	it('rejects month/day out of range', () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [
+				{ ...baseItem, timestamp: '2026130100', views: 10 }, // month 13
+				{ ...baseItem, timestamp: '2026010000', views: 20 }, // day 0
+				{ ...baseItem, timestamp: '2026010101', views: 30 }, // valid (hour 01)
+			],
+		};
+		expect(extractPageviews(payload).map((o) => o.views)).toEqual([30]);
+	});
+});

--- a/packages/providers/wikipedia/src/acl/pageviews-to-observations.acl.ts
+++ b/packages/providers/wikipedia/src/acl/pageviews-to-observations.acl.ts
@@ -1,0 +1,65 @@
+import type { PageviewsPerArticleResponse } from '../endpoints/pageviews-per-article.js';
+
+/**
+ * Pageview observation in the ubiquitous language of `entity-awareness`:
+ * one (article, day, views) tuple per row, ready to be persisted as a
+ * domain row.
+ *
+ * The Wikimedia API timestamp comes as `YYYYMMDDHH` (always 00 for
+ * daily granularity) — we normalise to a `Date` at midnight UTC of
+ * that day so downstream queries can do range filtering trivially.
+ */
+export interface WikipediaPageviewExtraction {
+	project: string;
+	article: string;
+	observedAt: Date;
+	views: number;
+	access: string;
+	agent: string;
+	granularity: string;
+}
+
+/**
+ * Pure ACL: takes the raw Wikimedia REST payload and produces typed
+ * observations. Filters out any item missing a required field instead
+ * of throwing — Wikimedia occasionally returns partial rows for
+ * articles with sparse history; we want best-effort persistence, not
+ * a worker abort.
+ */
+export const extractPageviews = (
+	payload: PageviewsPerArticleResponse,
+): readonly WikipediaPageviewExtraction[] => {
+	const items = payload.items ?? [];
+	const out: WikipediaPageviewExtraction[] = [];
+	for (const item of items) {
+		const observedAt = parseWikimediaTimestamp(item.timestamp);
+		if (!observedAt) continue;
+		// `Number.isFinite` rejects NaN and ±Infinity; both are
+		// observably present in the wild when Wikimedia backfills are
+		// in progress for an article and the view counter hasn't
+		// converged yet.
+		if (!Number.isFinite(item.views) || item.views < 0) continue;
+		out.push({
+			project: item.project,
+			article: item.article,
+			observedAt,
+			views: Math.round(item.views),
+			access: item.access,
+			agent: item.agent,
+			granularity: item.granularity,
+		});
+	}
+	return out;
+};
+
+const parseWikimediaTimestamp = (raw: string): Date | null => {
+	// `YYYYMMDDHH` (10 chars) for daily, `YYYYMMDD00` for monthly bucket.
+	if (typeof raw !== 'string') return null;
+	if (raw.length !== 10 || !/^\d{10}$/.test(raw)) return null;
+	const year = Number(raw.slice(0, 4));
+	const month = Number(raw.slice(4, 6));
+	const day = Number(raw.slice(6, 8));
+	const hour = Number(raw.slice(8, 10));
+	if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23) return null;
+	return new Date(Date.UTC(year, month - 1, day, hour, 0, 0, 0));
+};

--- a/packages/providers/wikipedia/src/endpoints/pageviews-per-article.ts
+++ b/packages/providers/wikipedia/src/endpoints/pageviews-per-article.ts
@@ -1,0 +1,89 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { WikipediaHttp } from '../http.js';
+
+/**
+ * `pageviews-per-article` — the per-article daily/monthly view counts.
+ * https://wikimedia.org/api/rest_v1/#/Pageviews_data
+ *
+ * `project` is the Wikipedia subdomain (e.g. `en.wikipedia.org`,
+ * `es.wikipedia.org`). `article` is the URL-encoded title with
+ * underscores in place of spaces (`Eiffel_Tower`, `Torre_Eiffel`).
+ *
+ * Date format is `YYYYMMDD` (or with hour `YYYYMMDDHH` for hourly).
+ * `start` and `end` accept the BACKLOG #22 token form `{{today-N}}` —
+ * the worker resolves them before dispatch.
+ */
+export const PageviewsPerArticleParams = z.object({
+	project: z
+		.string()
+		.regex(/^[a-z]{2,3}(?:-[a-z]+)?\.wikipedia\.org$/, 'project must be like "en.wikipedia.org"'),
+	article: z.string().min(1).max(255),
+	access: z.enum(['all-access', 'desktop', 'mobile-app', 'mobile-web']).default('all-access'),
+	agent: z.enum(['all-agents', 'user', 'spider', 'automated']).default('user'),
+	granularity: z.enum(['daily', 'monthly']).default('daily'),
+	start: z.string().regex(/^\d{8}$|^\{\{today(?:-\d+)?\}\}$/),
+	end: z.string().regex(/^\d{8}$|^\{\{today(?:-\d+)?\}\}$/),
+});
+export type PageviewsPerArticleParams = z.infer<typeof PageviewsPerArticleParams>;
+
+/**
+ * Free API. Cost is bookkeeping only (so the api_usage ledger has a
+ * row), pinned to 0 cents. We model the rate-limit at descriptor
+ * level (~100 req/s globally per Wikimedia's robot policy) so the
+ * scheduling layer doesn't fan out beyond that.
+ */
+export const PAGEVIEWS_COST_CENTS = 0;
+
+export const pageviewsPerArticleDescriptor: EndpointDescriptor = {
+	id: 'wikipedia-pageviews-per-article',
+	category: 'brand',
+	displayName: 'Wikipedia — pageviews per article',
+	description:
+		'Daily or monthly view counts for a single Wikipedia article in a given language project. Signal of brand / entity awareness over time.',
+	paramsSchema: PageviewsPerArticleParams,
+	cost: { unit: 'usd_cents', amount: PAGEVIEWS_COST_CENTS },
+	defaultCron: '0 4 * * 1',
+	rateLimit: { max: 200, durationMs: 1_000 },
+};
+
+export interface PageviewItem {
+	project: string;
+	article: string;
+	granularity: string;
+	timestamp: string;
+	access: string;
+	agent: string;
+	views: number;
+}
+
+export interface PageviewsPerArticleResponse {
+	items?: PageviewItem[];
+}
+
+const buildPath = (params: PageviewsPerArticleParams): string => {
+	const segments = [
+		'/metrics/pageviews/per-article',
+		params.project,
+		params.access,
+		params.agent,
+		encodeURIComponent(params.article),
+		params.granularity,
+		params.start,
+		params.end,
+	];
+	return segments.join('/');
+};
+
+export const fetchPageviewsPerArticle = async (
+	http: WikipediaHttp,
+	params: PageviewsPerArticleParams,
+	ctx: FetchContext,
+): Promise<PageviewsPerArticleResponse> => {
+	const raw = (await http.get(buildPath(params), ctx.signal)) as PageviewsPerArticleResponse;
+	if (!raw || !Array.isArray(raw.items)) {
+		ctx.logger.warn('Wikipedia pageviews response missing items array', { raw });
+		return { items: [] };
+	}
+	return raw;
+};

--- a/packages/providers/wikipedia/src/endpoints/top-articles.ts
+++ b/packages/providers/wikipedia/src/endpoints/top-articles.ts
@@ -1,0 +1,68 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { WikipediaHttp } from '../http.js';
+
+/**
+ * `top-articles` — the most-viewed articles in a project on a given day
+ * or month. Useful for trend monitoring and competitor entity discovery.
+ *
+ * Date model: { year, month, day } strings; pass `'all-days'` to get a
+ * monthly aggregate.
+ */
+export const TopArticlesParams = z.object({
+	project: z
+		.string()
+		.regex(/^[a-z]{2,3}(?:-[a-z]+)?\.wikipedia\.org$/, 'project must be like "en.wikipedia.org"'),
+	access: z.enum(['all-access', 'desktop', 'mobile-app', 'mobile-web']).default('all-access'),
+	year: z.string().regex(/^\d{4}$/),
+	month: z.string().regex(/^\d{2}$/),
+	day: z.string().regex(/^\d{2}$|^all-days$/),
+});
+export type TopArticlesParams = z.infer<typeof TopArticlesParams>;
+
+export const TOP_ARTICLES_COST_CENTS = 0;
+
+export const topArticlesDescriptor: EndpointDescriptor = {
+	id: 'wikipedia-top-articles',
+	category: 'brand',
+	displayName: 'Wikipedia — top articles',
+	description:
+		'Top viewed articles in a Wikipedia project for a given day or month. Surfaces trending entities and what the broader audience is searching for.',
+	paramsSchema: TopArticlesParams,
+	cost: { unit: 'usd_cents', amount: TOP_ARTICLES_COST_CENTS },
+	defaultCron: '0 5 1 * *',
+	rateLimit: { max: 200, durationMs: 1_000 },
+};
+
+export interface TopArticleItem {
+	article: string;
+	views: number;
+	rank: number;
+}
+
+export interface TopArticlesResponse {
+	items?: Array<{
+		project: string;
+		access: string;
+		year: string;
+		month: string;
+		day: string;
+		articles?: TopArticleItem[];
+	}>;
+}
+
+const buildPath = (params: TopArticlesParams): string =>
+	['/metrics/pageviews/top', params.project, params.access, params.year, params.month, params.day].join('/');
+
+export const fetchTopArticles = async (
+	http: WikipediaHttp,
+	params: TopArticlesParams,
+	ctx: FetchContext,
+): Promise<TopArticlesResponse> => {
+	const raw = (await http.get(buildPath(params), ctx.signal)) as TopArticlesResponse;
+	if (!raw || !Array.isArray(raw.items)) {
+		ctx.logger.warn('Wikipedia top-articles response missing items array', { raw });
+		return { items: [] };
+	}
+	return raw;
+};

--- a/packages/providers/wikipedia/src/http.ts
+++ b/packages/providers/wikipedia/src/http.ts
@@ -1,0 +1,92 @@
+/**
+ * Wikimedia REST API client. The API is unauthenticated; the only
+ * etiquette requirement is a descriptive `User-Agent` so the Wikimedia
+ * ops team can contact us if our usage pattern misbehaves
+ * (https://wikitech.wikimedia.org/wiki/Robot_policy).
+ */
+
+export interface WikipediaHttpOptions {
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+	/** Override the User-Agent (defaults to RankPulse contact). */
+	userAgent?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://wikimedia.org/api/rest_v1';
+const DEFAULT_USER_AGENT = 'RankPulse/1.0 (https://github.com/vgpastor/rankpulse; ops@rankpulse.local)';
+
+/**
+ * Cap on response body — Wikipedia daily-views per article rarely
+ * exceeds a few KB, even for the longest date ranges. 4MB is generous
+ * but tight enough to abort runaway responses before OOM.
+ */
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+export class WikipediaHttp {
+	private readonly baseUrl: string;
+	private readonly fetchImpl: typeof fetch;
+	private readonly userAgent: string;
+
+	constructor(options: WikipediaHttpOptions = {}) {
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+		this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+	}
+
+	async get(path: string, signal?: AbortSignal): Promise<unknown> {
+		const url = `${this.baseUrl}${path}`;
+		const response = await this.fetchImpl(url, {
+			method: 'GET',
+			headers: {
+				'User-Agent': this.userAgent,
+				Accept: 'application/json',
+				'Accept-Encoding': 'gzip',
+			},
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new WikipediaApiError(
+				response.status,
+				null,
+				`Wikipedia ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new WikipediaApiError(
+				response.status,
+				null,
+				`Wikipedia ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new WikipediaApiError(
+				response.status,
+				parsed,
+				`Wikipedia ${path} returned HTTP ${response.status}`,
+			);
+		}
+		return parsed;
+	}
+}
+
+export class WikipediaApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'WikipediaApiError';
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/wikipedia/src/index.ts
+++ b/packages/providers/wikipedia/src/index.ts
@@ -1,0 +1,5 @@
+export * from './acl/pageviews-to-observations.acl.js';
+export * from './endpoints/pageviews-per-article.js';
+export * from './endpoints/top-articles.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/wikipedia/src/provider.spec.ts
+++ b/packages/providers/wikipedia/src/provider.spec.ts
@@ -1,0 +1,97 @@
+import type { FetchContext } from '@rankpulse/provider-core';
+import { describe, expect, it } from 'vitest';
+import { WikipediaProvider } from './provider.js';
+
+const stubContext = (): FetchContext => ({
+	credential: { plaintextSecret: 'public' },
+	logger: { debug: () => {}, warn: () => {} },
+	now: () => new Date('2026-05-04T10:00:00Z'),
+});
+
+describe('WikipediaProvider', () => {
+	it('exposes both endpoints via discover()', () => {
+		const provider = new WikipediaProvider();
+		const ids = provider.discover().map((e) => e.id);
+		expect(ids).toEqual(
+			expect.arrayContaining(['wikipedia-pageviews-per-article', 'wikipedia-top-articles']),
+		);
+	});
+
+	it('every descriptor declares a non-empty defaultCron (BACKLOG #21)', () => {
+		const provider = new WikipediaProvider();
+		for (const descriptor of provider.discover()) {
+			expect(descriptor.defaultCron).toMatch(/^\S+ \S+ \S+ \S+ \S+$/);
+		}
+	});
+
+	it('rejects unknown endpoint ids', async () => {
+		const provider = new WikipediaProvider();
+		await expect(provider.fetch('bogus', {}, stubContext())).rejects.toThrowError(/no endpoint/);
+	});
+
+	it('rejects malformed params with InvalidInputError', async () => {
+		const provider = new WikipediaProvider();
+		await expect(
+			provider.fetch('wikipedia-pageviews-per-article', { project: '' }, stubContext()),
+		).rejects.toThrow();
+	});
+
+	it('forwards a properly shaped request and returns the typed response', async () => {
+		let capturedUrl: string | undefined;
+		const fakeFetch = async (url: RequestInfo | URL): Promise<Response> => {
+			capturedUrl = String(url);
+			return new Response(
+				JSON.stringify({
+					items: [
+						{
+							project: 'es.wikipedia.org',
+							article: 'Torre_Eiffel',
+							granularity: 'daily',
+							timestamp: '2026010100',
+							access: 'all-access',
+							agent: 'user',
+							views: 1500,
+						},
+					],
+				}),
+				{ status: 200, headers: { 'content-type': 'application/json' } },
+			);
+		};
+		const provider = new WikipediaProvider({ fetchImpl: fakeFetch as typeof fetch });
+		const result = (await provider.fetch(
+			'wikipedia-pageviews-per-article',
+			{
+				project: 'es.wikipedia.org',
+				article: 'Torre_Eiffel',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '20260101',
+				end: '20260131',
+			},
+			stubContext(),
+		)) as { items: Array<{ views: number }> };
+
+		expect(capturedUrl).toContain('/metrics/pageviews/per-article/es.wikipedia.org/');
+		expect(capturedUrl).toContain('/Torre_Eiffel/daily/20260101/20260131');
+		expect(result.items[0]?.views).toBe(1500);
+	});
+
+	it('top-articles endpoint URL includes year/month/day path segments', async () => {
+		let capturedUrl: string | undefined;
+		const fakeFetch = async (url: RequestInfo | URL): Promise<Response> => {
+			capturedUrl = String(url);
+			return new Response(JSON.stringify({ items: [] }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		};
+		const provider = new WikipediaProvider({ fetchImpl: fakeFetch as typeof fetch });
+		await provider.fetch(
+			'wikipedia-top-articles',
+			{ project: 'en.wikipedia.org', access: 'all-access', year: '2026', month: '05', day: '01' },
+			stubContext(),
+		);
+		expect(capturedUrl).toContain('/metrics/pageviews/top/en.wikipedia.org/all-access/2026/05/01');
+	});
+});

--- a/packages/providers/wikipedia/src/provider.ts
+++ b/packages/providers/wikipedia/src/provider.ts
@@ -1,0 +1,71 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import {
+	fetchPageviewsPerArticle,
+	type PageviewsPerArticleParams,
+	pageviewsPerArticleDescriptor,
+} from './endpoints/pageviews-per-article.js';
+import { fetchTopArticles, type TopArticlesParams, topArticlesDescriptor } from './endpoints/top-articles.js';
+import { WikipediaHttp, type WikipediaHttpOptions } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [pageviewsPerArticleDescriptor, topArticlesDescriptor];
+
+/**
+ * Wikimedia REST API provider — entity awareness signal (issue #33).
+ *
+ * Auth: NONE. The API is public; we only attach a contact `User-Agent`.
+ * `validateCredentialPlaintext` accepts any input including the empty
+ * string because there's nothing to validate; the
+ * RegisterProviderCredentialUseCase still gets called by the operator
+ * to track that the source is "enabled" for an org, but the secret can
+ * be a sentinel like "public".
+ */
+export class WikipediaProvider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('wikipedia');
+	readonly displayName = 'Wikipedia (Wikimedia REST API)';
+	readonly authStrategy = 'apiKey' as const;
+
+	private readonly http: WikipediaHttp;
+
+	constructor(options?: WikipediaHttpOptions) {
+		this.http = new WikipediaHttp(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(_plaintextSecret: string): void {
+		// Wikipedia REST API is unauthenticated. We accept any
+		// credential (typically the literal "public") so the
+		// registration flow stays uniform across providers.
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case pageviewsPerArticleDescriptor.id:
+				return await fetchPageviewsPerArticle(
+					this.http,
+					this.parseParams(pageviewsPerArticleDescriptor, params) as PageviewsPerArticleParams,
+					ctx,
+				);
+			case topArticlesDescriptor.id:
+				return await fetchTopArticles(
+					this.http,
+					this.parseParams(topArticlesDescriptor, params) as TopArticlesParams,
+					ctx,
+				);
+			default:
+				throw new InvalidInputError(`Wikipedia has no endpoint "${endpointId}"`);
+		}
+	}
+
+	private parseParams(descriptor: EndpointDescriptor, raw: unknown): unknown {
+		const parsed = descriptor.paramsSchema.safeParse(raw);
+		if (!parsed.success) {
+			throw new InvalidInputError(`Invalid params for ${descriptor.id}: ${parsed.error.message}`);
+		}
+		return parsed.data;
+	}
+}

--- a/packages/providers/wikipedia/tsconfig.build.json
+++ b/packages/providers/wikipedia/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/wikipedia/tsconfig.json
+++ b/packages/providers/wikipedia/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/wikipedia/vitest.config.ts
+++ b/packages/providers/wikipedia/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -4,6 +4,7 @@ import { GscResource } from './resources/gsc.js';
 import { ProjectsResource } from './resources/projects.js';
 import { ProvidersResource } from './resources/providers.js';
 import { RankTrackingResource } from './resources/rank-tracking.js';
+import { WikipediaResource } from './resources/wikipedia.js';
 
 export interface RankPulseClientOptions extends HttpClientOptions {
 	apiPrefix?: string;
@@ -17,6 +18,7 @@ export class RankPulseClient {
 	readonly providers: ProvidersResource;
 	readonly rankTracking: RankTrackingResource;
 	readonly gsc: GscResource;
+	readonly wikipedia: WikipediaResource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -27,5 +29,6 @@ export class RankPulseClient {
 		this.providers = new ProvidersResource(http);
 		this.rankTracking = new RankTrackingResource(http);
 		this.gsc = new GscResource(http);
+		this.wikipedia = new WikipediaResource(http);
 	}
 }

--- a/packages/sdk/src/resources/wikipedia.ts
+++ b/packages/sdk/src/resources/wikipedia.ts
@@ -1,0 +1,30 @@
+import type { EntityAwarenessContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class WikipediaResource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<EntityAwarenessContracts.WikipediaArticleDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/wikipedia/articles`);
+	}
+
+	link(
+		projectId: string,
+		body: EntityAwarenessContracts.LinkWikipediaArticleRequest,
+	): Promise<{ articleId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/wikipedia/articles`, body);
+	}
+
+	unlink(articleId: string): Promise<{ ok: true }> {
+		return this.http.post(`/wikipedia/articles/${encodeURIComponent(articleId)}/unlink`, {});
+	}
+
+	pageviews(
+		articleId: string,
+		query?: EntityAwarenessContracts.WikipediaPageviewQuery,
+	): Promise<EntityAwarenessContracts.WikipediaPageviewDto[]> {
+		return this.http.get(`/wikipedia/articles/${encodeURIComponent(articleId)}/pageviews`, {
+			query: { from: query?.from ?? null, to: query?.to ?? null },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
+      '@rankpulse/provider-wikipedia':
+        specifier: workspace:*
+        version: link:../../packages/providers/wikipedia
       '@rankpulse/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -380,6 +383,28 @@ importers:
       google-auth-library:
         specifier: 10.6.2
         version: 10.6.2
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/wikipedia:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

Closes [#33](https://github.com/vgpastor/RankPulse/issues/33). Wikipedia pageviews as an entity-awareness signal — first issue of milestone v1.3 (Brand & community mentions). Slice vertical end-to-end: provider → domain → infra → application → worker → API → SDK → UI.

| Layer | What |
|---|---|
| Provider | `packages/providers/wikipedia` — Wikimedia REST client (no auth, contact UA, 32MB cap) + 2 endpoints + ACL + 12 tests |
| Domain | New bounded context `entity-awareness`: aggregate `WikipediaArticle` (linked → unlinked), VOs `WikipediaProject` + `ArticleSlug`, value-like `WikipediaPageviewObservation`, ports + 3 events |
| Application | `LinkWikipediaArticle` (idempotent + re-link), `UnlinkWikipediaArticle`, `IngestWikipediaPageviews` (1 summary event/batch), `QueryWikipediaPageviews`. 5 use-case tests |
| Infra | Migration 0005 con IF NOT EXISTS + tablas `wikipedia_articles` (unique project_id+wp_project+slug) y `wikipedia_pageviews` (PK natural, bigint views) + Drizzle repos |
| Worker | `WikipediaProvider` registrado, processor dispatch del `wikipedia-pageviews-per-article` con `extractPageviews` + ingest |
| API | `WikipediaController` con 4 endpoints — IDOR-safe (404 colapsa not-found + forbidden) |
| SDK | `RankPulseClient.wikipedia` |
| UI | `LinkWikipediaDrawer` (atomic-design organism, mobile-first, auto-strip URL → slug) + Card en project-detail |

## DDD/SOLID/Clean Code

- Domain sin imports de infra. Invariantes en agregados (slug sin espacios, project shape, terminal unlink).
- Per-row observations son value-like; solo el aggregate link/unlink emite eventos. IngestUseCase publica 1 summary event por batch (mismo patrón que GscPerformanceBatchIngested).
- Repos infra mapean unique-violation → `ConflictError`. `saveAll` devuelve `{inserted: number}` real (post `onConflictDoNothing`).
- Provider ACL-isolated: la response shape de Wikimedia nunca escapa de `packages/providers/wikipedia/`.
- Atomic design: `Select` + `Input` + `FormField` (atoms/molecules) → `Drawer` (molecule) → `LinkWikipediaDrawer` (organism) → `project-detail.page.tsx` composición.

## Test plan

- [x] `pnpm -r typecheck` (15/15 done)
- [x] `pnpm -r test` (40 archivos, 197 tests — +12 nuevos del provider, +5 del use case)
- [x] `pnpm lint` (0 errors)
- [x] `docker buildx build` para api + worker (runtime stages OK)
- [ ] Manual on staging: link `Eiffel_Tower` en `en.wikipedia.org`, scheduler con `systemParams: { wikipediaArticleId }`, verificar fila en `wikipedia_pageviews` tras la primera ejecución
- [ ] Manual on staging: link duplicado → 409, link tras unlink → nueva row, fetch de pageviews con range desde-hasta