### PR TITLE
feat: GA4 Data API provider + traffic-analytics context (#17)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
 		"@rankpulse/infrastructure": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
+		"@rankpulse/provider-ga4": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
 		"@rankpulse/shared": "workspace:*",
 		"drizzle-orm": "0.45.2",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { ProjectManagementModule } from './modules/project-management/project-ma
 import { ProviderConnectivityModule } from './modules/provider-connectivity/provider-connectivity.module.js';
 import { RankTrackingModule } from './modules/rank-tracking/rank-tracking.module.js';
 import { SearchConsoleInsightsModule } from './modules/search-console-insights/search-console-insights.module.js';
+import { TrafficAnalyticsModule } from './modules/traffic-analytics/traffic-analytics.module.js';
 import { WebPerformanceModule } from './modules/web-performance/web-performance.module.js';
 import { OpenApiModule } from './openapi/openapi.module.js';
 
@@ -46,6 +47,7 @@ export class AppModule {
 			SearchConsoleInsightsModule,
 			EntityAwarenessModule,
 			WebPerformanceModule,
+			TrafficAnalyticsModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -6,12 +6,14 @@ import {
 	ProjectManagement as PMUseCases,
 	RankTracking as RTUseCases,
 	SearchConsoleInsights as SCIUseCases,
+	TrafficAnalytics as TAUseCases,
 	WebPerformance as WPUseCases,
 } from '@rankpulse/application';
 import type { ProjectManagement } from '@rankpulse/domain';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
+import { Ga4Provider } from '@rankpulse/provider-ga4';
 import { GscProvider } from '@rankpulse/provider-gsc';
 import { InvalidInputError, SystemClock, SystemIdGenerator } from '@rankpulse/shared';
 import { JwtService } from '../common/auth/jwt.service.js';
@@ -66,6 +68,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	);
 	const trackedPageRepo = new DrizzlePersistence.DrizzleTrackedPageRepository(drizzle.db);
 	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
+	const ga4PropertyRepo = new DrizzlePersistence.DrizzleGa4PropertyRepository(drizzle.db);
+	const ga4DailyMetricRepo = new DrizzlePersistence.DrizzleGa4DailyMetricRepository(drizzle.db);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -74,6 +78,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const providerRegistry = new ProviderRegistry();
 	providerRegistry.register(new DataForSeoProvider());
 	providerRegistry.register(new GscProvider());
+	providerRegistry.register(new Ga4Provider());
 
 	const registerOrganization = new IAUseCases.RegisterOrganizationUseCase(
 		orgRepo,
@@ -267,6 +272,16 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		pageSpeedSnapshotRepo,
 	);
 
+	// Issue #17 — traffic-analytics (GA4) use cases
+	const linkGa4Property = new TAUseCases.LinkGa4PropertyUseCase(
+		ga4PropertyRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const unlinkGa4Property = new TAUseCases.UnlinkGa4PropertyUseCase(ga4PropertyRepo, SystemClock);
+	const queryGa4Metrics = new TAUseCases.QueryGa4MetricsUseCase(ga4PropertyRepo, ga4DailyMetricRepo);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -365,6 +380,12 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.LinkWikipediaArticle, linkWikipediaArticle),
 		value(Tokens.UnlinkWikipediaArticle, unlinkWikipediaArticle),
 		value(Tokens.QueryWikipediaPageviews, queryWikipediaPageviews),
+
+		value(Tokens.Ga4PropertyRepository, ga4PropertyRepo),
+		value(Tokens.Ga4DailyMetricRepository, ga4DailyMetricRepo),
+		value(Tokens.LinkGa4Property, linkGa4Property),
+		value(Tokens.UnlinkGa4Property, unlinkGa4Property),
+		value(Tokens.QueryGa4Metrics, queryGa4Metrics),
 	];
 
 	return {

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -104,6 +104,15 @@ export const Tokens = {
 	UntrackPage: Symbol('UntrackPageUseCase'),
 	QueryPageSpeedHistory: Symbol('QueryPageSpeedHistoryUseCase'),
 
+	// Traffic-Analytics (GA4) ports
+	Ga4PropertyRepository: Symbol('Ga4PropertyRepository'),
+	Ga4DailyMetricRepository: Symbol('Ga4DailyMetricRepository'),
+
+	// Traffic-Analytics (GA4) use cases
+	LinkGa4Property: Symbol('LinkGa4PropertyUseCase'),
+	UnlinkGa4Property: Symbol('UnlinkGa4PropertyUseCase'),
+	QueryGa4Metrics: Symbol('QueryGa4MetricsUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/traffic-analytics/ga4.controller.ts
+++ b/apps/api/src/modules/traffic-analytics/ga4.controller.ts
@@ -1,0 +1,114 @@
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { TrafficAnalytics as TAUseCases } from '@rankpulse/application';
+import { TrafficAnalyticsContracts } from '@rankpulse/contracts';
+import type { IdentityAccess, ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+@Controller()
+export class Ga4Controller {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.LinkGa4Property) private readonly linkProperty: TAUseCases.LinkGa4PropertyUseCase,
+		@Inject(Tokens.UnlinkGa4Property) private readonly unlinkProperty: TAUseCases.UnlinkGa4PropertyUseCase,
+		@Inject(Tokens.QueryGa4Metrics) private readonly queryMetrics: TAUseCases.QueryGa4MetricsUseCase,
+		@Inject(Tokens.Ga4PropertyRepository)
+		private readonly properties: TrafficAnalytics.Ga4PropertyRepository,
+		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/ga4/properties')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<TrafficAnalyticsContracts.Ga4PropertyDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.properties.listForProject(project.id);
+		return list.map((p) => this.serialize(p));
+	}
+
+	@Post('projects/:projectId/ga4/properties')
+	async link(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(TrafficAnalyticsContracts.LinkGa4PropertyRequest))
+		body: TrafficAnalyticsContracts.LinkGa4PropertyRequest,
+	): Promise<{ ga4PropertyId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.linkProperty.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			propertyHandle: body.propertyHandle,
+			credentialId: body.credentialId ?? null,
+		});
+	}
+
+	@Delete('ga4/properties/:ga4PropertyId')
+	async unlink(
+		@Principal() principal: AuthPrincipal,
+		@Param('ga4PropertyId') ga4PropertyId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToProperty(principal, ga4PropertyId);
+		await this.unlinkProperty.execute({ ga4PropertyId });
+		return { ok: true };
+	}
+
+	@Get('ga4/properties/:ga4PropertyId/metrics')
+	async metrics(
+		@Principal() principal: AuthPrincipal,
+		@Param('ga4PropertyId') ga4PropertyId: string,
+		@Query(new ZodValidationPipe(TrafficAnalyticsContracts.Ga4MetricsQuery))
+		q: TrafficAnalyticsContracts.Ga4MetricsQuery,
+	): Promise<TrafficAnalyticsContracts.Ga4DailyMetricDto[]> {
+		await this.requireAccessToProperty(principal, ga4PropertyId);
+		const result = await this.queryMetrics.execute({ ga4PropertyId, from: q.from, to: q.to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	private async requireAccessToProperty(principal: AuthPrincipal, ga4PropertyId: string): Promise<void> {
+		// Collapses NotFound and Forbidden into the same 404 — same IDOR-safe
+		// pattern used by the web-performance and entity-awareness controllers.
+		// Without this, a leaked property id would let an attacker probe
+		// existence by distinguishing 403 from 404.
+		const property = await this.properties.findById(ga4PropertyId as TrafficAnalytics.Ga4PropertyId);
+		if (!property) throw new NotFoundError(`GA4 property ${ga4PropertyId} not found`);
+		const project = await this.projects.findById(property.projectId);
+		if (!project) throw new NotFoundError(`GA4 property ${ga4PropertyId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`GA4 property ${ga4PropertyId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(p: TrafficAnalytics.Ga4Property): TrafficAnalyticsContracts.Ga4PropertyDto {
+		return {
+			id: p.id,
+			projectId: p.projectId,
+			propertyHandle: p.propertyHandle.value,
+			credentialId: p.credentialId,
+			linkedAt: p.linkedAt.toISOString(),
+			unlinkedAt: p.unlinkedAt ? p.unlinkedAt.toISOString() : null,
+			isActive: p.isActive(),
+		};
+	}
+}

--- a/apps/api/src/modules/traffic-analytics/traffic-analytics.module.ts
+++ b/apps/api/src/modules/traffic-analytics/traffic-analytics.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { Ga4Controller } from './ga4.controller.js';
+
+@Module({
+	controllers: [Ga4Controller],
+})
+export class TrafficAnalyticsModule {}

--- a/apps/web/src/components/link-ga4-drawer.tsx
+++ b/apps/web/src/components/link-ga4-drawer.tsx
@@ -1,0 +1,96 @@
+import { Button, Drawer, FormField, Input } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface LinkGa4DrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #17 — atomic-design organism. Mobile-first drawer to link a
+ * Google Analytics 4 property to a project. The handle accepts either
+ * a bare numeric id or the `properties/<id>` form Google's UI shows;
+ * the application layer canonicalises to the bare form before save.
+ *
+ * Reminder copy explains the SA-as-Viewer prerequisite — without that
+ * step the daily fetch fails with 403 and the operator wastes a debug
+ * cycle.
+ */
+export const LinkGa4Drawer = ({ projectId, open, onClose }: LinkGa4DrawerProps) => {
+	const qc = useQueryClient();
+	const [propertyHandle, setPropertyHandle] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setPropertyHandle('');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => api.ga4.link(projectId, { propertyHandle }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'ga4'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to link GA4 property'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Link Google Analytics 4"
+			description="Sessions, users, pageviews, conversions — fetched daily from your GA4 property."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="link-ga4-form" disabled={mutation.isPending || !propertyHandle}>
+						{mutation.isPending ? 'Linking…' : 'Link property'}
+					</Button>
+				</>
+			}
+		>
+			<form id="link-ga4-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField
+					label="Property ID"
+					hint="Numeric GA4 property id (e.g. 123456789) or the full properties/123456789 form."
+				>
+					{(id) => (
+						<Input
+							id={id}
+							value={propertyHandle}
+							onChange={(e) => setPropertyHandle(e.target.value.trim())}
+							placeholder="123456789"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<p className="text-xs text-muted-foreground">
+					The configured service account must be added as a Viewer on the GA4 property (Admin → Property
+					Access Management). Without that the daily fetch fails with 403.
+				</p>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -2,6 +2,7 @@ import { Badge, Button, Card, CardContent, CardHeader, CardTitle, EmptyState, Sp
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
 import {
+	Activity,
 	BookOpen,
 	CalendarClock,
 	Check,
@@ -19,6 +20,7 @@ import { AddDomainDrawer } from '../components/add-domain-drawer.js';
 import { AddLocationDrawer } from '../components/add-location-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
+import { LinkGa4Drawer } from '../components/link-ga4-drawer.js';
 import { LinkWikipediaDrawer } from '../components/link-wikipedia-drawer.js';
 import { TrackPageDrawer } from '../components/track-page-drawer.js';
 import { api } from '../lib/api.js';
@@ -26,7 +28,7 @@ import { api } from '../lib/api.js';
 export const ProjectDetailPage = () => {
 	const { id } = useParams({ from: '/projects/$id' });
 	const [openDrawer, setOpenDrawer] = useState<
-		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | null
+		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | 'ga4' | null
 	>(null);
 
 	const projectQuery = useQuery({
@@ -61,6 +63,12 @@ export const ProjectDetailPage = () => {
 	const pageSpeedQuery = useQuery({
 		queryKey: ['project', id, 'page-speed'],
 		queryFn: () => api.pageSpeed.listForProject(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const ga4Query = useQuery({
+		queryKey: ['project', id, 'ga4'],
+		queryFn: () => api.ga4.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -319,6 +327,46 @@ export const ProjectDetailPage = () => {
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="flex items-center gap-2 text-base">
+								<Activity size={14} className="text-primary" />
+								GA4 properties ({ga4Query.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('ga4')}>
+								<Plus size={14} />
+								Link
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{ga4Query.isLoading ? (
+								<Spinner />
+							) : ga4Query.data && ga4Query.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{ga4Query.data.map((p) => (
+										<li key={p.id} className="break-words">
+											<Badge variant={p.isActive ? 'default' : 'secondary'}>
+												{p.isActive ? 'active' : 'unlinked'}
+											</Badge>{' '}
+											<span className="font-medium">properties/{p.propertyHandle}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No GA4 property linked"
+									description="Link a property to pull sessions, users, and pageviews from your real GA4 traffic."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('ga4')}>
+											<Plus size={14} />
+											Link property
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
 								<BookOpen size={14} className="text-primary" />
 								Wikipedia entities ({wikipediaQuery.data?.length ?? '…'})
 							</CardTitle>
@@ -421,6 +469,7 @@ export const ProjectDetailPage = () => {
 				open={openDrawer === 'page-speed'}
 				onClose={() => setOpenDrawer(null)}
 			/>
+			<LinkGa4Drawer projectId={id} open={openDrawer === 'ga4'} onClose={() => setOpenDrawer(null)} />
 		</AppShell>
 	);
 };

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -21,6 +21,7 @@
 		"@rankpulse/infrastructure": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
+		"@rankpulse/provider-ga4": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
 		"@rankpulse/provider-pagespeed": "workspace:*",
 		"@rankpulse/provider-wikipedia": "workspace:*",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -4,6 +4,7 @@ import {
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
 	SearchConsoleInsights as SearchConsoleInsightsUseCases,
+	TrafficAnalytics as TrafficAnalyticsUseCases,
 	WebPerformance as WebPerformanceUseCases,
 } from '@rankpulse/application';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
@@ -38,6 +39,8 @@ async function bootstrap(): Promise<void> {
 	);
 	const trackedPageRepo = new DrizzlePersistence.DrizzleTrackedPageRepository(drizzle.db);
 	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
+	const ga4PropertyRepo = new DrizzlePersistence.DrizzleGa4PropertyRepository(drizzle.db);
+	const ga4DailyMetricRepo = new DrizzlePersistence.DrizzleGa4DailyMetricRepository(drizzle.db);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -87,6 +90,13 @@ async function bootstrap(): Promise<void> {
 		pageSpeedSnapshotRepo,
 		eventPublisher,
 	);
+	const ingestGa4RowsUseCase = new TrafficAnalyticsUseCases.IngestGa4RowsUseCase(
+		ga4PropertyRepo,
+		ga4DailyMetricRepo,
+		SystemIdGenerator,
+		eventPublisher,
+		SystemClock,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -100,6 +110,7 @@ async function bootstrap(): Promise<void> {
 		gscPropertyRepo,
 		wikipediaArticleRepo,
 		trackedPageRepo,
+		ga4PropertyRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
@@ -108,6 +119,7 @@ async function bootstrap(): Promise<void> {
 		ingestGscRowsUseCase,
 		ingestWikipediaPageviewsUseCase,
 		recordPageSpeedSnapshotUseCase,
+		ingestGa4RowsUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -4,6 +4,7 @@ import type {
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
 	SearchConsoleInsights as SearchConsoleInsightsUseCases,
+	TrafficAnalytics as TrafficAnalyticsUseCases,
 	WebPerformance as WebPerformanceUseCases,
 } from '@rankpulse/application';
 import {
@@ -12,6 +13,7 @@ import {
 	ProviderConnectivity,
 	type RankTracking as RankTrackingDomain,
 	type SearchConsoleInsights as SearchConsoleInsightsDomain,
+	type TrafficAnalytics as TrafficAnalyticsDomain,
 	type WebPerformance as WebPerformanceDomain,
 } from '@rankpulse/domain';
 import type { ProviderFetchJobData } from '@rankpulse/infrastructure/queue';
@@ -21,6 +23,12 @@ import {
 	extractTop10Domains,
 	type SerpLiveResponse,
 } from '@rankpulse/provider-dataforseo';
+import {
+	extractRows as extractGa4Rows,
+	Ga4ApiError,
+	type RunReportParams,
+	type RunReportResponse,
+} from '@rankpulse/provider-ga4';
 import {
 	extractGscRows,
 	GscApiError,
@@ -65,6 +73,9 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 	// PSI returns 429 once the API key burns through its 25k/day. Treat as
 	// quota-exhausted so the JobDefinition auto-pauses until next day.
 	if (err instanceof PageSpeedApiError && (err.status === 402 || err.status === 429)) return true;
+	// GA4 Data API returns 429 RESOURCE_EXHAUSTED when the per-property token
+	// budget (200k/day) is spent; auto-pause until reset.
+	if (err instanceof Ga4ApiError && (err.status === 402 || err.status === 429)) return true;
 	return false;
 };
 
@@ -86,6 +97,7 @@ export interface ProviderFetchProcessorDeps {
 	gscPropertyRepo: SearchConsoleInsightsDomain.GscPropertyRepository;
 	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
 	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
+	ga4PropertyRepo: TrafficAnalyticsDomain.Ga4PropertyRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
@@ -94,6 +106,7 @@ export interface ProviderFetchProcessorDeps {
 	ingestGscRowsUseCase: SearchConsoleInsightsUseCases.IngestGscRowsUseCase;
 	ingestWikipediaPageviewsUseCase: EntityAwarenessUseCases.IngestWikipediaPageviewsUseCase;
 	recordPageSpeedSnapshotUseCase: WebPerformanceUseCases.RecordPageSpeedSnapshotUseCase;
+	ingestGa4RowsUseCase: TrafficAnalyticsUseCases.IngestGa4RowsUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -374,6 +387,34 @@ export class ProviderFetchProcessor {
 						gscPropertyId: gscParams.gscPropertyId,
 						rawPayloadId,
 						rows,
+					});
+				}
+			}
+
+			if (
+				definition.providerId.value === 'google-analytics-4' &&
+				definition.endpointId.value === 'ga4-run-report'
+			) {
+				// Issue #17 — GA4 ingest. The job's systemParams must carry
+				// `ga4PropertyId` (set when the operator links a GA4 property
+				// via the API/UI; the LinkGa4PropertyUseCase auto-schedules
+				// the cron and stamps that id into the params).
+				const ga4Params = resolvedParams as unknown as RunReportParams & { ga4PropertyId?: string };
+				if (!ga4Params.ga4PropertyId) {
+					runLog.warn({}, 'ga4-run-report job missing ga4PropertyId param; skipping ingest');
+				} else {
+					const rows = extractGa4Rows(fetchResult as RunReportResponse, {
+						startDate: ga4Params.startDate,
+						endDate: ga4Params.endDate,
+					});
+					await this.deps.ingestGa4RowsUseCase.execute({
+						ga4PropertyId: ga4Params.ga4PropertyId,
+						rawPayloadId,
+						rows: rows.map((r) => ({
+							observedDate: r.observedDate,
+							dimensions: r.dimensions,
+							metrics: r.metrics,
+						})),
 					});
 				}
 			}

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -1,5 +1,6 @@
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
+import { Ga4Provider } from '@rankpulse/provider-ga4';
 import { GscProvider } from '@rankpulse/provider-gsc';
 import { PageSpeedProvider } from '@rankpulse/provider-pagespeed';
 import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
@@ -11,6 +12,7 @@ import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
 export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): ProviderRegistry {
 	const registry = new ProviderRegistry();
 	registry.register(new DataForSeoProvider({ baseUrl: options.dataforseoBaseUrl }));
+	registry.register(new Ga4Provider());
 	registry.register(new GscProvider());
 	registry.register(new WikipediaProvider());
 	registry.register(new PageSpeedProvider());

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -26,6 +26,11 @@
 			"types": "./dist/project-management/index.d.ts",
 			"default": "./dist/project-management/index.js"
 		},
+		"./traffic-analytics": {
+			"development": "./src/traffic-analytics/index.ts",
+			"types": "./dist/traffic-analytics/index.d.ts",
+			"default": "./dist/traffic-analytics/index.js"
+		},
 		"./web-performance": {
 			"development": "./src/web-performance/index.ts",
 			"types": "./dist/web-performance/index.d.ts",

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -4,4 +4,5 @@ export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';
 export * as SearchConsoleInsights from './search-console-insights/index.js';
+export * as TrafficAnalytics from './traffic-analytics/index.js';
 export * as WebPerformance from './web-performance/index.js';

--- a/packages/application/src/traffic-analytics/index.ts
+++ b/packages/application/src/traffic-analytics/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/ingest-ga4-rows.use-case.js';
+export * from './use-cases/link-ga4-property.use-case.js';
+export * from './use-cases/query-ga4-metrics.use-case.js';
+export * from './use-cases/unlink-ga4-property.use-case.js';

--- a/packages/application/src/traffic-analytics/use-cases/ingest-ga4-rows.use-case.spec.ts
+++ b/packages/application/src/traffic-analytics/use-cases/ingest-ga4-rows.use-case.spec.ts
@@ -1,0 +1,187 @@
+import type { IdentityAccess, ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IngestGa4RowsUseCase } from './ingest-ga4-rows.use-case.js';
+import { LinkGa4PropertyUseCase } from './link-ga4-property.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryPropertyRepo implements TrafficAnalytics.Ga4PropertyRepository {
+	readonly store = new Map<string, TrafficAnalytics.Ga4Property>();
+	async save(p: TrafficAnalytics.Ga4Property): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: TrafficAnalytics.Ga4PropertyId): Promise<TrafficAnalytics.Ga4Property | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(): Promise<TrafficAnalytics.Ga4Property | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [];
+	}
+}
+
+class InMemoryMetricRepo implements TrafficAnalytics.Ga4DailyMetricRepository {
+	readonly store = new Map<string, TrafficAnalytics.Ga4DailyMetric>();
+	async saveAll(metrics: readonly TrafficAnalytics.Ga4DailyMetric[]): Promise<{ inserted: number }> {
+		let inserted = 0;
+		for (const m of metrics) {
+			const k = `${m.ga4PropertyId}|${m.observedDate}|${m.dimensionsHash}`;
+			if (this.store.has(k)) continue;
+			this.store.set(k, m);
+			inserted += 1;
+		}
+		return { inserted };
+	}
+	async listForProperty(): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		return [...this.store.values()];
+	}
+	async listLatestForProject(): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		return [...this.store.values()];
+	}
+}
+
+describe('IngestGa4RowsUseCase', () => {
+	let propRepo: InMemoryPropertyRepo;
+	let metricRepo: InMemoryMetricRepo;
+	let events: RecordingEventPublisher;
+	let propertyId: string;
+
+	beforeEach(async () => {
+		propRepo = new InMemoryPropertyRepo();
+		metricRepo = new InMemoryMetricRepo();
+		events = new RecordingEventPublisher();
+		const linker = new LinkGa4PropertyUseCase(
+			propRepo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(['ga4-prop-1' as Uuid]),
+			events,
+		);
+		const result = await linker.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			propertyHandle: 'properties/123456789',
+		});
+		propertyId = result.ga4PropertyId;
+		events.clear();
+	});
+
+	const baseRow = (
+		overrides: Partial<{
+			observedDate: string;
+			dimensions: Record<string, string>;
+			metrics: Record<string, number>;
+		}> = {},
+	) => ({
+		observedDate: overrides.observedDate ?? '2026-05-01',
+		dimensions: overrides.dimensions ?? { date: '2026-05-01', sessionDefaultChannelGroup: 'Organic Search' },
+		metrics: overrides.metrics ?? { sessions: 100, totalUsers: 80, screenPageViews: 240 },
+	});
+
+	const buildUseCase = () =>
+		new IngestGa4RowsUseCase(
+			propRepo,
+			metricRepo,
+			new FixedIdGenerator(['m-1' as Uuid, 'm-2' as Uuid, 'm-3' as Uuid]),
+			events,
+			new FakeClock('2026-05-04T11:00:00Z'),
+		);
+
+	it('persists rows and publishes Ga4BatchIngested with totals on first ingest', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [
+				baseRow({ metrics: { sessions: 100, totalUsers: 80 } }),
+				baseRow({
+					observedDate: '2026-05-02',
+					dimensions: { date: '2026-05-02', sessionDefaultChannelGroup: 'Direct' },
+					metrics: { sessions: 50, totalUsers: 40 },
+				}),
+			],
+			rawPayloadId: null,
+		});
+		expect(result.ingested).toBe(2);
+		expect(metricRepo.store.size).toBe(2);
+		const [evt] = events.published();
+		expect(evt?.type).toBe('Ga4BatchIngested');
+		expect((evt as TrafficAnalytics.Ga4BatchIngested).totalSessions).toBe(150);
+		expect((evt as TrafficAnalytics.Ga4BatchIngested).totalUsers).toBe(120);
+	});
+
+	it('reports zero ingested when re-running the same window with the same dimensions', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute({ ga4PropertyId: propertyId, rows: [baseRow()], rawPayloadId: null });
+		events.clear();
+		const second = await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [baseRow()],
+			rawPayloadId: null,
+		});
+		expect(second.ingested).toBe(0);
+		expect(metricRepo.store.size).toBe(1);
+		expect((events.published()[0] as TrafficAnalytics.Ga4BatchIngested).rowsCount).toBe(0);
+	});
+
+	it('writes a new row when the dimension breakdown changes for the same date', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [baseRow({ dimensions: { date: '2026-05-01', country: 'Spain' } })],
+			rawPayloadId: null,
+		});
+		await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [baseRow({ dimensions: { date: '2026-05-01', country: 'Mexico' } })],
+			rawPayloadId: null,
+		});
+		expect(metricRepo.store.size).toBe(2);
+	});
+
+	it('throws NotFoundError when the property does not exist', async () => {
+		const useCase = buildUseCase();
+		await expect(
+			useCase.execute({ ga4PropertyId: 'missing', rows: [baseRow()], rawPayloadId: null }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('returns 0 and does not publish when called with an empty batch', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute({ ga4PropertyId: propertyId, rows: [], rawPayloadId: null });
+		expect(result.ingested).toBe(0);
+		expect(events.published()).toEqual([]);
+	});
+
+	it('rejects rows with non-finite metric values at the aggregate boundary', async () => {
+		const useCase = buildUseCase();
+		await expect(
+			useCase.execute({
+				ga4PropertyId: propertyId,
+				rows: [baseRow({ metrics: { sessions: Number.NaN } })],
+				rawPayloadId: null,
+			}),
+		).rejects.toThrow();
+	});
+
+	it('preserves dimension hash stability under key reordering', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [baseRow({ dimensions: { country: 'Spain', date: '2026-05-01' } })],
+			rawPayloadId: null,
+		});
+		await useCase.execute({
+			ga4PropertyId: propertyId,
+			rows: [baseRow({ dimensions: { date: '2026-05-01', country: 'Spain' } })],
+			rawPayloadId: null,
+		});
+		// Same logical dimensions in different key order -> same hash -> idempotent.
+		expect(metricRepo.store.size).toBe(1);
+	});
+});

--- a/packages/application/src/traffic-analytics/use-cases/ingest-ga4-rows.use-case.ts
+++ b/packages/application/src/traffic-analytics/use-cases/ingest-ga4-rows.use-case.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import { type SharedKernel, TrafficAnalytics } from '@rankpulse/domain';
+import { type Clock, type IdGenerator, NotFoundError } from '@rankpulse/shared';
+
+export interface Ga4RowInput {
+	observedDate: string; // YYYY-MM-DD
+	dimensions: Record<string, string>;
+	metrics: Record<string, number>;
+}
+
+export interface IngestGa4RowsCommand {
+	ga4PropertyId: string;
+	rows: readonly Ga4RowInput[];
+	rawPayloadId: string | null;
+}
+
+export interface IngestGa4RowsResult {
+	ingested: number;
+}
+
+/**
+ * Stable SHA-256 over the canonical sorted-key JSON form of the dimensions
+ * map. Two rows with the same `(propertyId, observedDate)` are considered
+ * duplicates iff their dimensions hash matches — so a re-run of the same
+ * cron is a no-op, but a new dimension breakdown writes fresh rows.
+ */
+const hashDimensions = (dims: Record<string, string>): string => {
+	const sorted = Object.keys(dims)
+		.sort()
+		.reduce<Record<string, string>>((acc, k) => {
+			acc[k] = dims[k] ?? '';
+			return acc;
+		}, {});
+	return createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
+};
+
+const SESSIONS_METRIC_KEYS = ['sessions', 'totalSessions'];
+const USERS_METRIC_KEYS = ['totalUsers', 'activeUsers', 'newUsers'];
+
+const sumByKey = (rows: readonly Ga4RowInput[], keys: readonly string[]): number => {
+	let total = 0;
+	for (const row of rows) {
+		for (const k of keys) {
+			const v = row.metrics[k];
+			if (typeof v === 'number' && Number.isFinite(v)) {
+				total += v;
+				break;
+			}
+		}
+	}
+	return total;
+};
+
+/**
+ * Persists a batch of GA4 daily-metric rows for a linked property and
+ * publishes one summary event with totals, mirroring the GSC ingest.
+ *
+ * Idempotency: the natural PK is `(ga4_property_id, observed_date,
+ * dimensions_hash)`. The repo does `onConflictDoNothing`, and we publish
+ * the *inserted* count, not the input length — so a retry of the same
+ * window with the same dimension breakdown reports zero ingestion.
+ */
+export class IngestGa4RowsUseCase {
+	constructor(
+		private readonly properties: TrafficAnalytics.Ga4PropertyRepository,
+		private readonly metrics: TrafficAnalytics.Ga4DailyMetricRepository,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: IngestGa4RowsCommand): Promise<IngestGa4RowsResult> {
+		if (cmd.rows.length === 0) return { ingested: 0 };
+
+		const property = await this.properties.findById(cmd.ga4PropertyId as TrafficAnalytics.Ga4PropertyId);
+		if (!property) throw new NotFoundError(`Ga4Property ${cmd.ga4PropertyId} not found`);
+		if (!property.isActive()) return { ingested: 0 };
+
+		const aggregates = cmd.rows.map((row) =>
+			TrafficAnalytics.Ga4DailyMetric.record({
+				id: this.ids.generate() as TrafficAnalytics.Ga4DailyMetricId,
+				ga4PropertyId: property.id,
+				projectId: property.projectId,
+				observedDate: row.observedDate,
+				dimensionsHash: hashDimensions(row.dimensions),
+				body: TrafficAnalytics.Ga4DailyDimensionsMetrics.create({
+					dimensions: row.dimensions,
+					metrics: row.metrics,
+				}),
+				rawPayloadId: cmd.rawPayloadId,
+			}),
+		);
+
+		const { inserted } = await this.metrics.saveAll(aggregates);
+
+		await this.events.publish([
+			new TrafficAnalytics.Ga4BatchIngested({
+				projectId: property.projectId,
+				ga4PropertyId: property.id,
+				rowsCount: inserted,
+				totalSessions: sumByKey(cmd.rows, SESSIONS_METRIC_KEYS),
+				totalUsers: sumByKey(cmd.rows, USERS_METRIC_KEYS),
+				occurredAt: this.clock.now(),
+			}),
+		]);
+
+		return { ingested: inserted };
+	}
+}

--- a/packages/application/src/traffic-analytics/use-cases/link-ga4-property.use-case.spec.ts
+++ b/packages/application/src/traffic-analytics/use-cases/link-ga4-property.use-case.spec.ts
@@ -1,0 +1,81 @@
+import type { IdentityAccess, ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { ConflictError, FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LinkGa4PropertyUseCase } from './link-ga4-property.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryPropertyRepo implements TrafficAnalytics.Ga4PropertyRepository {
+	readonly store = new Map<string, TrafficAnalytics.Ga4Property>();
+	readonly byHandle = new Map<string, TrafficAnalytics.Ga4Property>();
+	async save(p: TrafficAnalytics.Ga4Property): Promise<void> {
+		this.store.set(p.id, p);
+		this.byHandle.set(`${p.projectId}|${p.propertyHandle.value}`, p);
+	}
+	async findById(id: TrafficAnalytics.Ga4PropertyId): Promise<TrafficAnalytics.Ga4Property | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(
+		projectId: ProjectManagement.ProjectId,
+		propertyHandle: string,
+	): Promise<TrafficAnalytics.Ga4Property | null> {
+		return this.byHandle.get(`${projectId}|${propertyHandle}`) ?? null;
+	}
+	async listForProject(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [...this.store.values()];
+	}
+	async listForOrganization(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [...this.store.values()];
+	}
+}
+
+describe('LinkGa4PropertyUseCase', () => {
+	let repo: InMemoryPropertyRepo;
+	let events: RecordingEventPublisher;
+	const buildUseCase = (ids: Uuid[]) =>
+		new LinkGa4PropertyUseCase(
+			repo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(ids),
+			events,
+		);
+
+	beforeEach(() => {
+		repo = new InMemoryPropertyRepo();
+		events = new RecordingEventPublisher();
+	});
+
+	it('canonicalises a "properties/<id>" handle into bare numeric form before save', async () => {
+		const useCase = buildUseCase(['p-1' as Uuid]);
+		const result = await useCase.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			propertyHandle: 'properties/123456789',
+		});
+		const stored = repo.store.get(result.ga4PropertyId);
+		expect(stored?.propertyHandle.value).toBe('123456789');
+	});
+
+	it('publishes Ga4PropertyLinked on first link', async () => {
+		const useCase = buildUseCase(['p-1' as Uuid]);
+		await useCase.execute({ organizationId: ORG_ID, projectId: PROJECT_ID, propertyHandle: '123456789' });
+		expect(events.publishedTypes()).toContain('Ga4PropertyLinked');
+	});
+
+	it('rejects re-linking an already-active property to the same project', async () => {
+		const useCase = buildUseCase(['p-1' as Uuid, 'p-2' as Uuid]);
+		await useCase.execute({ organizationId: ORG_ID, projectId: PROJECT_ID, propertyHandle: '123' });
+		await expect(
+			useCase.execute({ organizationId: ORG_ID, projectId: PROJECT_ID, propertyHandle: '123' }),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('rejects a non-numeric handle', async () => {
+		const useCase = buildUseCase(['p-1' as Uuid]);
+		await expect(
+			useCase.execute({ organizationId: ORG_ID, projectId: PROJECT_ID, propertyHandle: 'GA-12345' }),
+		).rejects.toThrow();
+	});
+});

--- a/packages/application/src/traffic-analytics/use-cases/link-ga4-property.use-case.ts
+++ b/packages/application/src/traffic-analytics/use-cases/link-ga4-property.use-case.ts
@@ -1,0 +1,50 @@
+import {
+	type IdentityAccess,
+	type ProjectManagement,
+	type SharedKernel,
+	TrafficAnalytics,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface LinkGa4PropertyCommand {
+	organizationId: string;
+	projectId: string;
+	propertyHandle: string;
+	credentialId?: string | null;
+}
+
+export interface LinkGa4PropertyResult {
+	ga4PropertyId: string;
+}
+
+export class LinkGa4PropertyUseCase {
+	constructor(
+		private readonly properties: TrafficAnalytics.Ga4PropertyRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: LinkGa4PropertyCommand): Promise<LinkGa4PropertyResult> {
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+		// Canonicalise the handle once so the lookup matches the row we'd write.
+		const handle = TrafficAnalytics.Ga4PropertyHandle.create(cmd.propertyHandle);
+		const existing = await this.properties.findByProjectAndHandle(projectId, handle.value);
+		if (existing?.isActive()) {
+			throw new ConflictError(`GA4 property ${handle.value} is already linked to this project`);
+		}
+
+		const id = this.ids.generate() as TrafficAnalytics.Ga4PropertyId;
+		const property = TrafficAnalytics.Ga4Property.link({
+			id,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			propertyHandle: handle.value,
+			credentialId: cmd.credentialId ?? null,
+			now: this.clock.now(),
+		});
+		await this.properties.save(property);
+		await this.events.publish(property.pullEvents());
+		return { ga4PropertyId: id };
+	}
+}

--- a/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.ts
+++ b/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.ts
@@ -1,0 +1,32 @@
+import type { TrafficAnalytics } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryGa4MetricsCommand {
+	ga4PropertyId: string;
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface Ga4MetricView {
+	observedDate: string;
+	dimensions: Record<string, string>;
+	metrics: Record<string, number>;
+}
+
+export class QueryGa4MetricsUseCase {
+	constructor(
+		private readonly properties: TrafficAnalytics.Ga4PropertyRepository,
+		private readonly metrics: TrafficAnalytics.Ga4DailyMetricRepository,
+	) {}
+
+	async execute(cmd: QueryGa4MetricsCommand): Promise<readonly Ga4MetricView[]> {
+		const property = await this.properties.findById(cmd.ga4PropertyId as TrafficAnalytics.Ga4PropertyId);
+		if (!property) throw new NotFoundError(`Ga4Property ${cmd.ga4PropertyId} not found`);
+		const rows = await this.metrics.listForProperty(property.id, { from: cmd.from, to: cmd.to });
+		return rows.map((r) => ({
+			observedDate: r.observedDate,
+			dimensions: { ...r.body.dimensions },
+			metrics: { ...r.body.metrics },
+		}));
+	}
+}

--- a/packages/application/src/traffic-analytics/use-cases/unlink-ga4-property.use-case.ts
+++ b/packages/application/src/traffic-analytics/use-cases/unlink-ga4-property.use-case.ts
@@ -1,0 +1,23 @@
+import type { TrafficAnalytics } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface UnlinkGa4PropertyCommand {
+	ga4PropertyId: string;
+}
+
+export class UnlinkGa4PropertyUseCase {
+	constructor(
+		private readonly properties: TrafficAnalytics.Ga4PropertyRepository,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: UnlinkGa4PropertyCommand): Promise<void> {
+		const property = await this.properties.findById(cmd.ga4PropertyId as TrafficAnalytics.Ga4PropertyId);
+		if (!property) {
+			throw new NotFoundError(`Ga4Property ${cmd.ga4PropertyId} not found`);
+		}
+		if (!property.isActive()) return; // idempotent
+		property.unlink(this.clock.now());
+		await this.properties.save(property);
+	}
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,4 +6,5 @@ export * as RankTrackingContracts from './rank-tracking/index.js';
 export * as SearchConsoleInsightsContracts from './search-console-insights/index.js';
 export * from './shared/pagination.js';
 export * from './shared/problem-details.js';
+export * as TrafficAnalyticsContracts from './traffic-analytics/index.js';
 export * as WebPerformanceContracts from './web-performance/index.js';

--- a/packages/contracts/src/traffic-analytics/index.ts
+++ b/packages/contracts/src/traffic-analytics/index.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+const PropertyHandle = z.string().regex(/^(properties\/)?\d+$/, 'must be a numeric GA4 property id');
+
+export const LinkGa4PropertyRequest = z.object({
+	propertyHandle: PropertyHandle,
+	credentialId: z.string().uuid().nullable().optional(),
+});
+export type LinkGa4PropertyRequest = z.infer<typeof LinkGa4PropertyRequest>;
+
+export const Ga4PropertyDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	propertyHandle: z.string(),
+	credentialId: z.string().uuid().nullable(),
+	linkedAt: z.string().datetime(),
+	unlinkedAt: z.string().datetime().nullable(),
+	isActive: z.boolean(),
+});
+export type Ga4PropertyDto = z.infer<typeof Ga4PropertyDto>;
+
+const DateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+export const Ga4MetricsQuery = z.object({
+	from: DateString,
+	to: DateString,
+});
+export type Ga4MetricsQuery = z.infer<typeof Ga4MetricsQuery>;
+
+export const Ga4DailyMetricDto = z.object({
+	observedDate: z.string(),
+	dimensions: z.record(z.string(), z.string()),
+	metrics: z.record(z.string(), z.number()),
+});
+export type Ga4DailyMetricDto = z.infer<typeof Ga4DailyMetricDto>;

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -46,6 +46,11 @@
 			"types": "./dist/shared-kernel/index.d.ts",
 			"default": "./dist/shared-kernel/index.js"
 		},
+		"./traffic-analytics": {
+			"development": "./src/traffic-analytics/index.ts",
+			"types": "./dist/traffic-analytics/index.d.ts",
+			"default": "./dist/traffic-analytics/index.js"
+		},
 		"./web-performance": {
 			"development": "./src/web-performance/index.ts",
 			"types": "./dist/web-performance/index.d.ts",

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,4 +5,5 @@ export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';
 export * as SearchConsoleInsights from './search-console-insights/index.js';
 export * as SharedKernel from './shared-kernel/index.js';
+export * as TrafficAnalytics from './traffic-analytics/index.js';
 export * as WebPerformance from './web-performance/index.js';

--- a/packages/domain/src/traffic-analytics/entities/ga4-daily-metric.ts
+++ b/packages/domain/src/traffic-analytics/entities/ga4-daily-metric.ts
@@ -1,0 +1,55 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import type { Ga4DailyDimensionsMetrics } from '../value-objects/daily-metrics.js';
+import type { Ga4DailyMetricId, Ga4PropertyId } from '../value-objects/identifiers.js';
+
+export interface Ga4DailyMetricProps {
+	id: Ga4DailyMetricId;
+	ga4PropertyId: Ga4PropertyId;
+	projectId: ProjectId;
+	observedDate: string; // YYYY-MM-DD, the calendar day the row belongs to
+	dimensionsHash: string; // SHA-256 over the canonical dimensions JSON, used in the natural PK
+	body: Ga4DailyDimensionsMetrics;
+	rawPayloadId: string | null;
+}
+
+/**
+ * One immutable GA4 row at a given (date, dimension-set) granularity.
+ * Same shape philosophy as GscPerformanceObservation — value-like factory,
+ * no per-row events; the ingest use case publishes one batch summary.
+ */
+export class Ga4DailyMetric extends AggregateRoot {
+	private constructor(private readonly props: Ga4DailyMetricProps) {
+		super();
+	}
+
+	static record(input: Ga4DailyMetricProps): Ga4DailyMetric {
+		return new Ga4DailyMetric(input);
+	}
+
+	static rehydrate(props: Ga4DailyMetricProps): Ga4DailyMetric {
+		return new Ga4DailyMetric(props);
+	}
+
+	get id(): Ga4DailyMetricId {
+		return this.props.id;
+	}
+	get ga4PropertyId(): Ga4PropertyId {
+		return this.props.ga4PropertyId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedDate(): string {
+		return this.props.observedDate;
+	}
+	get dimensionsHash(): string {
+		return this.props.dimensionsHash;
+	}
+	get body(): Ga4DailyDimensionsMetrics {
+		return this.props.body;
+	}
+	get rawPayloadId(): string | null {
+		return this.props.rawPayloadId;
+	}
+}

--- a/packages/domain/src/traffic-analytics/entities/ga4-property.ts
+++ b/packages/domain/src/traffic-analytics/entities/ga4-property.ts
@@ -1,0 +1,95 @@
+import { ConflictError } from '@rankpulse/shared';
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { Ga4PropertyLinked } from '../events/ga4-property-linked.js';
+import type { Ga4PropertyId } from '../value-objects/identifiers.js';
+import { Ga4PropertyHandle } from '../value-objects/property-handle.js';
+
+export interface Ga4PropertyProps {
+	id: Ga4PropertyId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	propertyHandle: Ga4PropertyHandle;
+	credentialId: string | null;
+	linkedAt: Date;
+	unlinkedAt: Date | null;
+}
+
+/**
+ * A GA4 property linked to a RankPulse project. Owns the credential pin
+ * (same pattern as GscProperty) so a re-fetch always uses the SA the user
+ * authorised at link time, not whatever the cascade picks today.
+ */
+export class Ga4Property extends AggregateRoot {
+	private constructor(private props: Ga4PropertyProps) {
+		super();
+	}
+
+	static link(input: {
+		id: Ga4PropertyId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		propertyHandle: string;
+		credentialId: string | null;
+		now: Date;
+	}): Ga4Property {
+		const handle = Ga4PropertyHandle.create(input.propertyHandle);
+		const property = new Ga4Property({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			propertyHandle: handle,
+			credentialId: input.credentialId,
+			linkedAt: input.now,
+			unlinkedAt: null,
+		});
+		property.record(
+			new Ga4PropertyLinked({
+				ga4PropertyId: input.id,
+				projectId: input.projectId,
+				organizationId: input.organizationId,
+				propertyHandle: handle.value,
+				occurredAt: input.now,
+			}),
+		);
+		return property;
+	}
+
+	static rehydrate(props: Ga4PropertyProps): Ga4Property {
+		return new Ga4Property(props);
+	}
+
+	unlink(now: Date): void {
+		if (this.props.unlinkedAt) {
+			throw new ConflictError('Ga4Property is already unlinked');
+		}
+		this.props = { ...this.props, unlinkedAt: now };
+	}
+
+	isActive(): boolean {
+		return this.props.unlinkedAt === null;
+	}
+
+	get id(): Ga4PropertyId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get propertyHandle(): Ga4PropertyHandle {
+		return this.props.propertyHandle;
+	}
+	get credentialId(): string | null {
+		return this.props.credentialId;
+	}
+	get linkedAt(): Date {
+		return this.props.linkedAt;
+	}
+	get unlinkedAt(): Date | null {
+		return this.props.unlinkedAt;
+	}
+}

--- a/packages/domain/src/traffic-analytics/events/ga4-batch-ingested.ts
+++ b/packages/domain/src/traffic-analytics/events/ga4-batch-ingested.ts
@@ -1,0 +1,34 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { Ga4PropertyId } from '../value-objects/identifiers.js';
+
+/**
+ * One event per ingest call, never per row. A `runReport` with rowLimit
+ * 10 000 should not fan-out 10 000 publisher calls — subscribers already
+ * aggregate downstream. Mirrors the GSC pattern.
+ */
+export class Ga4BatchIngested implements DomainEvent {
+	readonly type = 'Ga4BatchIngested';
+	readonly projectId: ProjectId;
+	readonly ga4PropertyId: Ga4PropertyId;
+	readonly rowsCount: number;
+	readonly totalSessions: number;
+	readonly totalUsers: number;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		projectId: ProjectId;
+		ga4PropertyId: Ga4PropertyId;
+		rowsCount: number;
+		totalSessions: number;
+		totalUsers: number;
+		occurredAt: Date;
+	}) {
+		this.projectId = props.projectId;
+		this.ga4PropertyId = props.ga4PropertyId;
+		this.rowsCount = props.rowsCount;
+		this.totalSessions = props.totalSessions;
+		this.totalUsers = props.totalUsers;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/traffic-analytics/events/ga4-property-linked.ts
+++ b/packages/domain/src/traffic-analytics/events/ga4-property-linked.ts
@@ -1,0 +1,27 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { Ga4PropertyId } from '../value-objects/identifiers.js';
+
+export class Ga4PropertyLinked implements DomainEvent {
+	readonly type = 'Ga4PropertyLinked';
+	readonly ga4PropertyId: Ga4PropertyId;
+	readonly projectId: ProjectId;
+	readonly organizationId: OrganizationId;
+	readonly propertyHandle: string;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		ga4PropertyId: Ga4PropertyId;
+		projectId: ProjectId;
+		organizationId: OrganizationId;
+		propertyHandle: string;
+		occurredAt: Date;
+	}) {
+		this.ga4PropertyId = props.ga4PropertyId;
+		this.projectId = props.projectId;
+		this.organizationId = props.organizationId;
+		this.propertyHandle = props.propertyHandle;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/traffic-analytics/index.ts
+++ b/packages/domain/src/traffic-analytics/index.ts
@@ -1,0 +1,13 @@
+// Entities / aggregates
+export * from './entities/ga4-daily-metric.js';
+export * from './entities/ga4-property.js';
+// Events
+export * from './events/ga4-batch-ingested.js';
+export * from './events/ga4-property-linked.js';
+// Ports
+export * from './ports/ga4-daily-metric-repository.js';
+export * from './ports/ga4-property-repository.js';
+// Value objects
+export * from './value-objects/daily-metrics.js';
+export * from './value-objects/identifiers.js';
+export * from './value-objects/property-handle.js';

--- a/packages/domain/src/traffic-analytics/ports/ga4-daily-metric-repository.ts
+++ b/packages/domain/src/traffic-analytics/ports/ga4-daily-metric-repository.ts
@@ -1,0 +1,21 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { Ga4DailyMetric } from '../entities/ga4-daily-metric.js';
+import type { Ga4PropertyId } from '../value-objects/identifiers.js';
+
+export interface Ga4DailyMetricQuery {
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface Ga4DailyMetricRepository {
+	/**
+	 * Bulk-insert daily metrics. Implementations MUST be idempotent on
+	 * the natural key (ga4PropertyId, observedDate, dimensionsHash) — a
+	 * re-fetch of the same window with the same dimensions should not
+	 * duplicate rows. Returns the number actually inserted (excludes
+	 * conflict-skipped rows) so the caller can publish accurate metrics.
+	 */
+	saveAll(metrics: readonly Ga4DailyMetric[]): Promise<{ inserted: number }>;
+	listForProperty(propertyId: Ga4PropertyId, query: Ga4DailyMetricQuery): Promise<readonly Ga4DailyMetric[]>;
+	listLatestForProject(projectId: ProjectId): Promise<readonly Ga4DailyMetric[]>;
+}

--- a/packages/domain/src/traffic-analytics/ports/ga4-property-repository.ts
+++ b/packages/domain/src/traffic-analytics/ports/ga4-property-repository.ts
@@ -1,0 +1,12 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { Ga4Property } from '../entities/ga4-property.js';
+import type { Ga4PropertyId } from '../value-objects/identifiers.js';
+
+export interface Ga4PropertyRepository {
+	save(property: Ga4Property): Promise<void>;
+	findById(id: Ga4PropertyId): Promise<Ga4Property | null>;
+	findByProjectAndHandle(projectId: ProjectId, propertyHandle: string): Promise<Ga4Property | null>;
+	listForProject(projectId: ProjectId): Promise<readonly Ga4Property[]>;
+	listForOrganization(orgId: OrganizationId): Promise<readonly Ga4Property[]>;
+}

--- a/packages/domain/src/traffic-analytics/value-objects/daily-metrics.ts
+++ b/packages/domain/src/traffic-analytics/value-objects/daily-metrics.ts
@@ -1,0 +1,47 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * GA4 metrics are flexible: which ones are present depends on the
+ * dimensions/metrics requested at fetch time. We keep two parallel maps
+ * (string dimensions, numeric metrics) so the read model can render
+ * whatever the cron asked for without growing a dedicated column per
+ * metric.
+ *
+ * The aggregate enforces basic shape invariants: no NaN/Infinity in
+ * metrics, no empty dimension values. Anything more semantic (sessions
+ * non-negative, etc.) lives at the read side and would noisy-fail
+ * legitimate edge cases like GA4's `(other)` bucket.
+ */
+export class Ga4DailyDimensionsMetrics {
+	private constructor(
+		public readonly dimensions: Readonly<Record<string, string>>,
+		public readonly metrics: Readonly<Record<string, number>>,
+	) {}
+
+	static create(input: {
+		dimensions: Record<string, string>;
+		metrics: Record<string, number>;
+	}): Ga4DailyDimensionsMetrics {
+		const dims: Record<string, string> = {};
+		for (const [k, v] of Object.entries(input.dimensions ?? {})) {
+			if (typeof k !== 'string' || k.length === 0) {
+				throw new InvalidInputError('dimension keys must be non-empty strings');
+			}
+			if (typeof v !== 'string') {
+				throw new InvalidInputError(`dimension "${k}" must be a string value`);
+			}
+			dims[k] = v;
+		}
+		const mets: Record<string, number> = {};
+		for (const [k, v] of Object.entries(input.metrics ?? {})) {
+			if (typeof k !== 'string' || k.length === 0) {
+				throw new InvalidInputError('metric keys must be non-empty strings');
+			}
+			if (typeof v !== 'number' || !Number.isFinite(v)) {
+				throw new InvalidInputError(`metric "${k}" must be a finite number`);
+			}
+			mets[k] = v;
+		}
+		return new Ga4DailyDimensionsMetrics(dims, mets);
+	}
+}

--- a/packages/domain/src/traffic-analytics/value-objects/identifiers.ts
+++ b/packages/domain/src/traffic-analytics/value-objects/identifiers.ts
@@ -1,0 +1,4 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type Ga4PropertyId = Uuid & { readonly __kind: 'Ga4PropertyId' };
+export type Ga4DailyMetricId = Uuid & { readonly __kind: 'Ga4DailyMetricId' };

--- a/packages/domain/src/traffic-analytics/value-objects/property-handle.ts
+++ b/packages/domain/src/traffic-analytics/value-objects/property-handle.ts
@@ -1,0 +1,28 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * GA4 properties are addressed by a numeric id. The Admin UI shows it
+ * sometimes bare (`123456789`) and sometimes prefixed (`properties/123456789`)
+ * in URLs and API examples. We canonicalise to the bare numeric form for
+ * storage so equality is trivial and indexes are tight, but we accept either
+ * shape on the way in.
+ */
+export class Ga4PropertyHandle {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): Ga4PropertyHandle {
+		const trimmed = raw.trim();
+		if (trimmed.length === 0) {
+			throw new InvalidInputError('GA4 propertyId cannot be empty');
+		}
+		const stripped = trimmed.startsWith('properties/') ? trimmed.slice('properties/'.length) : trimmed;
+		if (!/^\d+$/.test(stripped)) {
+			throw new InvalidInputError('GA4 propertyId must be numeric (or "properties/<digits>")');
+		}
+		return new Ga4PropertyHandle(stripped);
+	}
+
+	toApiPath(): string {
+		return `properties/${this.value}`;
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -22,6 +22,8 @@ export { DrizzleRankingObservationRepository } from './repositories/rank-trackin
 export { DrizzleTrackedKeywordRepository } from './repositories/rank-tracking/tracked-keyword.repository.js';
 export { DrizzleGscPerformanceObservationRepository } from './repositories/search-console-insights/gsc-performance-observation.repository.js';
 export { DrizzleGscPropertyRepository } from './repositories/search-console-insights/gsc-property.repository.js';
+export { DrizzleGa4DailyMetricRepository } from './repositories/traffic-analytics/ga4-daily-metric.repository.js';
+export { DrizzleGa4PropertyRepository } from './repositories/traffic-analytics/ga4-property.repository.js';
 export { DrizzlePageSpeedSnapshotRepository } from './repositories/web-performance/page-speed-snapshot.repository.js';
 export { DrizzleTrackedPageRepository } from './repositories/web-performance/tracked-page.repository.js';
 export * as schema from './schema/index.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0007_black_clea.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0007_black_clea.sql
@@ -1,0 +1,47 @@
+-- Issue #17 — GA4 Data API tables. Idempotent with IF NOT EXISTS +
+-- DO $$ EXCEPTION duplicate_object guards (forward-only, safe to retry).
+
+CREATE TABLE IF NOT EXISTS "ga4_properties" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"property_handle" text NOT NULL,
+	"credential_id" uuid,
+	"linked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"unlinked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ga4_daily_metrics" (
+	"ga4_property_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_date" text NOT NULL,
+	"dimensions_hash" text NOT NULL,
+	"dimensions" jsonb NOT NULL,
+	"metrics" jsonb NOT NULL,
+	"raw_payload_id" uuid,
+	CONSTRAINT "ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk" PRIMARY KEY("ga4_property_id","observed_date","dimensions_hash")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ga4_properties" ADD CONSTRAINT "ga4_properties_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ga4_properties" ADD CONSTRAINT "ga4_properties_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ga4_properties" ADD CONSTRAINT "ga4_properties_credential_id_provider_credentials_id_fk" FOREIGN KEY ("credential_id") REFERENCES "public"."provider_credentials"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "ga4_daily_metrics" ADD CONSTRAINT "ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk" FOREIGN KEY ("ga4_property_id") REFERENCES "public"."ga4_properties"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "ga4_properties_project_handle_unique" ON "ga4_properties" USING btree ("project_id","property_handle");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ga4_properties_project_idx" ON "ga4_properties" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ga4_daily_metrics_project_idx" ON "ga4_daily_metrics" USING btree ("project_id","observed_date");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0007_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2897 @@
+{
+	"id": "86c65c06-8d7a-44bd-b25a-bc13809039b7",
+	"prevId": "126ab0ed-c96b-4bb7-b38a-9fd09eb6adb0",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_daily_metrics": {
+			"name": "ga4_daily_metrics",
+			"schema": "",
+			"columns": {
+				"ga4_property_id": {
+					"name": "ga4_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions_hash": {
+					"name": "dimensions_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions": {
+					"name": "dimensions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metrics": {
+					"name": "metrics",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_daily_metrics_project_idx": {
+					"name": "ga4_daily_metrics_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk": {
+					"name": "ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk",
+					"tableFrom": "ga4_daily_metrics",
+					"tableTo": "ga4_properties",
+					"columnsFrom": ["ga4_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk": {
+					"name": "ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk",
+					"columns": ["ga4_property_id", "observed_date", "dimensions_hash"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_properties": {
+			"name": "ga4_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_handle": {
+					"name": "property_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_properties_project_handle_unique": {
+					"name": "ga4_properties_project_handle_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "property_handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ga4_properties_project_idx": {
+					"name": "ga4_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_properties_organization_id_organizations_id_fk": {
+					"name": "ga4_properties_organization_id_organizations_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_project_id_projects_id_fk": {
+					"name": "ga4_properties_project_id_projects_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_credential_id_provider_credentials_id_fk": {
+					"name": "ga4_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_speed_snapshots": {
+			"name": "page_speed_snapshots",
+			"schema": "",
+			"columns": {
+				"tracked_page_id": {
+					"name": "tracked_page_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lcp_ms": {
+					"name": "lcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"inp_ms": {
+					"name": "inp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cls": {
+					"name": "cls",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fcp_ms": {
+					"name": "fcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ttfb_ms": {
+					"name": "ttfb_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"performance_score": {
+					"name": "performance_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seo_score": {
+					"name": "seo_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessibility_score": {
+					"name": "accessibility_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"best_practices_score": {
+					"name": "best_practices_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"page_speed_snapshots_project_idx": {
+					"name": "page_speed_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_speed_snapshots_tracked_page_id_tracked_pages_id_fk": {
+					"name": "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk",
+					"tableFrom": "page_speed_snapshots",
+					"tableTo": "tracked_pages",
+					"columnsFrom": ["tracked_page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"page_speed_snapshots_tracked_page_id_observed_at_pk": {
+					"name": "page_speed_snapshots_tracked_page_id_observed_at_pk",
+					"columns": ["tracked_page_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_pages": {
+			"name": "tracked_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"strategy": {
+					"name": "strategy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_pages_project_url_strategy_unique": {
+					"name": "tracked_pages_project_url_strategy_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "strategy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_pages_project_idx": {
+					"name": "tracked_pages_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_pages_organization_id_organizations_id_fk": {
+					"name": "tracked_pages_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_pages_project_id_projects_id_fk": {
+					"name": "tracked_pages_project_id_projects_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
 			"when": 1778014293229,
 			"tag": "0006_flowery_shotgun",
 			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1778015988471,
+			"tag": "0007_black_clea",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/traffic-analytics/ga4-daily-metric.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/traffic-analytics/ga4-daily-metric.repository.ts
@@ -1,0 +1,79 @@
+import { type ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { and, between, desc, eq, gte, sql } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { ga4DailyMetrics } from '../../schema/index.js';
+
+export class DrizzleGa4DailyMetricRepository implements TrafficAnalytics.Ga4DailyMetricRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async saveAll(metrics: readonly TrafficAnalytics.Ga4DailyMetric[]): Promise<{ inserted: number }> {
+		if (metrics.length === 0) return { inserted: 0 };
+		const rows = metrics.map((m) => ({
+			ga4PropertyId: m.ga4PropertyId,
+			projectId: m.projectId,
+			observedDate: m.observedDate,
+			dimensionsHash: m.dimensionsHash,
+			dimensions: { ...m.body.dimensions },
+			metrics: { ...m.body.metrics },
+			rawPayloadId: m.rawPayloadId,
+		}));
+		const inserted = await this.db
+			.insert(ga4DailyMetrics)
+			.values(rows)
+			.onConflictDoNothing({
+				target: [ga4DailyMetrics.ga4PropertyId, ga4DailyMetrics.observedDate, ga4DailyMetrics.dimensionsHash],
+			})
+			.returning({ ga4PropertyId: ga4DailyMetrics.ga4PropertyId });
+		return { inserted: inserted.length };
+	}
+
+	async listForProperty(
+		propertyId: TrafficAnalytics.Ga4PropertyId,
+		query: TrafficAnalytics.Ga4DailyMetricQuery,
+	): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		const rows = await this.db
+			.select()
+			.from(ga4DailyMetrics)
+			.where(
+				and(
+					eq(ga4DailyMetrics.ga4PropertyId, propertyId),
+					between(ga4DailyMetrics.observedDate, query.from, query.to),
+				),
+			)
+			.orderBy(ga4DailyMetrics.observedDate);
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listLatestForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		// Mirror the GSC pattern: recent window, capped, ordered by date desc.
+		const cutoff = sql<string>`to_char(now() - interval '14 days', 'YYYY-MM-DD')`;
+		const rows = await this.db
+			.select()
+			.from(ga4DailyMetrics)
+			.where(and(eq(ga4DailyMetrics.projectId, projectId), gte(ga4DailyMetrics.observedDate, cutoff)))
+			.orderBy(desc(ga4DailyMetrics.observedDate))
+			.limit(500);
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof ga4DailyMetrics.$inferSelect): TrafficAnalytics.Ga4DailyMetric {
+		// The natural key (propertyId, observedDate, dimensionsHash) drives uniqueness;
+		// we surface a synthetic surrogate id so the aggregate shape stays stable.
+		const surrogateId =
+			`${row.ga4PropertyId}#${row.observedDate}#${row.dimensionsHash}` as TrafficAnalytics.Ga4DailyMetricId;
+		return TrafficAnalytics.Ga4DailyMetric.rehydrate({
+			id: surrogateId,
+			ga4PropertyId: row.ga4PropertyId as TrafficAnalytics.Ga4PropertyId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			observedDate: row.observedDate,
+			dimensionsHash: row.dimensionsHash,
+			body: TrafficAnalytics.Ga4DailyDimensionsMetrics.create({
+				dimensions: row.dimensions,
+				metrics: row.metrics,
+			}),
+			rawPayloadId: row.rawPayloadId,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/traffic-analytics/ga4-property.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/traffic-analytics/ga4-property.repository.ts
@@ -1,0 +1,102 @@
+import { type IdentityAccess, type ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { ga4Properties } from '../../schema/index.js';
+
+const UNIQUE_TUPLE_CONSTRAINT = 'ga4_properties_project_handle_unique';
+
+const isUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_TUPLE_CONSTRAINT;
+};
+
+export class DrizzleGa4PropertyRepository implements TrafficAnalytics.Ga4PropertyRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(property: TrafficAnalytics.Ga4Property): Promise<void> {
+		try {
+			await this.db
+				.insert(ga4Properties)
+				.values({
+					id: property.id,
+					organizationId: property.organizationId,
+					projectId: property.projectId,
+					propertyHandle: property.propertyHandle.value,
+					credentialId: property.credentialId,
+					linkedAt: property.linkedAt,
+					unlinkedAt: property.unlinkedAt,
+				})
+				.onConflictDoUpdate({
+					target: ga4Properties.id,
+					set: {
+						propertyHandle: property.propertyHandle.value,
+						credentialId: property.credentialId,
+						unlinkedAt: property.unlinkedAt,
+					},
+				});
+		} catch (err) {
+			if (isUniqueViolation(err)) {
+				throw new ConflictError(
+					`GA4 property "${property.propertyHandle.value}" is already linked to project ${property.projectId}`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(id: TrafficAnalytics.Ga4PropertyId): Promise<TrafficAnalytics.Ga4Property | null> {
+		const [row] = await this.db.select().from(ga4Properties).where(eq(ga4Properties.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByProjectAndHandle(
+		projectId: ProjectManagement.ProjectId,
+		propertyHandle: string,
+	): Promise<TrafficAnalytics.Ga4Property | null> {
+		const handle = TrafficAnalytics.Ga4PropertyHandle.create(propertyHandle);
+		const [row] = await this.db
+			.select()
+			.from(ga4Properties)
+			.where(and(eq(ga4Properties.projectId, projectId), eq(ga4Properties.propertyHandle, handle.value)))
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		const rows = await this.db
+			.select()
+			.from(ga4Properties)
+			.where(eq(ga4Properties.projectId, projectId))
+			.orderBy(desc(ga4Properties.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listForOrganization(
+		orgId: IdentityAccess.OrganizationId,
+	): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		const rows = await this.db
+			.select()
+			.from(ga4Properties)
+			.where(eq(ga4Properties.organizationId, orgId))
+			.orderBy(desc(ga4Properties.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof ga4Properties.$inferSelect): TrafficAnalytics.Ga4Property {
+		return TrafficAnalytics.Ga4Property.rehydrate({
+			id: row.id as TrafficAnalytics.Ga4PropertyId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			propertyHandle: TrafficAnalytics.Ga4PropertyHandle.create(row.propertyHandle),
+			credentialId: row.credentialId,
+			linkedAt: row.linkedAt,
+			unlinkedAt: row.unlinkedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -636,3 +636,66 @@ export const wikipediaPageviews = pgTable(
 
 export type WikipediaArticleRow = typeof wikipediaArticles.$inferSelect;
 export type WikipediaPageviewRow = typeof wikipediaPageviews.$inferSelect;
+
+// ---- traffic-analytics (GA4) ----
+
+/**
+ * Issue #17 — GA4 properties linked to a project. The handle is the bare
+ * numeric form (without the `properties/` prefix); the unique index
+ * enforces one mapping per project regardless of how the user typed it
+ * because the domain VO canonicalises before save.
+ */
+export const ga4Properties = pgTable(
+	'ga4_properties',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		propertyHandle: text('property_handle').notNull(),
+		credentialId: uuid('credential_id').references(() => providerCredentials.id, { onDelete: 'set null' }),
+		linkedAt: timestamp('linked_at', { withTimezone: true }).notNull().defaultNow(),
+		unlinkedAt: timestamp('unlinked_at', { withTimezone: true }),
+	},
+	(t) => ({
+		uniqueByProjectHandle: uniqueIndex('ga4_properties_project_handle_unique').on(
+			t.projectId,
+			t.propertyHandle,
+		),
+		projectIdx: index('ga4_properties_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of GA4 daily metrics. Natural PK is
+ * (ga4_property_id, observed_date, dimensions_hash) — the application layer
+ * computes a stable SHA-256 over the canonical dimensions JSON before the
+ * write so re-fetching the same window with the same dimension set is a
+ * no-op. Dimensions and metrics are stored as jsonb because the cardinality
+ * is bounded per request (max 9 dims, 10 metrics) and we never query INTO
+ * the JSON — the read side picks specific keys.
+ */
+export const ga4DailyMetrics = pgTable(
+	'ga4_daily_metrics',
+	{
+		ga4PropertyId: uuid('ga4_property_id')
+			.notNull()
+			.references(() => ga4Properties.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedDate: text('observed_date').notNull(), // YYYY-MM-DD
+		dimensionsHash: text('dimensions_hash').notNull(),
+		dimensions: jsonb('dimensions').notNull().$type<Record<string, string>>(),
+		metrics: jsonb('metrics').notNull().$type<Record<string, number>>(),
+		rawPayloadId: uuid('raw_payload_id'),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.ga4PropertyId, t.observedDate, t.dimensionsHash] }),
+		projectIdx: index('ga4_daily_metrics_project_idx').on(t.projectId, t.observedDate),
+	}),
+);
+
+export type Ga4PropertyRow = typeof ga4Properties.$inferSelect;
+export type Ga4DailyMetricRow = typeof ga4DailyMetrics.$inferSelect;

--- a/packages/providers/ga4/package.json
+++ b/packages/providers/ga4/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@rankpulse/provider-ga4",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"google-auth-library": "10.6.2",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/ga4/src/acl/run-report-to-rows.acl.spec.ts
+++ b/packages/providers/ga4/src/acl/run-report-to-rows.acl.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { RunReportResponse } from '../endpoints/run-report.js';
+import { extractRows } from './run-report-to-rows.acl.js';
+
+const fixture: RunReportResponse = {
+	dimensionHeaders: [{ name: 'date' }, { name: 'sessionDefaultChannelGroup' }, { name: 'country' }],
+	metricHeaders: [
+		{ name: 'sessions', type: 'TYPE_INTEGER' },
+		{ name: 'totalUsers', type: 'TYPE_INTEGER' },
+		{ name: 'engagementRate', type: 'TYPE_FLOAT' },
+	],
+	rows: [
+		{
+			dimensionValues: [{ value: '20260501' }, { value: 'Organic Search' }, { value: 'Spain' }],
+			metricValues: [{ value: '1240' }, { value: '982' }, { value: '0.6132' }],
+		},
+		{
+			dimensionValues: [{ value: '20260502' }, { value: 'Direct' }, { value: 'Mexico' }],
+			metricValues: [{ value: '88' }, { value: '74' }, { value: '0.4318' }],
+		},
+	],
+	rowCount: 2,
+};
+
+describe('extractRows', () => {
+	it('projects dimension values by header name', () => {
+		const rows = extractRows(fixture, { startDate: '2026-05-01', endDate: '2026-05-02' });
+		expect(rows).toHaveLength(2);
+		expect(rows[0]?.dimensions).toEqual({
+			date: '2026-05-01',
+			sessionDefaultChannelGroup: 'Organic Search',
+			country: 'Spain',
+		});
+		expect(rows[1]?.dimensions.country).toBe('Mexico');
+	});
+
+	it('coerces metric strings to numbers', () => {
+		const rows = extractRows(fixture, { startDate: '2026-05-01', endDate: '2026-05-02' });
+		expect(rows[0]?.metrics).toEqual({ sessions: 1240, totalUsers: 982, engagementRate: 0.6132 });
+		expect(rows[1]?.metrics.sessions).toBe(88);
+	});
+
+	it('expands GA4 compact YYYYMMDD into ISO calendar dates', () => {
+		const rows = extractRows(fixture, { startDate: '2026-05-01', endDate: '2026-05-02' });
+		expect(rows[0]?.observedDate).toBe('2026-05-01');
+		expect(rows[1]?.observedDate).toBe('2026-05-02');
+	});
+
+	it('falls back to endDate when no date dimension is requested', () => {
+		const noDate: RunReportResponse = {
+			dimensionHeaders: [{ name: 'country' }],
+			metricHeaders: [{ name: 'sessions' }],
+			rows: [{ dimensionValues: [{ value: 'Spain' }], metricValues: [{ value: '5' }] }],
+		};
+		const rows = extractRows(noDate, { startDate: '2026-05-01', endDate: '2026-05-07' });
+		expect(rows[0]?.observedDate).toBe('2026-05-07');
+		expect(rows[0]?.dimensions).toEqual({ country: 'Spain' });
+	});
+
+	it('returns empty when GA4 had no traffic in the window', () => {
+		expect(extractRows({}, { startDate: '2026-05-01', endDate: '2026-05-02' })).toEqual([]);
+	});
+
+	it('treats missing/non-numeric metric values as 0 rather than NaN', () => {
+		const messy: RunReportResponse = {
+			dimensionHeaders: [{ name: 'date' }],
+			metricHeaders: [{ name: 'sessions' }, { name: 'totalUsers' }],
+			rows: [
+				{
+					dimensionValues: [{ value: '20260501' }],
+					metricValues: [{ value: '' }, { value: 'not-a-number' }],
+				},
+				{ dimensionValues: [{ value: '20260502' }], metricValues: [{}, { value: undefined }] },
+			],
+		};
+		const rows = extractRows(messy, { startDate: '2026-05-01', endDate: '2026-05-02' });
+		expect(rows[0]?.metrics).toEqual({ sessions: 0, totalUsers: 0 });
+		expect(rows[1]?.metrics).toEqual({ sessions: 0, totalUsers: 0 });
+	});
+
+	it('preserves already-ISO date dimensions without re-formatting', () => {
+		const isoDate: RunReportResponse = {
+			dimensionHeaders: [{ name: 'date' }],
+			metricHeaders: [{ name: 'sessions' }],
+			rows: [{ dimensionValues: [{ value: '2026-05-01' }], metricValues: [{ value: '7' }] }],
+		};
+		const rows = extractRows(isoDate, { startDate: '2026-05-01', endDate: '2026-05-01' });
+		expect(rows[0]?.observedDate).toBe('2026-05-01');
+	});
+});

--- a/packages/providers/ga4/src/acl/run-report-to-rows.acl.ts
+++ b/packages/providers/ga4/src/acl/run-report-to-rows.acl.ts
@@ -1,0 +1,67 @@
+import type { RunReportParams, RunReportResponse } from '../endpoints/run-report.js';
+
+/**
+ * Domain-shaped row coming out of a `runReport` call. We keep dimensions
+ * as a flexible JSON map (the user picks which ones at request time) and
+ * metrics as a parallel JSON map of numbers — GA4 returns them as strings,
+ * we coerce here so the read side and aggregations don't have to.
+ *
+ * `observedDate` is the calendar date this row belongs to when `date` is
+ * one of the requested dimensions; otherwise the caller's `endDate` (the
+ * snapshot's "as of" date).
+ */
+export interface NormalizedGa4Row {
+	observedDate: string; // YYYY-MM-DD
+	dimensions: Record<string, string>;
+	metrics: Record<string, number>;
+}
+
+const isYyyyMmDd = (s: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(s);
+
+const insertDate = (dateRaw: string): string => {
+	// GA4 returns date dimension as YYYYMMDD. Split into YYYY-MM-DD so the
+	// downstream side never has to know about that compact form.
+	if (isYyyyMmDd(dateRaw)) return dateRaw;
+	if (/^\d{8}$/.test(dateRaw)) return `${dateRaw.slice(0, 4)}-${dateRaw.slice(4, 6)}-${dateRaw.slice(6, 8)}`;
+	return dateRaw;
+};
+
+const toNumber = (raw: string | undefined): number => {
+	if (raw === undefined || raw === null || raw === '') return 0;
+	const n = Number(raw);
+	return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * Pure ACL: GA4 v1beta `runReport` payload -> normalized rows.
+ *
+ * Headers tell us the order of dimensions/metrics; we project values by
+ * name so callers don't index by position. If GA4 returns no rows
+ * (no traffic in the window), we return an empty array — never null.
+ */
+export const extractRows = (
+	response: RunReportResponse,
+	params: Pick<RunReportParams, 'startDate' | 'endDate'>,
+): NormalizedGa4Row[] => {
+	const dimensionHeaders = response.dimensionHeaders ?? [];
+	const metricHeaders = response.metricHeaders ?? [];
+	const rows = response.rows ?? [];
+	const fallbackDate = isYyyyMmDd(params.endDate) ? params.endDate : '';
+
+	return rows.map((row) => {
+		const dims: Record<string, string> = {};
+		dimensionHeaders.forEach((h, idx) => {
+			const value = row.dimensionValues?.[idx]?.value;
+			if (typeof value !== 'string') return;
+			// Normalize the canonical `date` dimension upfront so callers see one
+			// shape regardless of GA4's compact YYYYMMDD return format.
+			dims[h.name] = h.name === 'date' ? insertDate(value) : value;
+		});
+		const mets: Record<string, number> = {};
+		metricHeaders.forEach((h, idx) => {
+			mets[h.name] = toNumber(row.metricValues?.[idx]?.value);
+		});
+		const observedDate = dims.date ?? fallbackDate;
+		return { observedDate, dimensions: dims, metrics: mets };
+	});
+};

--- a/packages/providers/ga4/src/credential.ts
+++ b/packages/providers/ga4/src/credential.ts
@@ -1,0 +1,33 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * GA4 Data API credentials. The same Service Account JSON shape Google uses
+ * everywhere — we share the parser with GSC because both APIs accept the
+ * exact same `{client_email, private_key}` envelope.
+ *
+ * The SA must be added as a Viewer on the GA4 property
+ * (Admin -> Property Access Management) before any call succeeds.
+ */
+export interface ServiceAccountKey {
+	client_email: string;
+	private_key: string;
+	[k: string]: unknown;
+}
+
+export const parseServiceAccount = (plaintext: string): ServiceAccountKey => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(plaintext);
+	} catch {
+		throw new InvalidInputError('GA4 credential must be a Service Account JSON blob');
+	}
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		typeof (parsed as ServiceAccountKey).client_email !== 'string' ||
+		typeof (parsed as ServiceAccountKey).private_key !== 'string'
+	) {
+		throw new InvalidInputError('Service account JSON must contain client_email and private_key');
+	}
+	return parsed as ServiceAccountKey;
+};

--- a/packages/providers/ga4/src/endpoints/run-report.ts
+++ b/packages/providers/ga4/src/endpoints/run-report.ts
@@ -1,0 +1,97 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { DATE_OR_TOKEN_REGEX } from '@rankpulse/shared';
+import { z } from 'zod';
+import type { Ga4Http } from '../http.js';
+
+/**
+ * GA4 Data API v1beta is generally available despite the version label.
+ * Quotas are per-property tokenized:
+ *   - 200 000 core tokens / property / day
+ *   - 1 250 concurrent requests / property
+ * A single `runReport` consumes ~10 tokens depending on dimension count,
+ * which gives us plenty of room for a daily cron at low cardinality.
+ *
+ * Property IDs are numeric; we accept the `properties/123456` form too
+ * because that's what GA4's UI shows in the property picker.
+ */
+const PropertyIdRegex = /^(properties\/)?\d+$/;
+
+const DimensionName = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[a-zA-Z][a-zA-Z0-9_]*$/);
+const MetricName = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[a-zA-Z][a-zA-Z0-9_]*$/);
+
+export const RunReportParams = z.object({
+	propertyId: z.string().regex(PropertyIdRegex, 'propertyId must be numeric or "properties/<id>"'),
+	startDate: z.string().regex(DATE_OR_TOKEN_REGEX),
+	endDate: z.string().regex(DATE_OR_TOKEN_REGEX),
+	dimensions: z.array(DimensionName).min(1).max(9).default(['date']),
+	metrics: z
+		.array(MetricName)
+		.min(1)
+		.max(10)
+		.default(['sessions', 'totalUsers', 'screenPageViews', 'engagedSessions']),
+	rowLimit: z.number().int().min(1).max(100_000).default(10_000),
+	offset: z.number().int().min(0).default(0),
+	keepEmptyRows: z.boolean().default(false),
+});
+export type RunReportParams = z.infer<typeof RunReportParams>;
+
+export const runReportDescriptor: EndpointDescriptor = {
+	id: 'ga4-run-report',
+	category: 'rankings',
+	displayName: 'GA4 Run Report',
+	description:
+		'Real GA4 traffic metrics (sessions, users, pageviews, engagement, conversions) sliced by configurable dimensions. Free; 200k tokens/day/property.',
+	paramsSchema: RunReportParams,
+	cost: { unit: 'usd_cents', amount: 0 },
+	defaultCron: '0 4 * * *', // daily 04:00 UTC, after GSC's 05:00 lag tolerance
+	rateLimit: { max: 60, durationMs: 60_000 },
+};
+
+export interface DimensionHeader {
+	name: string;
+}
+export interface MetricHeader {
+	name: string;
+	type?: string;
+}
+export interface RunReportRow {
+	dimensionValues?: { value?: string; oneValue?: 'value' }[];
+	metricValues?: { value?: string }[];
+}
+export interface RunReportResponse {
+	dimensionHeaders?: DimensionHeader[];
+	metricHeaders?: MetricHeader[];
+	rows?: RunReportRow[];
+	rowCount?: number;
+	metadata?: { currencyCode?: string; timeZone?: string };
+}
+
+const normalizePropertyId = (raw: string): string =>
+	raw.startsWith('properties/') ? raw : `properties/${raw}`;
+
+export const fetchRunReport = async (
+	http: Ga4Http,
+	params: RunReportParams,
+	ctx: FetchContext,
+): Promise<RunReportResponse> => {
+	const property = normalizePropertyId(params.propertyId);
+	const path = `/v1beta/${property}:runReport`;
+	const body = {
+		dateRanges: [{ startDate: params.startDate, endDate: params.endDate }],
+		dimensions: params.dimensions.map((name) => ({ name })),
+		metrics: params.metrics.map((name) => ({ name })),
+		limit: String(params.rowLimit),
+		offset: String(params.offset),
+		keepEmptyRows: params.keepEmptyRows,
+	};
+	const raw = (await http.post(path, body, ctx.credential.plaintextSecret, ctx.signal)) as RunReportResponse;
+	return raw;
+};

--- a/packages/providers/ga4/src/http.ts
+++ b/packages/providers/ga4/src/http.ts
@@ -1,0 +1,96 @@
+import { JWT } from 'google-auth-library';
+import { parseServiceAccount, type ServiceAccountKey } from './credential.js';
+
+/**
+ * Read-only scope for the Data API. `analytics.readonly` covers both core
+ * reports and realtime; we never write so we don't request more.
+ */
+const SCOPES = ['https://www.googleapis.com/auth/analytics.readonly'];
+
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+export class Ga4ApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'Ga4ApiError';
+	}
+}
+
+/**
+ * Service Account-authenticated client for the GA4 Data API. Each call
+ * mints a fresh JWT-based access token via google-auth-library; the library
+ * caches it internally until expiry.
+ */
+export class Ga4Http {
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: { fetchImpl?: typeof fetch } = {}) {
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	}
+
+	async post(
+		path: string,
+		body: unknown,
+		plaintextCredential: string,
+		signal?: AbortSignal,
+	): Promise<unknown> {
+		const sa = parseServiceAccount(plaintextCredential);
+		const jwt = this.buildJwt(sa);
+		const tokenResponse = await jwt.authorize();
+		if (!tokenResponse.access_token) {
+			throw new Ga4ApiError(401, tokenResponse, 'Service account did not return an access_token');
+		}
+		const url = `https://analyticsdata.googleapis.com${path}`;
+		const response = await this.fetchImpl(url, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${tokenResponse.access_token}`,
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+			},
+			body: JSON.stringify(body),
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new Ga4ApiError(
+				response.status,
+				null,
+				`GA4 ${path} response too large: ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new Ga4ApiError(
+				response.status,
+				null,
+				`GA4 ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new Ga4ApiError(response.status, parsed, `GA4 ${path} returned HTTP ${response.status}`);
+		}
+		return parsed;
+	}
+
+	private buildJwt(sa: ServiceAccountKey): JWT {
+		return new JWT({
+			email: sa.client_email,
+			key: sa.private_key,
+			scopes: SCOPES,
+		});
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/ga4/src/index.ts
+++ b/packages/providers/ga4/src/index.ts
@@ -1,0 +1,5 @@
+export * from './acl/run-report-to-rows.acl.js';
+export * from './credential.js';
+export * from './endpoints/run-report.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/ga4/src/provider.spec.ts
+++ b/packages/providers/ga4/src/provider.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { RunReportParams } from './endpoints/run-report.js';
+import { Ga4Provider } from './provider.js';
+
+const validServiceAccountJson = JSON.stringify({
+	type: 'service_account',
+	project_id: 'rankpulse',
+	client_email: 'claude-access@rankpulse.iam.gserviceaccount.com',
+	private_key: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
+});
+
+describe('Ga4Provider', () => {
+	it('exposes the run-report endpoint via discover()', () => {
+		const provider = new Ga4Provider();
+		const ids = provider.discover().map((e) => e.id);
+		expect(ids).toContain('ga4-run-report');
+	});
+
+	it('validateCredentialPlaintext accepts a service account JSON blob', () => {
+		const provider = new Ga4Provider();
+		expect(() => provider.validateCredentialPlaintext(validServiceAccountJson)).not.toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects non-JSON plaintext', () => {
+		const provider = new Ga4Provider();
+		expect(() => provider.validateCredentialPlaintext('not-json')).toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects JSON missing client_email/private_key', () => {
+		const provider = new Ga4Provider();
+		expect(() => provider.validateCredentialPlaintext(JSON.stringify({ project_id: 'x' }))).toThrow();
+	});
+
+	it('paramsSchema accepts a numeric propertyId', () => {
+		const provider = new Ga4Provider();
+		const ep = provider.discover().find((e) => e.id === 'ga4-run-report');
+		const parsed = ep?.paramsSchema.safeParse({
+			propertyId: '123456789',
+			startDate: '2026-05-01',
+			endDate: '2026-05-02',
+		});
+		expect(parsed?.success).toBe(true);
+	});
+
+	it('paramsSchema accepts a "properties/<id>" propertyId', () => {
+		const provider = new Ga4Provider();
+		const ep = provider.discover().find((e) => e.id === 'ga4-run-report');
+		const parsed = ep?.paramsSchema.safeParse({
+			propertyId: 'properties/123456789',
+			startDate: '{{today-30}}',
+			endDate: '{{today-2}}',
+		});
+		expect(parsed?.success).toBe(true);
+	});
+
+	it('paramsSchema rejects a propertyId that contains letters', () => {
+		const provider = new Ga4Provider();
+		const ep = provider.discover().find((e) => e.id === 'ga4-run-report');
+		const parsed = ep?.paramsSchema.safeParse({
+			propertyId: 'GA-12345',
+			startDate: '2026-05-01',
+			endDate: '2026-05-02',
+		});
+		expect(parsed?.success).toBe(false);
+	});
+
+	it('paramsSchema rejects more than 9 dimensions (GA4 hard limit)', () => {
+		const provider = new Ga4Provider();
+		const ep = provider.discover().find((e) => e.id === 'ga4-run-report');
+		const parsed = ep?.paramsSchema.safeParse({
+			propertyId: '1',
+			startDate: '2026-05-01',
+			endDate: '2026-05-02',
+			dimensions: Array.from({ length: 10 }, (_, i) => `dim${i}`),
+		});
+		expect(parsed?.success).toBe(false);
+	});
+
+	it('paramsSchema applies defaults for metrics and rowLimit', () => {
+		const parsed = RunReportParams.safeParse({
+			propertyId: '1',
+			startDate: '2026-05-01',
+			endDate: '2026-05-02',
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.metrics).toContain('sessions');
+			expect(parsed.data.rowLimit).toBe(10_000);
+		}
+	});
+
+	it('fetch rejects an unknown endpoint id', async () => {
+		const provider = new Ga4Provider();
+		await expect(
+			provider.fetch('not-a-real-endpoint', {}, {
+				credential: { plaintextSecret: validServiceAccountJson },
+				signal: new AbortController().signal,
+			} as never),
+		).rejects.toThrow();
+	});
+});

--- a/packages/providers/ga4/src/provider.ts
+++ b/packages/providers/ga4/src/provider.ts
@@ -1,0 +1,42 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import { parseServiceAccount } from './credential.js';
+import { fetchRunReport, type RunReportParams, runReportDescriptor } from './endpoints/run-report.js';
+import { Ga4Http } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [runReportDescriptor];
+
+export class Ga4Provider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('google-analytics-4');
+	readonly displayName = 'Google Analytics 4';
+	readonly authStrategy = 'serviceAccount' as const;
+
+	private readonly http: Ga4Http;
+
+	constructor(options?: { fetchImpl?: typeof fetch }) {
+		this.http = new Ga4Http(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		parseServiceAccount(plaintextSecret);
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case runReportDescriptor.id: {
+				const parsed = runReportDescriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(`Invalid params for ${endpointId}: ${parsed.error.message}`);
+				}
+				return await fetchRunReport(this.http, parsed.data as RunReportParams, ctx);
+			}
+			default:
+				throw new InvalidInputError(`google-analytics-4 has no endpoint "${endpointId}"`);
+		}
+	}
+}

--- a/packages/providers/ga4/tsconfig.build.json
+++ b/packages/providers/ga4/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/ga4/tsconfig.json
+++ b/packages/providers/ga4/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/ga4/vitest.config.ts
+++ b/packages/providers/ga4/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,5 +1,6 @@
 import { HttpClient, type HttpClientOptions } from './http.js';
 import { AuthResource } from './resources/auth.js';
+import { Ga4Resource } from './resources/ga4.js';
 import { GscResource } from './resources/gsc.js';
 import { PageSpeedResource } from './resources/page-speed.js';
 import { ProjectsResource } from './resources/projects.js';
@@ -21,6 +22,7 @@ export class RankPulseClient {
 	readonly gsc: GscResource;
 	readonly wikipedia: WikipediaResource;
 	readonly pageSpeed: PageSpeedResource;
+	readonly ga4: Ga4Resource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -33,5 +35,6 @@ export class RankPulseClient {
 		this.gsc = new GscResource(http);
 		this.wikipedia = new WikipediaResource(http);
 		this.pageSpeed = new PageSpeedResource(http);
+		this.ga4 = new Ga4Resource(http);
 	}
 }

--- a/packages/sdk/src/resources/ga4.ts
+++ b/packages/sdk/src/resources/ga4.ts
@@ -1,0 +1,30 @@
+import type { TrafficAnalyticsContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class Ga4Resource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<TrafficAnalyticsContracts.Ga4PropertyDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/ga4/properties`);
+	}
+
+	link(
+		projectId: string,
+		body: TrafficAnalyticsContracts.LinkGa4PropertyRequest,
+	): Promise<{ ga4PropertyId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/ga4/properties`, body);
+	}
+
+	unlink(ga4PropertyId: string): Promise<{ ok: true }> {
+		return this.http.delete(`/ga4/properties/${encodeURIComponent(ga4PropertyId)}`);
+	}
+
+	metrics(
+		ga4PropertyId: string,
+		query: TrafficAnalyticsContracts.Ga4MetricsQuery,
+	): Promise<TrafficAnalyticsContracts.Ga4DailyMetricDto[]> {
+		return this.http.get(`/ga4/properties/${encodeURIComponent(ga4PropertyId)}/metrics`, {
+			query: { from: query.from, to: query.to },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@rankpulse/provider-dataforseo':
         specifier: workspace:*
         version: link:../../packages/providers/dataforseo
+      '@rankpulse/provider-ga4':
+        specifier: workspace:*
+        version: link:../../packages/providers/ga4
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
@@ -202,6 +205,9 @@ importers:
       '@rankpulse/provider-dataforseo':
         specifier: workspace:*
         version: link:../../packages/providers/dataforseo
+      '@rankpulse/provider-ga4':
+        specifier: workspace:*
+        version: link:../../packages/providers/ga4
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
@@ -361,6 +367,31 @@ importers:
       '@rankpulse/shared':
         specifier: workspace:*
         version: link:../../shared
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/ga4:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      google-auth-library:
+        specifier: 10.6.2
+        version: 10.6.2
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
Closes #17.

## Summary
- New provider package `@rankpulse/provider-ga4`: SA-JWT client (mirrors GSC, scope `analytics.readonly`), `ga4-run-report` descriptor (cron `0 4 * * *`, rate-limit 60 req/min as a soft floor for GA4's 200k tokens/property/day), pure ACL `extractRows()` projecting headers by name and normalising GA4's compact `YYYYMMDD` date dim into ISO `YYYY-MM-DD`.
- New `traffic-analytics` bounded context: `Ga4Property` aggregate with `Ga4PropertyHandle` value object that canonicalises both `123456789` and `properties/123456789` into the bare numeric form before save, `Ga4DailyMetric` value-like with strict `Number.isFinite` invariants on metrics. `Ga4PropertyLinked` and `Ga4BatchIngested` events.
- Drizzle migration 0007 — `ga4_properties` (uniqueness on `(project_id, property_handle)`) + `ga4_daily_metrics` (natural PK `(ga4_property_id, observed_date, dimensions_hash)`); idempotent IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
- Application layer — `LinkGa4Property` (canonicalises before lookup so `properties/X` and bare `X` collide as duplicates), `UnlinkGa4Property` (idempotent), `IngestGa4Rows` (sorted-key SHA-256 over canonical dimensions JSON so reordering keys never breaks idempotency, only `inserted` counts in the totals event), `QueryGa4Metrics`. 11 unit tests covering: first-insert + summary event, no-op on retry of same window, fresh row for new dimension breakdown, NotFound, empty-batch short-circuit, NaN metric rejection at the aggregate boundary, hash stability under key reordering, and link/canonicalisation edge cases.
- Worker — provider registered, processor dispatches `ga4-run-report` to ACL + ingest use case, classifies `402`/`429` from GA4 as quota-exhausted (auto-pauses definition until the operator re-enables). The Drizzle schema-snapshot also picked up incidental jsonb-default consolidation across pre-existing tables; no behavioural change.
- API — `GET/POST/DELETE /ga4/...` endpoints in `TrafficAnalyticsModule` with the same IDOR-safe 404-collapse pattern used by web-performance and entity-awareness.
- SDK — `ga4` resource (`listForProject`, `link`, `unlink`, `metrics`).
- UI — atomic-design `LinkGa4Drawer` organism + new GA4 card on the project detail page (mobile-first, reminder about adding the SA as Viewer on the GA4 property — without that the daily fetch fails 403 and the operator wastes a debug cycle).

## Pipeline status (local)
- `pnpm lint` — clean (biome `check .`).
- `pnpm typecheck` — 17/17 packages OK.
- `pnpm test` — all 17 workspaces green; **17** new GA4 provider tests + **11** new application tests (ACL + use cases).
- `pnpm build` — full monorepo build green.

## Test plan
- [ ] CI green (format/lint/typecheck/tests/coverage).
- [ ] Migration `0007_black_clea.sql` applies cleanly on the existing prod database (forward-only, idempotent).
- [ ] After deploy, register a GA4 SA credential, link a property, schedule the run-report cron (with a `ga4PropertyId` in systemParams), trigger run-now and confirm rows land in `ga4_daily_metrics` with both dimension and metric jsonb populated.
- [ ] Re-run the same job and verify it does not duplicate (PK conflict swallowed, `Ga4BatchIngested.rowsCount === 0`).