### PR TITLE
feat: PageSpeed Insights provider + web-performance context (#18)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { ProjectManagementModule } from './modules/project-management/project-ma
 import { ProviderConnectivityModule } from './modules/provider-connectivity/provider-connectivity.module.js';
 import { RankTrackingModule } from './modules/rank-tracking/rank-tracking.module.js';
 import { SearchConsoleInsightsModule } from './modules/search-console-insights/search-console-insights.module.js';
+import { WebPerformanceModule } from './modules/web-performance/web-performance.module.js';
 import { OpenApiModule } from './openapi/openapi.module.js';
 
 @Module({})
@@ -44,6 +45,7 @@ export class AppModule {
 			RankTrackingModule,
 			SearchConsoleInsightsModule,
 			EntityAwarenessModule,
+			WebPerformanceModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -6,6 +6,7 @@ import {
 	ProjectManagement as PMUseCases,
 	RankTracking as RTUseCases,
 	SearchConsoleInsights as SCIUseCases,
+	WebPerformance as WPUseCases,
 } from '@rankpulse/application';
 import type { ProjectManagement } from '@rankpulse/domain';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
@@ -63,6 +64,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const wikipediaPageviewRepo = new DrizzlePersistence.DrizzleWikipediaPageviewObservationRepository(
 		drizzle.db,
 	);
+	const trackedPageRepo = new DrizzlePersistence.DrizzleTrackedPageRepository(drizzle.db);
+	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -251,6 +254,19 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		wikipediaPageviewRepo,
 	);
 
+	// Issue #18 — web-performance use cases
+	const trackPage = new WPUseCases.TrackPageUseCase(
+		trackedPageRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const untrackPage = new WPUseCases.UntrackPageUseCase(trackedPageRepo);
+	const queryPageSpeedHistory = new WPUseCases.QueryPageSpeedHistoryUseCase(
+		trackedPageRepo,
+		pageSpeedSnapshotRepo,
+	);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -341,6 +357,11 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 
 		value(Tokens.WikipediaArticleRepository, wikipediaArticleRepo),
 		value(Tokens.WikipediaPageviewObservationRepository, wikipediaPageviewRepo),
+		value(Tokens.TrackedPageRepository, trackedPageRepo),
+		value(Tokens.PageSpeedSnapshotRepository, pageSpeedSnapshotRepo),
+		value(Tokens.TrackPage, trackPage),
+		value(Tokens.UntrackPage, untrackPage),
+		value(Tokens.QueryPageSpeedHistory, queryPageSpeedHistory),
 		value(Tokens.LinkWikipediaArticle, linkWikipediaArticle),
 		value(Tokens.UnlinkWikipediaArticle, unlinkWikipediaArticle),
 		value(Tokens.QueryWikipediaPageviews, queryWikipediaPageviews),

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -95,6 +95,15 @@ export const Tokens = {
 	UnlinkWikipediaArticle: Symbol('UnlinkWikipediaArticleUseCase'),
 	QueryWikipediaPageviews: Symbol('QueryWikipediaPageviewsUseCase'),
 
+	// Web-Performance ports
+	TrackedPageRepository: Symbol('TrackedPageRepository'),
+	PageSpeedSnapshotRepository: Symbol('PageSpeedSnapshotRepository'),
+
+	// Web-Performance use cases
+	TrackPage: Symbol('TrackPageUseCase'),
+	UntrackPage: Symbol('UntrackPageUseCase'),
+	QueryPageSpeedHistory: Symbol('QueryPageSpeedHistoryUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/web-performance/page-speed.controller.ts
+++ b/apps/api/src/modules/web-performance/page-speed.controller.ts
@@ -1,0 +1,111 @@
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { WebPerformance as WPUseCases } from '@rankpulse/application';
+import { WebPerformanceContracts } from '@rankpulse/contracts';
+import type { IdentityAccess, ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+@Controller()
+export class PageSpeedController {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.TrackPage) private readonly trackPage: WPUseCases.TrackPageUseCase,
+		@Inject(Tokens.UntrackPage) private readonly untrackPage: WPUseCases.UntrackPageUseCase,
+		@Inject(Tokens.QueryPageSpeedHistory)
+		private readonly queryHistory: WPUseCases.QueryPageSpeedHistoryUseCase,
+		@Inject(Tokens.TrackedPageRepository)
+		private readonly trackedPages: WebPerformance.TrackedPageRepository,
+		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/page-speed/pages')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<WebPerformanceContracts.TrackedPageDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.trackedPages.listForProject(project.id);
+		return list.map((p) => this.serialize(p));
+	}
+
+	@Post('projects/:projectId/page-speed/pages')
+	async track(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(WebPerformanceContracts.TrackPageRequest))
+		body: WebPerformanceContracts.TrackPageRequest,
+	): Promise<{ trackedPageId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.trackPage.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			url: body.url,
+			strategy: body.strategy,
+		});
+	}
+
+	@Delete('page-speed/pages/:trackedPageId')
+	async untrack(
+		@Principal() principal: AuthPrincipal,
+		@Param('trackedPageId') trackedPageId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToPage(principal, trackedPageId);
+		await this.untrackPage.execute(trackedPageId);
+		return { ok: true };
+	}
+
+	@Get('page-speed/pages/:trackedPageId/history')
+	async history(
+		@Principal() principal: AuthPrincipal,
+		@Param('trackedPageId') trackedPageId: string,
+		@Query(new ZodValidationPipe(WebPerformanceContracts.PageSpeedHistoryQuery))
+		q: WebPerformanceContracts.PageSpeedHistoryQuery,
+	): Promise<WebPerformanceContracts.PageSpeedSnapshotDto[]> {
+		await this.requireAccessToPage(principal, trackedPageId);
+		const to = q.to ? new Date(q.to) : new Date();
+		const from = q.from ? new Date(q.from) : new Date(to.getTime() - 90 * 24 * 60 * 60 * 1000);
+		const result = await this.queryHistory.execute({ trackedPageId, from, to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	private async requireAccessToPage(principal: AuthPrincipal, trackedPageId: string): Promise<void> {
+		const page = await this.trackedPages.findById(trackedPageId as WebPerformance.TrackedPageId);
+		if (!page) throw new NotFoundError(`Tracked page ${trackedPageId} not found`);
+		const project = await this.projects.findById(page.projectId);
+		if (!project) throw new NotFoundError(`Tracked page ${trackedPageId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`Tracked page ${trackedPageId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(p: WebPerformance.TrackedPage): WebPerformanceContracts.TrackedPageDto {
+		return {
+			id: p.id,
+			projectId: p.projectId,
+			url: p.url.value,
+			strategy: p.strategy,
+			addedAt: p.addedAt.toISOString(),
+		};
+	}
+}

--- a/apps/api/src/modules/web-performance/web-performance.module.ts
+++ b/apps/api/src/modules/web-performance/web-performance.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { PageSpeedController } from './page-speed.controller.js';
+
+@Module({
+	controllers: [PageSpeedController],
+})
+export class WebPerformanceModule {}

--- a/apps/web/src/components/track-page-drawer.tsx
+++ b/apps/web/src/components/track-page-drawer.tsx
@@ -1,0 +1,99 @@
+import { Button, Drawer, FormField, Input, Select } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface TrackPageDrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #18 — atomic-design organism. Mobile-first drawer to start
+ * tracking a (URL, strategy) pair for PSI Core Web Vitals. Same URL
+ * with mobile + desktop strategies are two distinct tracked pages so
+ * the operator gets both signals.
+ */
+export const TrackPageDrawer = ({ projectId, open, onClose }: TrackPageDrawerProps) => {
+	const qc = useQueryClient();
+	const [url, setUrl] = useState('');
+	const [strategy, setStrategy] = useState<'mobile' | 'desktop'>('mobile');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setUrl('');
+		setStrategy('mobile');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => api.pageSpeed.track(projectId, { url, strategy }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'page-speed'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to track page'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Track page (PSI / Core Web Vitals)"
+			description="LCP, INP, CLS plus Lighthouse scores will be fetched daily."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="track-page-form" disabled={mutation.isPending || !url}>
+						{mutation.isPending ? 'Tracking…' : 'Track page'}
+					</Button>
+				</>
+			}
+		>
+			<form id="track-page-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField label="URL" hint="Absolute URL of the page (https://example.com/landing).">
+					{(id) => (
+						<Input
+							id={id}
+							value={url}
+							onChange={(e) => setUrl(e.target.value.trim())}
+							placeholder="https://example.com/"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<FormField label="Strategy" hint="Track the same URL twice (mobile + desktop) for both signals.">
+					{(id) => (
+						<Select
+							id={id}
+							value={strategy}
+							onChange={(e) => setStrategy(e.target.value as 'mobile' | 'desktop')}
+						>
+							<option value="mobile">Mobile</option>
+							<option value="desktop">Desktop</option>
+						</Select>
+					)}
+				</FormField>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -1,7 +1,18 @@
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle, EmptyState, Spinner } from '@rankpulse/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
-import { BookOpen, CalendarClock, Check, LineChart, MapPin, Plus, Search, Sparkles, X } from 'lucide-react';
+import {
+	BookOpen,
+	CalendarClock,
+	Check,
+	Gauge,
+	LineChart,
+	MapPin,
+	Plus,
+	Search,
+	Sparkles,
+	X,
+} from 'lucide-react';
 import { useState } from 'react';
 import { AddCompetitorDrawer } from '../components/add-competitor-drawer.js';
 import { AddDomainDrawer } from '../components/add-domain-drawer.js';
@@ -9,12 +20,13 @@ import { AddLocationDrawer } from '../components/add-location-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
 import { LinkWikipediaDrawer } from '../components/link-wikipedia-drawer.js';
+import { TrackPageDrawer } from '../components/track-page-drawer.js';
 import { api } from '../lib/api.js';
 
 export const ProjectDetailPage = () => {
 	const { id } = useParams({ from: '/projects/$id' });
 	const [openDrawer, setOpenDrawer] = useState<
-		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | null
+		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | null
 	>(null);
 
 	const projectQuery = useQuery({
@@ -43,6 +55,12 @@ export const ProjectDetailPage = () => {
 	const wikipediaQuery = useQuery({
 		queryKey: ['project', id, 'wikipedia'],
 		queryFn: () => api.wikipedia.listForProject(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const pageSpeedQuery = useQuery({
+		queryKey: ['project', id, 'page-speed'],
+		queryFn: () => api.pageSpeed.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -263,6 +281,44 @@ export const ProjectDetailPage = () => {
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="flex items-center gap-2 text-base">
+								<Gauge size={14} className="text-primary" />
+								PageSpeed pages ({pageSpeedQuery.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('page-speed')}>
+								<Plus size={14} />
+								Track
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{pageSpeedQuery.isLoading ? (
+								<Spinner />
+							) : pageSpeedQuery.data && pageSpeedQuery.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{pageSpeedQuery.data.map((p) => (
+										<li key={p.id} className="break-words">
+											<Badge variant={p.strategy === 'mobile' ? 'default' : 'secondary'}>{p.strategy}</Badge>{' '}
+											<span className="text-muted-foreground">{p.url}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No pages tracked yet"
+									description="Track a URL (mobile or desktop) to monitor LCP / INP / CLS over time."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('page-speed')}>
+											<Plus size={14} />
+											Track page
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
 								<BookOpen size={14} className="text-primary" />
 								Wikipedia entities ({wikipediaQuery.data?.length ?? '…'})
 							</CardTitle>
@@ -358,6 +414,11 @@ export const ProjectDetailPage = () => {
 			<LinkWikipediaDrawer
 				projectId={id}
 				open={openDrawer === 'wikipedia'}
+				onClose={() => setOpenDrawer(null)}
+			/>
+			<TrackPageDrawer
+				projectId={id}
+				open={openDrawer === 'page-speed'}
 				onClose={() => setOpenDrawer(null)}
 			/>
 		</AppShell>

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
+		"@rankpulse/provider-pagespeed": "workspace:*",
 		"@rankpulse/provider-wikipedia": "workspace:*",
 		"@rankpulse/shared": "workspace:*",
 		"bullmq": "5.76.5",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -4,6 +4,7 @@ import {
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
 	SearchConsoleInsights as SearchConsoleInsightsUseCases,
+	WebPerformance as WebPerformanceUseCases,
 } from '@rankpulse/application';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
 import { SystemClock, SystemIdGenerator } from '@rankpulse/shared';
@@ -35,6 +36,8 @@ async function bootstrap(): Promise<void> {
 	const wikipediaPageviewRepo = new DrizzlePersistence.DrizzleWikipediaPageviewObservationRepository(
 		drizzle.db,
 	);
+	const trackedPageRepo = new DrizzlePersistence.DrizzleTrackedPageRepository(drizzle.db);
+	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -79,6 +82,11 @@ async function bootstrap(): Promise<void> {
 		eventPublisher,
 		SystemClock,
 	);
+	const recordPageSpeedSnapshotUseCase = new WebPerformanceUseCases.RecordPageSpeedSnapshotUseCase(
+		trackedPageRepo,
+		pageSpeedSnapshotRepo,
+		eventPublisher,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -91,6 +99,7 @@ async function bootstrap(): Promise<void> {
 		competitorRepo,
 		gscPropertyRepo,
 		wikipediaArticleRepo,
+		trackedPageRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
@@ -98,6 +107,7 @@ async function bootstrap(): Promise<void> {
 		recordTop10HitsForSuggestionsUseCase,
 		ingestGscRowsUseCase,
 		ingestWikipediaPageviewsUseCase,
+		recordPageSpeedSnapshotUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -4,6 +4,7 @@ import type {
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
 	SearchConsoleInsights as SearchConsoleInsightsUseCases,
+	WebPerformance as WebPerformanceUseCases,
 } from '@rankpulse/application';
 import {
 	type EntityAwareness as EntityAwarenessDomain,
@@ -11,6 +12,7 @@ import {
 	ProviderConnectivity,
 	type RankTracking as RankTrackingDomain,
 	type SearchConsoleInsights as SearchConsoleInsightsDomain,
+	type WebPerformance as WebPerformanceDomain,
 } from '@rankpulse/domain';
 import type { ProviderFetchJobData } from '@rankpulse/infrastructure/queue';
 import type { ProviderRegistry } from '@rankpulse/provider-core';
@@ -25,6 +27,7 @@ import {
 	type SearchAnalyticsParams,
 	type SearchAnalyticsResponse,
 } from '@rankpulse/provider-gsc';
+import { extractSnapshot, PageSpeedApiError, type RunPagespeedResponse } from '@rankpulse/provider-pagespeed';
 import {
 	extractPageviews,
 	type PageviewsPerArticleResponse,
@@ -59,6 +62,9 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 	if (err instanceof GscApiError && err.status === 402) return true;
 	// Wikipedia is a public API, no quota; included for symmetry.
 	if (err instanceof WikipediaApiError && err.status === 402) return true;
+	// PSI returns 429 once the API key burns through its 25k/day. Treat as
+	// quota-exhausted so the JobDefinition auto-pauses until next day.
+	if (err instanceof PageSpeedApiError && (err.status === 402 || err.status === 429)) return true;
 	return false;
 };
 
@@ -79,6 +85,7 @@ export interface ProviderFetchProcessorDeps {
 	competitorRepo: ProjectManagement.CompetitorRepository;
 	gscPropertyRepo: SearchConsoleInsightsDomain.GscPropertyRepository;
 	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
+	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
@@ -86,6 +93,7 @@ export interface ProviderFetchProcessorDeps {
 	recordTop10HitsForSuggestionsUseCase: ProjectManagementUseCases.RecordTop10HitsForSuggestionsUseCase;
 	ingestGscRowsUseCase: SearchConsoleInsightsUseCases.IngestGscRowsUseCase;
 	ingestWikipediaPageviewsUseCase: EntityAwarenessUseCases.IngestWikipediaPageviewsUseCase;
+	recordPageSpeedSnapshotUseCase: WebPerformanceUseCases.RecordPageSpeedSnapshotUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -289,6 +297,31 @@ export class ProviderFetchProcessor {
 							externalDomainsInTop10: external,
 						});
 					}
+				}
+			}
+
+			if (definition.providerId.value === 'pagespeed' && definition.endpointId.value === 'psi-runpagespeed') {
+				// Issue #18 — Core Web Vitals. The job's systemParams must
+				// carry `trackedPageId` (set when the operator tracks a
+				// page via the API/UI). Missing-id case logs warn + skips.
+				const psiParams = resolvedParams as { trackedPageId?: string };
+				if (!psiParams.trackedPageId) {
+					runLog.warn({}, 'psi-runpagespeed job missing trackedPageId in systemParams; skipping ingest');
+				} else {
+					const snapshot = extractSnapshot(fetchResult as RunPagespeedResponse, this.deps.clock.now());
+					await this.deps.recordPageSpeedSnapshotUseCase.execute({
+						trackedPageId: psiParams.trackedPageId,
+						observedAt: snapshot.observedAt,
+						lcpMs: snapshot.lcpMs,
+						inpMs: snapshot.inpMs,
+						cls: snapshot.cls,
+						fcpMs: snapshot.fcpMs,
+						ttfbMs: snapshot.ttfbMs,
+						performanceScore: snapshot.performanceScore,
+						seoScore: snapshot.seoScore,
+						accessibilityScore: snapshot.accessibilityScore,
+						bestPracticesScore: snapshot.bestPracticesScore,
+					});
 				}
 			}
 

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { GscProvider } from '@rankpulse/provider-gsc';
+import { PageSpeedProvider } from '@rankpulse/provider-pagespeed';
 import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
 
 /**
@@ -12,5 +13,6 @@ export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): P
 	registry.register(new DataForSeoProvider({ baseUrl: options.dataforseoBaseUrl }));
 	registry.register(new GscProvider());
 	registry.register(new WikipediaProvider());
+	registry.register(new PageSpeedProvider());
 	return registry;
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -25,6 +25,11 @@
 			"development": "./src/project-management/index.ts",
 			"types": "./dist/project-management/index.d.ts",
 			"default": "./dist/project-management/index.js"
+		},
+		"./web-performance": {
+			"development": "./src/web-performance/index.ts",
+			"types": "./dist/web-performance/index.d.ts",
+			"default": "./dist/web-performance/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.ts
+++ b/packages/application/src/entity-awareness/use-cases/link-wikipedia-article.use-case.ts
@@ -39,7 +39,7 @@ export class LinkWikipediaArticleUseCase {
 		const projectId = cmd.projectId as ProjectManagement.ProjectId;
 
 		const existing = await this.articles.findByProjectAndSlug(projectId, wikipediaProject, slug);
-		if (existing && existing.isActive()) {
+		if (existing?.isActive()) {
 			throw new ConflictError(
 				`Wikipedia article "${slug.value}" on ${wikipediaProject.value} is already linked to this project`,
 			);

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -4,3 +4,4 @@ export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';
 export * as SearchConsoleInsights from './search-console-insights/index.js';
+export * as WebPerformance from './web-performance/index.js';

--- a/packages/application/src/web-performance/index.ts
+++ b/packages/application/src/web-performance/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/query-page-speed-history.use-case.js';
+export * from './use-cases/record-page-speed-snapshot.use-case.js';
+export * from './use-cases/track-page.use-case.js';
+export * from './use-cases/untrack-page.use-case.js';

--- a/packages/application/src/web-performance/use-cases/query-page-speed-history.use-case.ts
+++ b/packages/application/src/web-performance/use-cases/query-page-speed-history.use-case.ts
@@ -1,0 +1,46 @@
+import type { WebPerformance } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface PageSpeedSnapshotView {
+	observedAt: string;
+	lcpMs: number | null;
+	inpMs: number | null;
+	cls: number | null;
+	fcpMs: number | null;
+	ttfbMs: number | null;
+	performanceScore: number | null;
+	seoScore: number | null;
+	accessibilityScore: number | null;
+	bestPracticesScore: number | null;
+}
+
+export interface QueryPageSpeedHistoryQuery {
+	trackedPageId: string;
+	from: Date;
+	to: Date;
+}
+
+export class QueryPageSpeedHistoryUseCase {
+	constructor(
+		private readonly trackedPages: WebPerformance.TrackedPageRepository,
+		private readonly snapshots: WebPerformance.PageSpeedSnapshotRepository,
+	) {}
+
+	async execute(q: QueryPageSpeedHistoryQuery): Promise<readonly PageSpeedSnapshotView[]> {
+		const page = await this.trackedPages.findById(q.trackedPageId as WebPerformance.TrackedPageId);
+		if (!page) throw new NotFoundError(`Tracked page ${q.trackedPageId} not found`);
+		const rows = await this.snapshots.listForPage(page.id, { from: q.from, to: q.to });
+		return rows.map((s) => ({
+			observedAt: s.observedAt.toISOString(),
+			lcpMs: s.lcpMs,
+			inpMs: s.inpMs,
+			cls: s.cls,
+			fcpMs: s.fcpMs,
+			ttfbMs: s.ttfbMs,
+			performanceScore: s.performanceScore,
+			seoScore: s.seoScore,
+			accessibilityScore: s.accessibilityScore,
+			bestPracticesScore: s.bestPracticesScore,
+		}));
+	}
+}

--- a/packages/application/src/web-performance/use-cases/record-page-speed-snapshot.use-case.spec.ts
+++ b/packages/application/src/web-performance/use-cases/record-page-speed-snapshot.use-case.spec.ts
@@ -1,0 +1,136 @@
+import type { IdentityAccess, ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RecordPageSpeedSnapshotUseCase } from './record-page-speed-snapshot.use-case.js';
+import { TrackPageUseCase } from './track-page.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryTrackedPageRepo implements WebPerformance.TrackedPageRepository {
+	readonly store = new Map<string, WebPerformance.TrackedPage>();
+	async save(p: WebPerformance.TrackedPage): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: WebPerformance.TrackedPageId) {
+		return this.store.get(id) ?? null;
+	}
+	async findByTuple() {
+		return null;
+	}
+	async listForProject() {
+		return [...this.store.values()];
+	}
+	async delete() {}
+}
+
+class InMemorySnapshotRepo implements WebPerformance.PageSpeedSnapshotRepository {
+	readonly store = new Map<string, WebPerformance.PageSpeedSnapshot>();
+	async save(snap: WebPerformance.PageSpeedSnapshot): Promise<{ inserted: boolean }> {
+		const key = `${snap.trackedPageId}|${snap.observedAt.toISOString()}`;
+		if (this.store.has(key)) return { inserted: false };
+		this.store.set(key, snap);
+		return { inserted: true };
+	}
+	async listForPage() {
+		return [...this.store.values()];
+	}
+}
+
+describe('RecordPageSpeedSnapshotUseCase', () => {
+	let trackedPageRepo: InMemoryTrackedPageRepo;
+	let snapshotRepo: InMemorySnapshotRepo;
+	let events: RecordingEventPublisher;
+	let pageId: string;
+
+	beforeEach(async () => {
+		trackedPageRepo = new InMemoryTrackedPageRepo();
+		snapshotRepo = new InMemorySnapshotRepo();
+		events = new RecordingEventPublisher();
+		const tracker = new TrackPageUseCase(
+			trackedPageRepo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(['page-1' as Uuid]),
+			events,
+		);
+		const result = await tracker.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/',
+			strategy: 'mobile',
+		});
+		pageId = result.trackedPageId;
+		events.clear();
+	});
+
+	const baseSnapshot = (overrides: Partial<{ observedAt: Date; lcpMs: number | null }> = {}) => ({
+		trackedPageId: pageId,
+		observedAt: overrides.observedAt ?? new Date('2026-05-04T11:00:00Z'),
+		lcpMs: overrides.lcpMs ?? 2400,
+		inpMs: 180,
+		cls: 0.05,
+		fcpMs: 1500,
+		ttfbMs: 400,
+		performanceScore: 0.92,
+		seoScore: 0.95,
+		accessibilityScore: 0.88,
+		bestPracticesScore: 0.91,
+	});
+
+	it('persists the snapshot and publishes PageSpeedSnapshotRecorded on first insert', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		const result = await useCase.execute(baseSnapshot());
+		expect(result.inserted).toBe(true);
+		expect(snapshotRepo.store.size).toBe(1);
+		expect(events.publishedTypes()).toContain('PageSpeedSnapshotRecorded');
+	});
+
+	it('does NOT publish event on idempotent re-fetch (same observedAt)', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		await useCase.execute(baseSnapshot());
+		events.clear();
+		const second = await useCase.execute(baseSnapshot());
+		expect(second.inserted).toBe(false);
+		expect(events.publishedTypes()).toEqual([]);
+	});
+
+	it('throws NotFoundError when the tracked page does not exist', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		await expect(useCase.execute({ ...baseSnapshot(), trackedPageId: 'missing' })).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+
+	it('persists null metrics when PSI returned no CrUX data for the URL', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		await useCase.execute({
+			...baseSnapshot(),
+			lcpMs: null,
+			inpMs: null,
+			cls: null,
+			fcpMs: null,
+			ttfbMs: null,
+			performanceScore: null,
+			seoScore: null,
+			accessibilityScore: null,
+			bestPracticesScore: null,
+		});
+		expect(snapshotRepo.store.size).toBe(1);
+		const [stored] = snapshotRepo.store.values();
+		expect(stored?.lcpMs).toBeNull();
+		expect(stored?.performanceScore).toBeNull();
+	});
+
+	it('rejects scores outside [0,1] at the aggregate boundary', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		await expect(useCase.execute({ ...baseSnapshot(), performanceScore: 1.5 })).rejects.toThrow();
+		expect(snapshotRepo.store.size).toBe(0);
+	});
+
+	it('rejects negative ms metrics at the aggregate boundary', async () => {
+		const useCase = new RecordPageSpeedSnapshotUseCase(trackedPageRepo, snapshotRepo, events);
+		await expect(useCase.execute({ ...baseSnapshot(), lcpMs: -100 })).rejects.toThrow();
+		expect(snapshotRepo.store.size).toBe(0);
+	});
+});

--- a/packages/application/src/web-performance/use-cases/record-page-speed-snapshot.use-case.ts
+++ b/packages/application/src/web-performance/use-cases/record-page-speed-snapshot.use-case.ts
@@ -1,0 +1,73 @@
+import { type SharedKernel, WebPerformance } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface RecordPageSpeedSnapshotCommand {
+	trackedPageId: string;
+	observedAt: Date;
+	lcpMs: number | null;
+	inpMs: number | null;
+	cls: number | null;
+	fcpMs: number | null;
+	ttfbMs: number | null;
+	performanceScore: number | null;
+	seoScore: number | null;
+	accessibilityScore: number | null;
+	bestPracticesScore: number | null;
+}
+
+export interface RecordPageSpeedSnapshotResult {
+	inserted: boolean;
+}
+
+/**
+ * Worker entry point: persists a single PSI snapshot for an existing
+ * tracked page. Idempotent on (trackedPageId, observedAt) — the repo's
+ * `onConflictDoNothing` returns `inserted: false` for collisions and we
+ * skip the domain event so subscribers don't see retries as fresh
+ * data.
+ */
+export class RecordPageSpeedSnapshotUseCase {
+	constructor(
+		private readonly trackedPages: WebPerformance.TrackedPageRepository,
+		private readonly snapshots: WebPerformance.PageSpeedSnapshotRepository,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: RecordPageSpeedSnapshotCommand): Promise<RecordPageSpeedSnapshotResult> {
+		const page = await this.trackedPages.findById(cmd.trackedPageId as WebPerformance.TrackedPageId);
+		if (!page) throw new NotFoundError(`Tracked page ${cmd.trackedPageId} not found`);
+
+		const snapshot = WebPerformance.PageSpeedSnapshot.record({
+			trackedPageId: page.id,
+			projectId: page.projectId,
+			observedAt: cmd.observedAt,
+			lcpMs: cmd.lcpMs,
+			inpMs: cmd.inpMs,
+			cls: cmd.cls,
+			fcpMs: cmd.fcpMs,
+			ttfbMs: cmd.ttfbMs,
+			performanceScore: cmd.performanceScore,
+			seoScore: cmd.seoScore,
+			accessibilityScore: cmd.accessibilityScore,
+			bestPracticesScore: cmd.bestPracticesScore,
+		});
+
+		const { inserted } = await this.snapshots.save(snapshot);
+
+		if (inserted) {
+			await this.events.publish([
+				new WebPerformance.PageSpeedSnapshotRecorded({
+					trackedPageId: page.id,
+					projectId: page.projectId,
+					performanceScore: snapshot.performanceScore,
+					lcpMs: snapshot.lcpMs,
+					inpMs: snapshot.inpMs,
+					cls: snapshot.cls,
+					occurredAt: snapshot.observedAt,
+				}),
+			]);
+		}
+
+		return { inserted };
+	}
+}

--- a/packages/application/src/web-performance/use-cases/track-page.use-case.spec.ts
+++ b/packages/application/src/web-performance/use-cases/track-page.use-case.spec.ts
@@ -1,0 +1,137 @@
+import type { IdentityAccess, ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { ConflictError, FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { describe, expect, it } from 'vitest';
+import { TrackPageUseCase } from './track-page.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryTrackedPageRepo implements WebPerformance.TrackedPageRepository {
+	readonly store = new Map<string, WebPerformance.TrackedPage>();
+	async save(p: WebPerformance.TrackedPage): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: WebPerformance.TrackedPageId) {
+		return this.store.get(id) ?? null;
+	}
+	async findByTuple(
+		projectId: ProjectManagement.ProjectId,
+		url: WebPerformance.PageUrl,
+		strategy: WebPerformance.PageSpeedStrategy,
+	) {
+		for (const p of this.store.values()) {
+			if (p.projectId === projectId && p.url.value === url.value && p.strategy === strategy) return p;
+		}
+		return null;
+	}
+	async listForProject(projectId: ProjectManagement.ProjectId) {
+		return [...this.store.values()].filter((p) => p.projectId === projectId);
+	}
+	async delete(id: WebPerformance.TrackedPageId) {
+		this.store.delete(id);
+	}
+}
+
+const buildClock = () => new FakeClock('2026-05-04T10:00:00Z');
+const buildIds = (...uuids: string[]) => new FixedIdGenerator(uuids as Uuid[]);
+
+describe('TrackPageUseCase', () => {
+	it('persists a fresh tracked page and emits TrackedPageAdded', async () => {
+		const repo = new InMemoryTrackedPageRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new TrackPageUseCase(repo, buildClock(), buildIds('page-1' as never), events);
+
+		const result = await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/landing',
+			strategy: 'mobile',
+		});
+
+		expect(result.trackedPageId).toBe('page-1');
+		expect(repo.store.size).toBe(1);
+		const stored = [...repo.store.values()][0];
+		expect(stored?.url.value).toBe('https://example.com/landing');
+		expect(stored?.strategy).toBe('mobile');
+		expect(events.publishedTypes()).toContain('TrackedPageAdded');
+	});
+
+	it('throws ConflictError when (project, url, strategy) is already tracked', async () => {
+		const repo = new InMemoryTrackedPageRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new TrackPageUseCase(
+			repo,
+			buildClock(),
+			buildIds('page-1' as never, 'page-2' as never),
+			events,
+		);
+		await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/',
+			strategy: 'mobile',
+		});
+		await expect(
+			useCase.execute({
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				url: 'https://example.com/',
+				strategy: 'mobile',
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('allows the same URL with different strategies (mobile + desktop = 2 tracked pages)', async () => {
+		const repo = new InMemoryTrackedPageRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new TrackPageUseCase(
+			repo,
+			buildClock(),
+			buildIds('page-1' as never, 'page-2' as never),
+			events,
+		);
+		await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/',
+			strategy: 'mobile',
+		});
+		await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/',
+			strategy: 'desktop',
+		});
+		expect(repo.store.size).toBe(2);
+	});
+
+	it('strips URL fragments before persisting (canonicalisation)', async () => {
+		const repo = new InMemoryTrackedPageRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new TrackPageUseCase(repo, buildClock(), buildIds('page-1' as never), events);
+		await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			url: 'https://example.com/page#section',
+			strategy: 'mobile',
+		});
+		const stored = [...repo.store.values()][0];
+		expect(stored?.url.value).toBe('https://example.com/page');
+	});
+
+	it('rejects non-http(s) URLs before touching the repo', async () => {
+		const repo = new InMemoryTrackedPageRepo();
+		const events = new RecordingEventPublisher();
+		const useCase = new TrackPageUseCase(repo, buildClock(), buildIds('page-1' as never), events);
+		await expect(
+			useCase.execute({
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				url: 'ftp://example.com/',
+				strategy: 'mobile',
+			}),
+		).rejects.toThrow();
+		expect(repo.store.size).toBe(0);
+	});
+});

--- a/packages/application/src/web-performance/use-cases/track-page.use-case.ts
+++ b/packages/application/src/web-performance/use-cases/track-page.use-case.ts
@@ -1,0 +1,59 @@
+import {
+	type IdentityAccess,
+	type ProjectManagement,
+	type SharedKernel,
+	WebPerformance,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface TrackPageCommand {
+	organizationId: string;
+	projectId: string;
+	url: string;
+	strategy: WebPerformance.PageSpeedStrategy;
+}
+
+export interface TrackPageResult {
+	trackedPageId: string;
+}
+
+/**
+ * Operator action: start tracking a (URL, strategy) pair for PSI runs.
+ * Idempotent at the domain level — if the same tuple is already
+ * tracked, throws ConflictError. The repo's unique index is the
+ * second line of defence against the find→save race.
+ */
+export class TrackPageUseCase {
+	constructor(
+		private readonly trackedPages: WebPerformance.TrackedPageRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: TrackPageCommand): Promise<TrackPageResult> {
+		const url = WebPerformance.PageUrl.create(cmd.url);
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+
+		const existing = await this.trackedPages.findByTuple(projectId, url, cmd.strategy);
+		if (existing) {
+			throw new ConflictError(
+				`Page "${url.value}" with strategy "${cmd.strategy}" is already tracked for this project`,
+			);
+		}
+
+		const id = this.ids.generate() as WebPerformance.TrackedPageId;
+		const page = WebPerformance.TrackedPage.add({
+			id,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			url,
+			strategy: cmd.strategy,
+			now: this.clock.now(),
+		});
+		await this.trackedPages.save(page);
+		await this.events.publish(page.pullEvents());
+
+		return { trackedPageId: id };
+	}
+}

--- a/packages/application/src/web-performance/use-cases/untrack-page.use-case.ts
+++ b/packages/application/src/web-performance/use-cases/untrack-page.use-case.ts
@@ -1,0 +1,17 @@
+import type { WebPerformance } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+/**
+ * Hard-deletes the tracked page and (via the FK cascade) every snapshot
+ * recorded for it. PSI snapshots are inexpensive to recompute if the
+ * operator regrets — re-tracking the URL just starts a fresh history.
+ */
+export class UntrackPageUseCase {
+	constructor(private readonly trackedPages: WebPerformance.TrackedPageRepository) {}
+
+	async execute(trackedPageId: string): Promise<void> {
+		const page = await this.trackedPages.findById(trackedPageId as WebPerformance.TrackedPageId);
+		if (!page) throw new NotFoundError(`Tracked page ${trackedPageId} not found`);
+		await this.trackedPages.delete(page.id);
+	}
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,3 +6,4 @@ export * as RankTrackingContracts from './rank-tracking/index.js';
 export * as SearchConsoleInsightsContracts from './search-console-insights/index.js';
 export * from './shared/pagination.js';
 export * from './shared/problem-details.js';
+export * as WebPerformanceContracts from './web-performance/index.js';

--- a/packages/contracts/src/web-performance/index.ts
+++ b/packages/contracts/src/web-performance/index.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+export const PageSpeedStrategySchema = z.enum(['mobile', 'desktop']);
+export type PageSpeedStrategyDto = z.infer<typeof PageSpeedStrategySchema>;
+
+export const TrackPageRequest = z.object({
+	url: z.string().url(),
+	strategy: PageSpeedStrategySchema,
+});
+export type TrackPageRequest = z.infer<typeof TrackPageRequest>;
+
+export const TrackedPageDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	url: z.string(),
+	strategy: PageSpeedStrategySchema,
+	addedAt: z.string().datetime(),
+});
+export type TrackedPageDto = z.infer<typeof TrackedPageDto>;
+
+export const PageSpeedHistoryQuery = z.object({
+	from: z.string().datetime().optional(),
+	to: z.string().datetime().optional(),
+});
+export type PageSpeedHistoryQuery = z.infer<typeof PageSpeedHistoryQuery>;
+
+export const PageSpeedSnapshotDto = z.object({
+	observedAt: z.string().datetime(),
+	lcpMs: z.number().nonnegative().nullable(),
+	inpMs: z.number().nonnegative().nullable(),
+	cls: z.number().nonnegative().nullable(),
+	fcpMs: z.number().nonnegative().nullable(),
+	ttfbMs: z.number().nonnegative().nullable(),
+	performanceScore: z.number().min(0).max(1).nullable(),
+	seoScore: z.number().min(0).max(1).nullable(),
+	accessibilityScore: z.number().min(0).max(1).nullable(),
+	bestPracticesScore: z.number().min(0).max(1).nullable(),
+});
+export type PageSpeedSnapshotDto = z.infer<typeof PageSpeedSnapshotDto>;

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -45,6 +45,11 @@
 			"development": "./src/shared-kernel/index.ts",
 			"types": "./dist/shared-kernel/index.d.ts",
 			"default": "./dist/shared-kernel/index.js"
+		},
+		"./web-performance": {
+			"development": "./src/web-performance/index.ts",
+			"types": "./dist/web-performance/index.d.ts",
+			"default": "./dist/web-performance/index.js"
 		}
 	},
 	"scripts": {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,3 +5,4 @@ export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';
 export * as SearchConsoleInsights from './search-console-insights/index.js';
 export * as SharedKernel from './shared-kernel/index.js';
+export * as WebPerformance from './web-performance/index.js';

--- a/packages/domain/src/web-performance/entities/page-speed-snapshot.ts
+++ b/packages/domain/src/web-performance/entities/page-speed-snapshot.ts
@@ -1,0 +1,108 @@
+import { InvalidInputError } from '@rankpulse/shared';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+
+export interface PageSpeedSnapshotProps {
+	trackedPageId: TrackedPageId;
+	projectId: ProjectId;
+	observedAt: Date;
+	lcpMs: number | null;
+	inpMs: number | null;
+	cls: number | null;
+	fcpMs: number | null;
+	ttfbMs: number | null;
+	performanceScore: number | null;
+	seoScore: number | null;
+	accessibilityScore: number | null;
+	bestPracticesScore: number | null;
+}
+
+const validateMs = (raw: number | null, label: string): number | null => {
+	if (raw === null) return null;
+	if (!Number.isFinite(raw) || raw < 0) {
+		throw new InvalidInputError(`${label} must be a non-negative finite number or null`);
+	}
+	return raw;
+};
+
+const validateScore = (raw: number | null, label: string): number | null => {
+	if (raw === null) return null;
+	if (!Number.isFinite(raw) || raw < 0 || raw > 1) {
+		throw new InvalidInputError(`${label} must be in [0, 1] or null`);
+	}
+	return raw;
+};
+
+const validateCls = (raw: number | null): number | null => {
+	if (raw === null) return null;
+	if (!Number.isFinite(raw) || raw < 0) {
+		throw new InvalidInputError('cls must be a non-negative finite number or null');
+	}
+	return raw;
+};
+
+/**
+ * Immutable value-like row in the time-series store. Encodes its own
+ * validation rules so the read model can rely on the invariants
+ * (scores in [0, 1], milliseconds non-negative). No domain events;
+ * the IngestPageSpeedSnapshotUseCase publishes the event.
+ */
+export class PageSpeedSnapshot {
+	private constructor(private readonly props: PageSpeedSnapshotProps) {}
+
+	static record(input: PageSpeedSnapshotProps): PageSpeedSnapshot {
+		return new PageSpeedSnapshot({
+			...input,
+			lcpMs: validateMs(input.lcpMs, 'lcpMs'),
+			inpMs: validateMs(input.inpMs, 'inpMs'),
+			cls: validateCls(input.cls),
+			fcpMs: validateMs(input.fcpMs, 'fcpMs'),
+			ttfbMs: validateMs(input.ttfbMs, 'ttfbMs'),
+			performanceScore: validateScore(input.performanceScore, 'performanceScore'),
+			seoScore: validateScore(input.seoScore, 'seoScore'),
+			accessibilityScore: validateScore(input.accessibilityScore, 'accessibilityScore'),
+			bestPracticesScore: validateScore(input.bestPracticesScore, 'bestPracticesScore'),
+		});
+	}
+
+	static rehydrate(props: PageSpeedSnapshotProps): PageSpeedSnapshot {
+		return new PageSpeedSnapshot(props);
+	}
+
+	get trackedPageId(): TrackedPageId {
+		return this.props.trackedPageId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedAt(): Date {
+		return this.props.observedAt;
+	}
+	get lcpMs(): number | null {
+		return this.props.lcpMs;
+	}
+	get inpMs(): number | null {
+		return this.props.inpMs;
+	}
+	get cls(): number | null {
+		return this.props.cls;
+	}
+	get fcpMs(): number | null {
+		return this.props.fcpMs;
+	}
+	get ttfbMs(): number | null {
+		return this.props.ttfbMs;
+	}
+	get performanceScore(): number | null {
+		return this.props.performanceScore;
+	}
+	get seoScore(): number | null {
+		return this.props.seoScore;
+	}
+	get accessibilityScore(): number | null {
+		return this.props.accessibilityScore;
+	}
+	get bestPracticesScore(): number | null {
+		return this.props.bestPracticesScore;
+	}
+}

--- a/packages/domain/src/web-performance/entities/tracked-page.ts
+++ b/packages/domain/src/web-performance/entities/tracked-page.ts
@@ -1,0 +1,80 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { TrackedPageAdded } from '../events/tracked-page-added.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+import type { PageUrl } from '../value-objects/page-url.js';
+import type { PageSpeedStrategy } from '../value-objects/strategy.js';
+
+export interface TrackedPageProps {
+	id: TrackedPageId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	url: PageUrl;
+	strategy: PageSpeedStrategy;
+	addedAt: Date;
+}
+
+/**
+ * A page-strategy pair the operator wants PSI run against on a cron.
+ * `(projectId, url, strategy)` is unique — same URL with mobile +
+ * desktop strategies are two distinct tracked pages so the worker
+ * fires two PSI calls per day.
+ */
+export class TrackedPage extends AggregateRoot {
+	private constructor(private readonly props: TrackedPageProps) {
+		super();
+	}
+
+	static add(input: {
+		id: TrackedPageId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		url: PageUrl;
+		strategy: PageSpeedStrategy;
+		now: Date;
+	}): TrackedPage {
+		const page = new TrackedPage({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			url: input.url,
+			strategy: input.strategy,
+			addedAt: input.now,
+		});
+		page.record(
+			new TrackedPageAdded({
+				trackedPageId: input.id,
+				organizationId: input.organizationId,
+				projectId: input.projectId,
+				url: input.url.value,
+				strategy: input.strategy,
+				occurredAt: input.now,
+			}),
+		);
+		return page;
+	}
+
+	static rehydrate(props: TrackedPageProps): TrackedPage {
+		return new TrackedPage(props);
+	}
+
+	get id(): TrackedPageId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get url(): PageUrl {
+		return this.props.url;
+	}
+	get strategy(): PageSpeedStrategy {
+		return this.props.strategy;
+	}
+	get addedAt(): Date {
+		return this.props.addedAt;
+	}
+}

--- a/packages/domain/src/web-performance/events/page-speed-snapshot-recorded.ts
+++ b/packages/domain/src/web-performance/events/page-speed-snapshot-recorded.ts
@@ -1,0 +1,37 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+
+/**
+ * One event per ingested snapshot. Snapshots are atomic (1 PSI run =
+ * 1 row), so per-row events are fine here — unlike GSC ingestion
+ * which fans out 25k rows.
+ */
+export class PageSpeedSnapshotRecorded implements DomainEvent {
+	readonly type = 'PageSpeedSnapshotRecorded';
+	readonly trackedPageId: TrackedPageId;
+	readonly projectId: ProjectId;
+	readonly performanceScore: number | null;
+	readonly lcpMs: number | null;
+	readonly inpMs: number | null;
+	readonly cls: number | null;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		trackedPageId: TrackedPageId;
+		projectId: ProjectId;
+		performanceScore: number | null;
+		lcpMs: number | null;
+		inpMs: number | null;
+		cls: number | null;
+		occurredAt: Date;
+	}) {
+		this.trackedPageId = props.trackedPageId;
+		this.projectId = props.projectId;
+		this.performanceScore = props.performanceScore;
+		this.lcpMs = props.lcpMs;
+		this.inpMs = props.inpMs;
+		this.cls = props.cls;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/web-performance/events/tracked-page-added.ts
+++ b/packages/domain/src/web-performance/events/tracked-page-added.ts
@@ -1,0 +1,31 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+import type { PageSpeedStrategy } from '../value-objects/strategy.js';
+
+export class TrackedPageAdded implements DomainEvent {
+	readonly type = 'TrackedPageAdded';
+	readonly trackedPageId: TrackedPageId;
+	readonly organizationId: OrganizationId;
+	readonly projectId: ProjectId;
+	readonly url: string;
+	readonly strategy: PageSpeedStrategy;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		trackedPageId: TrackedPageId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		url: string;
+		strategy: PageSpeedStrategy;
+		occurredAt: Date;
+	}) {
+		this.trackedPageId = props.trackedPageId;
+		this.organizationId = props.organizationId;
+		this.projectId = props.projectId;
+		this.url = props.url;
+		this.strategy = props.strategy;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/web-performance/index.ts
+++ b/packages/domain/src/web-performance/index.ts
@@ -1,0 +1,13 @@
+// Entities
+export * from './entities/page-speed-snapshot.js';
+export * from './entities/tracked-page.js';
+// Events
+export * from './events/page-speed-snapshot-recorded.js';
+export * from './events/tracked-page-added.js';
+// Ports
+export * from './ports/page-speed-snapshot-repository.js';
+export * from './ports/tracked-page-repository.js';
+// Value objects
+export * from './value-objects/identifiers.js';
+export * from './value-objects/page-url.js';
+export * from './value-objects/strategy.js';

--- a/packages/domain/src/web-performance/ports/page-speed-snapshot-repository.ts
+++ b/packages/domain/src/web-performance/ports/page-speed-snapshot-repository.ts
@@ -1,0 +1,21 @@
+import type { PageSpeedSnapshot } from '../entities/page-speed-snapshot.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+
+export interface PageSpeedSnapshotQuery {
+	from: Date;
+	to: Date;
+}
+
+export interface PageSpeedSnapshotRepository {
+	/**
+	 * Idempotent on (trackedPageId, observedAt). Returns whether the
+	 * row was newly inserted (true) or collided with an existing one
+	 * (false), so the use case can decide whether to publish the
+	 * domain event.
+	 */
+	save(snapshot: PageSpeedSnapshot): Promise<{ inserted: boolean }>;
+	listForPage(
+		trackedPageId: TrackedPageId,
+		query: PageSpeedSnapshotQuery,
+	): Promise<readonly PageSpeedSnapshot[]>;
+}

--- a/packages/domain/src/web-performance/ports/tracked-page-repository.ts
+++ b/packages/domain/src/web-performance/ports/tracked-page-repository.ts
@@ -1,0 +1,13 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { TrackedPage } from '../entities/tracked-page.js';
+import type { TrackedPageId } from '../value-objects/identifiers.js';
+import type { PageUrl } from '../value-objects/page-url.js';
+import type { PageSpeedStrategy } from '../value-objects/strategy.js';
+
+export interface TrackedPageRepository {
+	save(page: TrackedPage): Promise<void>;
+	findById(id: TrackedPageId): Promise<TrackedPage | null>;
+	findByTuple(projectId: ProjectId, url: PageUrl, strategy: PageSpeedStrategy): Promise<TrackedPage | null>;
+	listForProject(projectId: ProjectId): Promise<readonly TrackedPage[]>;
+	delete(id: TrackedPageId): Promise<void>;
+}

--- a/packages/domain/src/web-performance/value-objects/identifiers.ts
+++ b/packages/domain/src/web-performance/value-objects/identifiers.ts
@@ -1,0 +1,3 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type TrackedPageId = Uuid & { readonly __kind: 'TrackedPageId' };

--- a/packages/domain/src/web-performance/value-objects/page-url.ts
+++ b/packages/domain/src/web-performance/value-objects/page-url.ts
@@ -1,0 +1,31 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Absolute URL of a page tracked for performance metrics. Stored
+ * canonical: scheme + host + path, no fragments. Trailing slash is
+ * preserved (PSI treats `/` and `/index` as different rows).
+ */
+export class PageUrl {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): PageUrl {
+		const trimmed = raw.trim();
+		if (trimmed.length === 0 || trimmed.length > 2048) {
+			throw new InvalidInputError(`PageUrl must be 1-2048 chars (got "${raw}")`);
+		}
+		let parsed: URL;
+		try {
+			parsed = new URL(trimmed);
+		} catch {
+			throw new InvalidInputError(`PageUrl is not a valid absolute URL: "${raw}"`);
+		}
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+			throw new InvalidInputError(`PageUrl must use http(s); got "${parsed.protocol}"`);
+		}
+		// Drop fragment (`#section`) — PSI ignores it but two URLs that
+		// only differ by fragment would otherwise produce two rows in the
+		// unique index for the same canonical resource.
+		parsed.hash = '';
+		return new PageUrl(parsed.toString());
+	}
+}

--- a/packages/domain/src/web-performance/value-objects/strategy.ts
+++ b/packages/domain/src/web-performance/value-objects/strategy.ts
@@ -1,0 +1,8 @@
+export const PageSpeedStrategies = {
+	MOBILE: 'mobile',
+	DESKTOP: 'desktop',
+} as const;
+export type PageSpeedStrategy = (typeof PageSpeedStrategies)[keyof typeof PageSpeedStrategies];
+
+export const isPageSpeedStrategy = (value: unknown): value is PageSpeedStrategy =>
+	value === 'mobile' || value === 'desktop';

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -11,7 +11,6 @@ export { DrizzleKeywordListRepository } from './repositories/project-management/
 export { DrizzlePortfolioRepository } from './repositories/project-management/portfolio.repository.js';
 export { DrizzleProjectRepository } from './repositories/project-management/project.repository.js';
 export { DrizzleApiUsageRepository } from './repositories/provider-connectivity/api-usage.repository.js';
-
 export { DrizzleCredentialRepository } from './repositories/provider-connectivity/credential.repository.js';
 export {
 	computeParamsHash,
@@ -20,9 +19,9 @@ export {
 export { DrizzleJobRunRepository } from './repositories/provider-connectivity/job-run.repository.js';
 export { DrizzleRawPayloadRepository } from './repositories/provider-connectivity/raw-payload.repository.js';
 export { DrizzleRankingObservationRepository } from './repositories/rank-tracking/ranking-observation.repository.js';
-
 export { DrizzleTrackedKeywordRepository } from './repositories/rank-tracking/tracked-keyword.repository.js';
 export { DrizzleGscPerformanceObservationRepository } from './repositories/search-console-insights/gsc-performance-observation.repository.js';
-
 export { DrizzleGscPropertyRepository } from './repositories/search-console-insights/gsc-property.repository.js';
+export { DrizzlePageSpeedSnapshotRepository } from './repositories/web-performance/page-speed-snapshot.repository.js';
+export { DrizzleTrackedPageRepository } from './repositories/web-performance/tracked-page.repository.js';
 export * as schema from './schema/index.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0006_flowery_shotgun.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0006_flowery_shotgun.sql
@@ -1,0 +1,46 @@
+-- Issue #18 — PageSpeed Insights / Core Web Vitals tables. Idempotent
+-- with IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
+
+CREATE TABLE IF NOT EXISTS "tracked_pages" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"url" text NOT NULL,
+	"strategy" text NOT NULL,
+	"added_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "page_speed_snapshots" (
+	"tracked_page_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_at" timestamp with time zone NOT NULL,
+	"lcp_ms" double precision,
+	"inp_ms" double precision,
+	"cls" double precision,
+	"fcp_ms" double precision,
+	"ttfb_ms" double precision,
+	"performance_score" double precision,
+	"seo_score" double precision,
+	"accessibility_score" double precision,
+	"best_practices_score" double precision,
+	CONSTRAINT "page_speed_snapshots_tracked_page_id_observed_at_pk" PRIMARY KEY("tracked_page_id","observed_at")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tracked_pages" ADD CONSTRAINT "tracked_pages_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tracked_pages" ADD CONSTRAINT "tracked_pages_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "page_speed_snapshots" ADD CONSTRAINT "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk" FOREIGN KEY ("tracked_page_id") REFERENCES "public"."tracked_pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "tracked_pages_project_url_strategy_unique" ON "tracked_pages" USING btree ("project_id","url","strategy");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tracked_pages_project_idx" ON "tracked_pages" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "page_speed_snapshots_project_idx" ON "page_speed_snapshots" USING btree ("project_id","observed_at");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0006_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,2684 @@
+{
+	"id": "126ab0ed-c96b-4bb7-b38a-9fd09eb6adb0",
+	"prevId": "a8992533-50de-42c4-9ee3-d055c864108b",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_speed_snapshots": {
+			"name": "page_speed_snapshots",
+			"schema": "",
+			"columns": {
+				"tracked_page_id": {
+					"name": "tracked_page_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lcp_ms": {
+					"name": "lcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"inp_ms": {
+					"name": "inp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cls": {
+					"name": "cls",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fcp_ms": {
+					"name": "fcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ttfb_ms": {
+					"name": "ttfb_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"performance_score": {
+					"name": "performance_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seo_score": {
+					"name": "seo_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessibility_score": {
+					"name": "accessibility_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"best_practices_score": {
+					"name": "best_practices_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"page_speed_snapshots_project_idx": {
+					"name": "page_speed_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_speed_snapshots_tracked_page_id_tracked_pages_id_fk": {
+					"name": "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk",
+					"tableFrom": "page_speed_snapshots",
+					"tableTo": "tracked_pages",
+					"columnsFrom": ["tracked_page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"page_speed_snapshots_tracked_page_id_observed_at_pk": {
+					"name": "page_speed_snapshots_tracked_page_id_observed_at_pk",
+					"columns": ["tracked_page_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_pages": {
+			"name": "tracked_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"strategy": {
+					"name": "strategy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_pages_project_url_strategy_unique": {
+					"name": "tracked_pages_project_url_strategy_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "strategy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_pages_project_idx": {
+					"name": "tracked_pages_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_pages_organization_id_organizations_id_fk": {
+					"name": "tracked_pages_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_pages_project_id_projects_id_fk": {
+					"name": "tracked_pages_project_id_projects_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1778009878203,
 			"tag": "0005_spooky_timeslip",
 			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1778014293229,
+			"tag": "0006_flowery_shotgun",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/web-performance/page-speed-snapshot.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/web-performance/page-speed-snapshot.repository.ts
@@ -1,0 +1,64 @@
+import { type ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { and, between, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { pageSpeedSnapshots } from '../../schema/index.js';
+
+export class DrizzlePageSpeedSnapshotRepository implements WebPerformance.PageSpeedSnapshotRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(snapshot: WebPerformance.PageSpeedSnapshot): Promise<{ inserted: boolean }> {
+		const result = await this.db
+			.insert(pageSpeedSnapshots)
+			.values({
+				trackedPageId: snapshot.trackedPageId,
+				projectId: snapshot.projectId,
+				observedAt: snapshot.observedAt,
+				lcpMs: snapshot.lcpMs,
+				inpMs: snapshot.inpMs,
+				cls: snapshot.cls,
+				fcpMs: snapshot.fcpMs,
+				ttfbMs: snapshot.ttfbMs,
+				performanceScore: snapshot.performanceScore,
+				seoScore: snapshot.seoScore,
+				accessibilityScore: snapshot.accessibilityScore,
+				bestPracticesScore: snapshot.bestPracticesScore,
+			})
+			.onConflictDoNothing({
+				target: [pageSpeedSnapshots.trackedPageId, pageSpeedSnapshots.observedAt],
+			})
+			.returning({ trackedPageId: pageSpeedSnapshots.trackedPageId });
+		return { inserted: result.length > 0 };
+	}
+
+	async listForPage(
+		trackedPageId: WebPerformance.TrackedPageId,
+		query: WebPerformance.PageSpeedSnapshotQuery,
+	): Promise<readonly WebPerformance.PageSpeedSnapshot[]> {
+		const rows = await this.db
+			.select()
+			.from(pageSpeedSnapshots)
+			.where(
+				and(
+					eq(pageSpeedSnapshots.trackedPageId, trackedPageId),
+					between(pageSpeedSnapshots.observedAt, query.from, query.to),
+				),
+			)
+			.orderBy(pageSpeedSnapshots.observedAt);
+		return rows.map((r) =>
+			WebPerformance.PageSpeedSnapshot.rehydrate({
+				trackedPageId: r.trackedPageId as WebPerformance.TrackedPageId,
+				projectId: r.projectId as ProjectManagement.ProjectId,
+				observedAt: r.observedAt,
+				lcpMs: r.lcpMs,
+				inpMs: r.inpMs,
+				cls: r.cls,
+				fcpMs: r.fcpMs,
+				ttfbMs: r.ttfbMs,
+				performanceScore: r.performanceScore,
+				seoScore: r.seoScore,
+				accessibilityScore: r.accessibilityScore,
+				bestPracticesScore: r.bestPracticesScore,
+			}),
+		);
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/web-performance/tracked-page.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/web-performance/tracked-page.repository.ts
@@ -1,0 +1,98 @@
+import { type IdentityAccess, type ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { trackedPages } from '../../schema/index.js';
+
+const UNIQUE_TUPLE_CONSTRAINT = 'tracked_pages_project_url_strategy_unique';
+
+const isUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_TUPLE_CONSTRAINT;
+};
+
+export class DrizzleTrackedPageRepository implements WebPerformance.TrackedPageRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(page: WebPerformance.TrackedPage): Promise<void> {
+		try {
+			await this.db
+				.insert(trackedPages)
+				.values({
+					id: page.id,
+					organizationId: page.organizationId,
+					projectId: page.projectId,
+					url: page.url.value,
+					strategy: page.strategy,
+					addedAt: page.addedAt,
+				})
+				.onConflictDoUpdate({
+					target: trackedPages.id,
+					set: { url: page.url.value, strategy: page.strategy },
+				});
+		} catch (err) {
+			if (isUniqueViolation(err)) {
+				throw new ConflictError(
+					`Tracked page (${page.projectId}, ${page.url.value}, ${page.strategy}) already exists`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(id: WebPerformance.TrackedPageId): Promise<WebPerformance.TrackedPage | null> {
+		const [row] = await this.db.select().from(trackedPages).where(eq(trackedPages.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByTuple(
+		projectId: ProjectManagement.ProjectId,
+		url: WebPerformance.PageUrl,
+		strategy: WebPerformance.PageSpeedStrategy,
+	): Promise<WebPerformance.TrackedPage | null> {
+		const [row] = await this.db
+			.select()
+			.from(trackedPages)
+			.where(
+				and(
+					eq(trackedPages.projectId, projectId),
+					eq(trackedPages.url, url.value),
+					eq(trackedPages.strategy, strategy),
+				),
+			)
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly WebPerformance.TrackedPage[]> {
+		const rows = await this.db
+			.select()
+			.from(trackedPages)
+			.where(eq(trackedPages.projectId, projectId))
+			.orderBy(desc(trackedPages.addedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async delete(id: WebPerformance.TrackedPageId): Promise<void> {
+		await this.db.delete(trackedPages).where(eq(trackedPages.id, id));
+	}
+
+	private toAggregate(row: typeof trackedPages.$inferSelect): WebPerformance.TrackedPage {
+		if (!WebPerformance.isPageSpeedStrategy(row.strategy)) {
+			throw new Error(`Stored tracked page has invalid strategy "${row.strategy}"`);
+		}
+		return WebPerformance.TrackedPage.rehydrate({
+			id: row.id as WebPerformance.TrackedPageId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			url: WebPerformance.PageUrl.create(row.url),
+			strategy: row.strategy,
+			addedAt: row.addedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -511,6 +511,70 @@ export type RankingObservationRow = typeof rankingObservations.$inferSelect;
 export type GscPropertyRow = typeof gscProperties.$inferSelect;
 export type GscObservationRow = typeof gscObservations.$inferSelect;
 
+// ---- web-performance ----
+
+/**
+ * Issue #18 — pages tracked for PSI / Core Web Vitals. Same URL with
+ * mobile vs desktop strategies counts as two separate tracked pages so
+ * the worker fires two PSI calls per day.
+ */
+export const trackedPages = pgTable(
+	'tracked_pages',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		url: text('url').notNull(),
+		strategy: text('strategy').notNull(),
+		addedAt: timestamp('added_at', { withTimezone: true }).notNull().defaultNow(),
+	},
+	(t) => ({
+		uniqueByTuple: uniqueIndex('tracked_pages_project_url_strategy_unique').on(
+			t.projectId,
+			t.url,
+			t.strategy,
+		),
+		projectIdx: index('tracked_pages_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of PSI observations. PK is (tracked_page_id, observed_at)
+ * so re-running the same fetch on the same minute is a no-op.
+ * `*_ms` and score columns nullable: PSI returns null for buckets
+ * without enough CrUX data; we persist what we got.
+ */
+export const pageSpeedSnapshots = pgTable(
+	'page_speed_snapshots',
+	{
+		trackedPageId: uuid('tracked_page_id')
+			.notNull()
+			.references(() => trackedPages.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedAt: timestamp('observed_at', { withTimezone: true }).notNull(),
+		lcpMs: doublePrecision('lcp_ms'),
+		inpMs: doublePrecision('inp_ms'),
+		cls: doublePrecision('cls'),
+		fcpMs: doublePrecision('fcp_ms'),
+		ttfbMs: doublePrecision('ttfb_ms'),
+		performanceScore: doublePrecision('performance_score'),
+		seoScore: doublePrecision('seo_score'),
+		accessibilityScore: doublePrecision('accessibility_score'),
+		bestPracticesScore: doublePrecision('best_practices_score'),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.trackedPageId, t.observedAt] }),
+		projectIdx: index('page_speed_snapshots_project_idx').on(t.projectId, t.observedAt),
+	}),
+);
+
+export type TrackedPageRow = typeof trackedPages.$inferSelect;
+export type PageSpeedSnapshotRow = typeof pageSpeedSnapshots.$inferSelect;
+
 // ---- entity-awareness ----
 
 /**

--- a/packages/providers/pagespeed/package.json
+++ b/packages/providers/pagespeed/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rankpulse/provider-pagespeed",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/pagespeed/src/acl/psi-to-snapshot.acl.spec.ts
+++ b/packages/providers/pagespeed/src/acl/psi-to-snapshot.acl.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { RunPagespeedResponse } from '../endpoints/runpagespeed.js';
+import { extractSnapshot } from './psi-to-snapshot.acl.js';
+
+const NOW = new Date('2026-05-04T10:00:00Z');
+
+describe('extractSnapshot', () => {
+	it('returns all-null when payload has neither field nor lab data', () => {
+		const out = extractSnapshot({}, NOW);
+		expect(out.lcpMs).toBeNull();
+		expect(out.cls).toBeNull();
+		expect(out.performanceScore).toBeNull();
+		expect(out.observedAt).toBe(NOW);
+	});
+
+	it('uses analysisUTCTimestamp when present, fallback to now() otherwise', () => {
+		const withTs = extractSnapshot({ analysisUTCTimestamp: '2026-05-01T08:00:00Z' }, NOW);
+		expect(withTs.observedAt.toISOString()).toBe('2026-05-01T08:00:00.000Z');
+		const withoutTs = extractSnapshot({}, NOW);
+		expect(withoutTs.observedAt).toBe(NOW);
+	});
+
+	it('falls back to now() if analysisUTCTimestamp is malformed', () => {
+		const out = extractSnapshot({ analysisUTCTimestamp: 'not-a-date' }, NOW);
+		expect(out.observedAt).toBe(NOW);
+	});
+
+	it('reads CrUX field metrics from loadingExperience preferentially', () => {
+		const payload: RunPagespeedResponse = {
+			loadingExperience: {
+				metrics: {
+					LARGEST_CONTENTFUL_PAINT_MS: { percentile: 2400 },
+					INTERACTION_TO_NEXT_PAINT: { percentile: 180 },
+					CUMULATIVE_LAYOUT_SHIFT_SCORE: { percentile: 5 }, // CrUX returns CLS×100
+				},
+			},
+		};
+		const out = extractSnapshot(payload, NOW);
+		expect(out.lcpMs).toBe(2400);
+		expect(out.inpMs).toBe(180);
+		expect(out.cls).toBeCloseTo(0.05, 5);
+	});
+
+	it('falls back to originLoadingExperience when URL-level metrics are missing (low-traffic page)', () => {
+		const payload: RunPagespeedResponse = {
+			originLoadingExperience: {
+				metrics: {
+					LARGEST_CONTENTFUL_PAINT_MS: { percentile: 3000 },
+				},
+			},
+		};
+		const out = extractSnapshot(payload, NOW);
+		expect(out.lcpMs).toBe(3000);
+	});
+
+	it('reads Lighthouse category scores (0-1)', () => {
+		const payload: RunPagespeedResponse = {
+			lighthouseResult: {
+				categories: {
+					performance: { score: 0.92 },
+					seo: { score: 1.0 },
+					accessibility: { score: 0.88 },
+					'best-practices': { score: 0.75 },
+				},
+			},
+		};
+		const out = extractSnapshot(payload, NOW);
+		expect(out.performanceScore).toBe(0.92);
+		expect(out.seoScore).toBe(1);
+		expect(out.accessibilityScore).toBe(0.88);
+		expect(out.bestPracticesScore).toBe(0.75);
+	});
+
+	it('treats non-finite percentiles as null (PSI returns null when bucket is empty)', () => {
+		const payload: RunPagespeedResponse = {
+			loadingExperience: {
+				metrics: {
+					LARGEST_CONTENTFUL_PAINT_MS: { percentile: Number.NaN },
+				},
+			},
+		};
+		expect(extractSnapshot(payload, NOW).lcpMs).toBeNull();
+	});
+
+	it('treats lighthouse score=null (audit not run) as null in the snapshot', () => {
+		const payload: RunPagespeedResponse = {
+			lighthouseResult: {
+				categories: {
+					performance: { score: null },
+				},
+			},
+		};
+		expect(extractSnapshot(payload, NOW).performanceScore).toBeNull();
+	});
+});

--- a/packages/providers/pagespeed/src/acl/psi-to-snapshot.acl.ts
+++ b/packages/providers/pagespeed/src/acl/psi-to-snapshot.acl.ts
@@ -1,0 +1,82 @@
+import type { RunPagespeedResponse } from '../endpoints/runpagespeed.js';
+
+/**
+ * Domain-shaped snapshot of a PSI run, ready to persist as one row in
+ * the time-series. Combines the field-metric percentiles (CrUX, what
+ * Google ranks against) with the lab-metric scores (Lighthouse).
+ *
+ * All numeric fields are nullable because PSI returns null/missing
+ * for URLs without enough CrUX data (cold pages, internal admin
+ * dashboards, sites that opted out). We persist what we got — the
+ * read model can decide how to render gaps.
+ */
+export interface PageSpeedSnapshotExtraction {
+	observedAt: Date;
+	// CrUX field metrics (75th percentile, real users)
+	lcpMs: number | null;
+	inpMs: number | null;
+	cls: number | null;
+	fcpMs: number | null;
+	ttfbMs: number | null;
+	// Lighthouse lab scores (0-1, multiply by 100 for the typical UI display)
+	performanceScore: number | null;
+	seoScore: number | null;
+	accessibilityScore: number | null;
+	bestPracticesScore: number | null;
+}
+
+const FIELD_METRIC_KEYS = {
+	lcp: 'LARGEST_CONTENTFUL_PAINT_MS',
+	inp: 'INTERACTION_TO_NEXT_PAINT',
+	cls: 'CUMULATIVE_LAYOUT_SHIFT_SCORE',
+	fcp: 'FIRST_CONTENTFUL_PAINT_MS',
+	ttfb: 'EXPERIMENTAL_TIME_TO_FIRST_BYTE',
+} as const;
+
+/**
+ * Both `loadingExperience.metrics` and `originLoadingExperience.metrics`
+ * carry entries with `percentile?: number`. We only read that one field
+ * so a structural type covers both shapes.
+ */
+type PercentileMetrics = Record<string, { percentile?: number } | undefined>;
+
+const readPercentile = (metrics: PercentileMetrics | undefined, key: string, scale = 1): number | null => {
+	const raw = metrics?.[key]?.percentile;
+	if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+	return raw / scale;
+};
+
+const readScore = (
+	categories: NonNullable<NonNullable<RunPagespeedResponse['lighthouseResult']>['categories']>,
+	key: string,
+): number | null => {
+	const raw = categories[key]?.score;
+	if (typeof raw !== 'number' || !Number.isFinite(raw)) return null;
+	return raw;
+};
+
+/**
+ * Pure ACL: PSI v5 payload → typed snapshot. Falls back to
+ * originLoadingExperience when the URL-level loadingExperience is
+ * missing (low-traffic page that doesn't have its own CrUX bucket;
+ * Google rolls up to origin in that case).
+ */
+export const extractSnapshot = (payload: RunPagespeedResponse, now: Date): PageSpeedSnapshotExtraction => {
+	const observedAt = payload.analysisUTCTimestamp ? new Date(payload.analysisUTCTimestamp) : now;
+	const fieldMetrics = payload.loadingExperience?.metrics ?? payload.originLoadingExperience?.metrics ?? {};
+	const categories = payload.lighthouseResult?.categories ?? {};
+
+	return {
+		observedAt: Number.isFinite(observedAt.getTime()) ? observedAt : now,
+		lcpMs: readPercentile(fieldMetrics, FIELD_METRIC_KEYS.lcp),
+		inpMs: readPercentile(fieldMetrics, FIELD_METRIC_KEYS.inp),
+		// CLS comes back as integer * 100 in CrUX (a CLS of 0.1 → percentile 10)
+		cls: readPercentile(fieldMetrics, FIELD_METRIC_KEYS.cls, 100),
+		fcpMs: readPercentile(fieldMetrics, FIELD_METRIC_KEYS.fcp),
+		ttfbMs: readPercentile(fieldMetrics, FIELD_METRIC_KEYS.ttfb),
+		performanceScore: readScore(categories, 'performance'),
+		seoScore: readScore(categories, 'seo'),
+		accessibilityScore: readScore(categories, 'accessibility'),
+		bestPracticesScore: readScore(categories, 'best-practices'),
+	};
+};

--- a/packages/providers/pagespeed/src/endpoints/runpagespeed.ts
+++ b/packages/providers/pagespeed/src/endpoints/runpagespeed.ts
@@ -1,0 +1,88 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { PageSpeedHttp } from '../http.js';
+
+/**
+ * `runPagespeed` — Lighthouse audit + CrUX (real-user metrics) for a
+ * single URL. PSI returns BOTH lab metrics (lighthouseResult) and
+ * field metrics (loadingExperience). For SEO purposes the field
+ * metrics are what Google ranks against.
+ */
+export const RunPagespeedParams = z.object({
+	url: z.string().url(),
+	strategy: z.enum(['mobile', 'desktop']).default('mobile'),
+	category: z
+		.array(z.enum(['performance', 'accessibility', 'best-practices', 'seo', 'pwa']))
+		.default(['performance', 'seo', 'best-practices', 'accessibility']),
+	locale: z.string().min(2).max(10).default('en'),
+});
+export type RunPagespeedParams = z.infer<typeof RunPagespeedParams>;
+
+/** Free quota — cost ledger is informational only. */
+export const PSI_COST_CENTS = 0;
+
+export const runPagespeedDescriptor: EndpointDescriptor = {
+	id: 'psi-runpagespeed',
+	category: 'onpage',
+	displayName: 'PageSpeed Insights — runPagespeed',
+	description:
+		'Lab metrics (Lighthouse) + field metrics (CrUX): LCP, INP, CLS, FCP, TTFB plus performance/SEO/accessibility scores for a URL.',
+	paramsSchema: RunPagespeedParams,
+	cost: { unit: 'usd_cents', amount: PSI_COST_CENTS },
+	defaultCron: '0 3 * * *',
+	rateLimit: { max: 1, durationMs: 1_000 },
+};
+
+const PATH = '/pagespeedonline/v5/runPagespeed';
+
+/** Subset of the PSI v5 response we actually care about. */
+export interface RunPagespeedResponse {
+	id?: string;
+	loadingExperience?: {
+		metrics?: Record<
+			string,
+			{
+				percentile?: number;
+				category?: 'FAST' | 'AVERAGE' | 'SLOW';
+				distributions?: Array<{ min: number; max?: number; proportion: number }>;
+			}
+		>;
+		overall_category?: string;
+	};
+	originLoadingExperience?: {
+		metrics?: Record<string, { percentile?: number; category?: string }>;
+	};
+	lighthouseResult?: {
+		categories?: Record<string, { score?: number | null }>;
+		audits?: Record<
+			string,
+			{
+				score?: number | null;
+				numericValue?: number;
+				displayValue?: string;
+			}
+		>;
+	};
+	analysisUTCTimestamp?: string;
+}
+
+export const fetchRunPagespeed = async (
+	http: PageSpeedHttp,
+	params: RunPagespeedParams,
+	apiKey: string,
+	ctx: FetchContext,
+): Promise<RunPagespeedResponse> => {
+	const query: Record<string, string | string[]> = {
+		url: params.url,
+		strategy: params.strategy,
+		locale: params.locale,
+		category: params.category,
+		key: apiKey,
+	};
+	const raw = (await http.get(PATH, query, ctx.signal)) as RunPagespeedResponse;
+	if (!raw || typeof raw !== 'object') {
+		ctx.logger.warn('PSI returned empty or non-object response', { raw });
+		return {};
+	}
+	return raw;
+};

--- a/packages/providers/pagespeed/src/http.ts
+++ b/packages/providers/pagespeed/src/http.ts
@@ -1,0 +1,80 @@
+/**
+ * Google PageSpeed Insights v5 client. Auth: API key as query param.
+ * Free tier: 1 req/sec, 25k/day per key. Without a key Google still
+ * accepts the request but applies a much harsher per-IP throttle that
+ * would fail in shared egress (CI runners, bursty cron). The descriptor
+ * declares the rate limit so the scheduling layer doesn't over-fan-out.
+ */
+
+export interface PageSpeedHttpOptions {
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_BASE_URL = 'https://www.googleapis.com';
+
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+export class PageSpeedHttp {
+	private readonly baseUrl: string;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: PageSpeedHttpOptions = {}) {
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	}
+
+	async get(path: string, query: Record<string, string | string[]>, signal?: AbortSignal): Promise<unknown> {
+		const params = new URLSearchParams();
+		for (const [k, v] of Object.entries(query)) {
+			if (Array.isArray(v)) for (const item of v) params.append(k, item);
+			else params.append(k, v);
+		}
+		const url = `${this.baseUrl}${path}?${params.toString()}`;
+		const response = await this.fetchImpl(url, {
+			method: 'GET',
+			headers: { Accept: 'application/json' },
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new PageSpeedApiError(
+				response.status,
+				null,
+				`PSI ${path} response too large: ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new PageSpeedApiError(
+				response.status,
+				null,
+				`PSI ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new PageSpeedApiError(response.status, parsed, `PSI ${path} returned HTTP ${response.status}`);
+		}
+		return parsed;
+	}
+}
+
+export class PageSpeedApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'PageSpeedApiError';
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/pagespeed/src/index.ts
+++ b/packages/providers/pagespeed/src/index.ts
@@ -1,0 +1,4 @@
+export * from './acl/psi-to-snapshot.acl.js';
+export * from './endpoints/runpagespeed.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/pagespeed/src/provider.spec.ts
+++ b/packages/providers/pagespeed/src/provider.spec.ts
@@ -1,0 +1,72 @@
+import type { FetchContext } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import { describe, expect, it } from 'vitest';
+import { PageSpeedProvider } from './provider.js';
+
+const validKey = 'AIzaSyDxxxxxxxxxxxxxxxxxxxxxxxxxx';
+
+const stubContext = (key = validKey): FetchContext => ({
+	credential: { plaintextSecret: key },
+	logger: { debug: () => {}, warn: () => {} },
+	now: () => new Date('2026-05-04T10:00:00Z'),
+});
+
+describe('PageSpeedProvider', () => {
+	it('exposes the runPagespeed endpoint', () => {
+		const provider = new PageSpeedProvider();
+		expect(provider.discover().map((e) => e.id)).toEqual(['psi-runpagespeed']);
+	});
+
+	it('every descriptor declares a non-empty defaultCron (BACKLOG #21)', () => {
+		const provider = new PageSpeedProvider();
+		for (const d of provider.discover()) {
+			expect(d.defaultCron).toMatch(/^\S+ \S+ \S+ \S+ \S+$/);
+		}
+	});
+
+	it('rejects too-short API keys with InvalidInputError', () => {
+		const provider = new PageSpeedProvider();
+		expect(() => provider.validateCredentialPlaintext('short')).toThrow(InvalidInputError);
+	});
+
+	it('accepts a well-formed API key', () => {
+		const provider = new PageSpeedProvider();
+		expect(() => provider.validateCredentialPlaintext(validKey)).not.toThrow();
+	});
+
+	it('rejects unknown endpoint ids', async () => {
+		const provider = new PageSpeedProvider();
+		await expect(provider.fetch('bogus', {}, stubContext())).rejects.toThrow(/no endpoint/);
+	});
+
+	it('rejects malformed params with InvalidInputError', async () => {
+		const provider = new PageSpeedProvider();
+		await expect(provider.fetch('psi-runpagespeed', { url: 'not-a-url' }, stubContext())).rejects.toThrow();
+	});
+
+	it('forwards a properly shaped request and returns the typed response', async () => {
+		let capturedUrl: string | undefined;
+		const fakeFetch = async (url: RequestInfo | URL): Promise<Response> => {
+			capturedUrl = String(url);
+			return new Response(
+				JSON.stringify({
+					id: 'https://example.com/',
+					analysisUTCTimestamp: '2026-05-04T09:00:00Z',
+					lighthouseResult: { categories: { performance: { score: 0.9 } } },
+				}),
+				{ status: 200, headers: { 'content-type': 'application/json' } },
+			);
+		};
+		const provider = new PageSpeedProvider({ fetchImpl: fakeFetch as typeof fetch });
+		const result = (await provider.fetch(
+			'psi-runpagespeed',
+			{ url: 'https://example.com', strategy: 'mobile' },
+			stubContext(),
+		)) as { id?: string };
+		expect(capturedUrl).toContain('/pagespeedonline/v5/runPagespeed');
+		expect(capturedUrl).toContain('url=https%3A%2F%2Fexample.com');
+		expect(capturedUrl).toContain('strategy=mobile');
+		expect(capturedUrl).toContain(`key=${validKey}`);
+		expect(result.id).toBe('https://example.com/');
+	});
+});

--- a/packages/providers/pagespeed/src/provider.ts
+++ b/packages/providers/pagespeed/src/provider.ts
@@ -1,0 +1,68 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import {
+	fetchRunPagespeed,
+	type RunPagespeedParams,
+	runPagespeedDescriptor,
+} from './endpoints/runpagespeed.js';
+import { PageSpeedHttp, type PageSpeedHttpOptions } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [runPagespeedDescriptor];
+
+const API_KEY_REGEX = /^[A-Za-z0-9_-]{20,}$/;
+
+/**
+ * Google PageSpeed Insights provider — v1.1 free expansion (issue #18).
+ *
+ * Auth: a single API key from Google Cloud Console (PSI v5). The
+ * plaintext credential is just the key string; we validate the
+ * minimum shape (alphanumeric + `_` / `-`, length >= 20) so a typo at
+ * registration time fails fast instead of becoming a runtime 403 in
+ * the worker.
+ */
+export class PageSpeedProvider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('pagespeed');
+	readonly displayName = 'Google PageSpeed Insights';
+	readonly authStrategy = 'apiKey' as const;
+
+	private readonly http: PageSpeedHttp;
+
+	constructor(options?: PageSpeedHttpOptions) {
+		this.http = new PageSpeedHttp(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		if (!API_KEY_REGEX.test(plaintextSecret)) {
+			throw new InvalidInputError(
+				'PageSpeed Insights API key must be at least 20 characters of [A-Za-z0-9_-]',
+			);
+		}
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case runPagespeedDescriptor.id:
+				return await fetchRunPagespeed(
+					this.http,
+					this.parseParams(runPagespeedDescriptor, params) as RunPagespeedParams,
+					ctx.credential.plaintextSecret,
+					ctx,
+				);
+			default:
+				throw new InvalidInputError(`PageSpeed has no endpoint "${endpointId}"`);
+		}
+	}
+
+	private parseParams(descriptor: EndpointDescriptor, raw: unknown): unknown {
+		const parsed = descriptor.paramsSchema.safeParse(raw);
+		if (!parsed.success) {
+			throw new InvalidInputError(`Invalid params for ${descriptor.id}: ${parsed.error.message}`);
+		}
+		return parsed.data;
+	}
+}

--- a/packages/providers/pagespeed/tsconfig.build.json
+++ b/packages/providers/pagespeed/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/pagespeed/tsconfig.json
+++ b/packages/providers/pagespeed/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/pagespeed/vitest.config.ts
+++ b/packages/providers/pagespeed/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,7 @@
 import { HttpClient, type HttpClientOptions } from './http.js';
 import { AuthResource } from './resources/auth.js';
 import { GscResource } from './resources/gsc.js';
+import { PageSpeedResource } from './resources/page-speed.js';
 import { ProjectsResource } from './resources/projects.js';
 import { ProvidersResource } from './resources/providers.js';
 import { RankTrackingResource } from './resources/rank-tracking.js';
@@ -19,6 +20,7 @@ export class RankPulseClient {
 	readonly rankTracking: RankTrackingResource;
 	readonly gsc: GscResource;
 	readonly wikipedia: WikipediaResource;
+	readonly pageSpeed: PageSpeedResource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -30,5 +32,6 @@ export class RankPulseClient {
 		this.rankTracking = new RankTrackingResource(http);
 		this.gsc = new GscResource(http);
 		this.wikipedia = new WikipediaResource(http);
+		this.pageSpeed = new PageSpeedResource(http);
 	}
 }

--- a/packages/sdk/src/resources/page-speed.ts
+++ b/packages/sdk/src/resources/page-speed.ts
@@ -1,0 +1,30 @@
+import type { WebPerformanceContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class PageSpeedResource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<WebPerformanceContracts.TrackedPageDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/page-speed/pages`);
+	}
+
+	track(
+		projectId: string,
+		body: WebPerformanceContracts.TrackPageRequest,
+	): Promise<{ trackedPageId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/page-speed/pages`, body);
+	}
+
+	untrack(trackedPageId: string): Promise<{ ok: true }> {
+		return this.http.delete(`/page-speed/pages/${encodeURIComponent(trackedPageId)}`);
+	}
+
+	history(
+		trackedPageId: string,
+		query?: WebPerformanceContracts.PageSpeedHistoryQuery,
+	): Promise<WebPerformanceContracts.PageSpeedSnapshotDto[]> {
+		return this.http.get(`/page-speed/pages/${encodeURIComponent(trackedPageId)}/history`, {
+			query: { from: query?.from ?? null, to: query?.to ?? null },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
+      '@rankpulse/provider-pagespeed':
+        specifier: workspace:*
+        version: link:../../packages/providers/pagespeed
       '@rankpulse/provider-wikipedia':
         specifier: workspace:*
         version: link:../../packages/providers/wikipedia
@@ -383,6 +386,28 @@ importers:
       google-auth-library:
         specifier: 10.6.2
         version: 10.6.2
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/pagespeed:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
Closes #18.

## Summary
- New provider package `@rankpulse/provider-pagespeed`: PSI v5 client (8 MB body cap), `psi-runpagespeed` descriptor (cron `0 3 * * *`, rate-limit 1 req/s aligned to free tier), pure ACL `extractSnapshot()` mapping CrUX field metrics + Lighthouse lab scores into a typed snapshot. Falls back to `originLoadingExperience` when the URL has no own CrUX bucket.
- New `web-performance` bounded context: `TrackedPage` aggregate (URL + strategy + active flag) and `PageSpeedSnapshot` value with strict invariants — scores in `[0, 1]`, ms metrics `>= 0`, all metrics nullable to honour the "no CrUX data" reality. Repository ports and domain events (`TrackedPageAdded`, `PageSpeedSnapshotRecorded`).
- Drizzle migration 0006 — `tracked_pages` (uniqueness on `(project_id, url, strategy)`) + `page_speed_snapshots` (natural PK `(tracked_page_id, observed_at)`) for idempotent re-fetches; rewritten with `IF NOT EXISTS` + `DO $$ EXCEPTION duplicate_object $$` guards so reruns are safe.
- Application layer — `TrackPageUseCase`, `UntrackPageUseCase`, `RecordPageSpeedSnapshotUseCase` (returns `{inserted}` so the worker can swallow duplicate observations and only emit the domain event on first insert), `QueryPageSpeedHistoryUseCase`. 11 unit tests covering happy path, idempotency, NotFound, score/ms boundary rejection.
- Worker — provider registered, processor dispatches `psi-runpagespeed` to ACL + record use case, classifies `402`/`429` from PSI as quota exhausted so the existing scheduler handles backoff.
- API — `GET/POST/DELETE /web-performance/...` endpoints in `WebPerformanceModule` with the same IDOR-safe 404-collapse pattern used elsewhere.
- SDK — `pageSpeed` resource (`track`, `untrack`, `list`, `history`).
- UI — atomic-design `TrackPageDrawer` organism + new card on the project detail page (URL input + mobile/desktop strategy select, mobile-first).

## Pipeline status (local)
- `pnpm lint` — clean (biome `check .`).
- `pnpm typecheck` — 16/16 packages OK.
- `pnpm test` — all 16 workspaces green; 106 application tests, 15 PSI provider tests added.
- `pnpm build` — full monorepo build green.

## Test plan
- [ ] CI green (format/lint/typecheck/tests/coverage).
- [ ] Migration `0006_flowery_shotgun.sql` applies cleanly on the existing prod database (forward-only, idempotent).
- [ ] After deploy, register a PSI credential, link a TrackedPage, trigger run-now and confirm a row lands in `page_speed_snapshots` with the CrUX/Lighthouse fields populated (or NULL where PSI returned no data).
- [ ] Re-run the same job and verify it does not duplicate (PK conflict swallowed, no duplicate `PageSpeedSnapshotRecorded`).