### PR TITLE
feat: Bing Webmaster Tools provider + insights context (#20)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
 		"@rankpulse/contracts": "workspace:*",
 		"@rankpulse/domain": "workspace:*",
 		"@rankpulse/infrastructure": "workspace:*",
+		"@rankpulse/provider-bing": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from './common/auth/jwt-auth.guard.js';
 import { DomainExceptionFilter } from './common/domain-exception.filter.js';
 import { Tokens } from './composition/tokens.js';
 import type { AppEnv } from './config/env.js';
+import { BingWebmasterInsightsModule } from './modules/bing-webmaster-insights/bing-webmaster-insights.module.js';
 import { EntityAwarenessModule } from './modules/entity-awareness/entity-awareness.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { IdentityAccessModule } from './modules/identity-access/identity-access.module.js';
@@ -48,6 +49,7 @@ export class AppModule {
 			EntityAwarenessModule,
 			WebPerformanceModule,
 			TrafficAnalyticsModule,
+			BingWebmasterInsightsModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -1,5 +1,6 @@
 import type { Provider, ValueProvider } from '@nestjs/common';
 import {
+	BingWebmasterInsights as BWIUseCases,
 	EntityAwareness as EAUseCases,
 	IdentityAccess as IAUseCases,
 	ProviderConnectivity as PCUseCases,
@@ -11,6 +12,7 @@ import {
 } from '@rankpulse/application';
 import type { ProjectManagement } from '@rankpulse/domain';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
+import { BingProvider } from '@rankpulse/provider-bing';
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
@@ -70,6 +72,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
 	const ga4PropertyRepo = new DrizzlePersistence.DrizzleGa4PropertyRepository(drizzle.db);
 	const ga4DailyMetricRepo = new DrizzlePersistence.DrizzleGa4DailyMetricRepository(drizzle.db);
+	const bingPropertyRepo = new DrizzlePersistence.DrizzleBingPropertyRepository(drizzle.db);
+	const bingTrafficObservationRepo = new DrizzlePersistence.DrizzleBingTrafficObservationRepository(
+		drizzle.db,
+	);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -79,6 +85,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	providerRegistry.register(new DataForSeoProvider());
 	providerRegistry.register(new GscProvider());
 	providerRegistry.register(new Ga4Provider());
+	providerRegistry.register(new BingProvider());
 
 	const registerOrganization = new IAUseCases.RegisterOrganizationUseCase(
 		orgRepo,
@@ -282,6 +289,19 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const unlinkGa4Property = new TAUseCases.UnlinkGa4PropertyUseCase(ga4PropertyRepo, SystemClock);
 	const queryGa4Metrics = new TAUseCases.QueryGa4MetricsUseCase(ga4PropertyRepo, ga4DailyMetricRepo);
 
+	// Issue #20 — bing-webmaster-insights use cases
+	const linkBingProperty = new BWIUseCases.LinkBingPropertyUseCase(
+		bingPropertyRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const unlinkBingProperty = new BWIUseCases.UnlinkBingPropertyUseCase(bingPropertyRepo, SystemClock);
+	const queryBingTraffic = new BWIUseCases.QueryBingTrafficUseCase(
+		bingPropertyRepo,
+		bingTrafficObservationRepo,
+	);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -386,6 +406,12 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.LinkGa4Property, linkGa4Property),
 		value(Tokens.UnlinkGa4Property, unlinkGa4Property),
 		value(Tokens.QueryGa4Metrics, queryGa4Metrics),
+
+		value(Tokens.BingPropertyRepository, bingPropertyRepo),
+		value(Tokens.BingTrafficObservationRepository, bingTrafficObservationRepo),
+		value(Tokens.LinkBingProperty, linkBingProperty),
+		value(Tokens.UnlinkBingProperty, unlinkBingProperty),
+		value(Tokens.QueryBingTraffic, queryBingTraffic),
 	];
 
 	return {

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -113,6 +113,15 @@ export const Tokens = {
 	UnlinkGa4Property: Symbol('UnlinkGa4PropertyUseCase'),
 	QueryGa4Metrics: Symbol('QueryGa4MetricsUseCase'),
 
+	// Bing-Webmaster-Insights ports
+	BingPropertyRepository: Symbol('BingPropertyRepository'),
+	BingTrafficObservationRepository: Symbol('BingTrafficObservationRepository'),
+
+	// Bing-Webmaster-Insights use cases
+	LinkBingProperty: Symbol('LinkBingPropertyUseCase'),
+	UnlinkBingProperty: Symbol('UnlinkBingPropertyUseCase'),
+	QueryBingTraffic: Symbol('QueryBingTrafficUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/bing-webmaster-insights/bing-webmaster-insights.module.ts
+++ b/apps/api/src/modules/bing-webmaster-insights/bing-webmaster-insights.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { BingController } from './bing.controller.js';
+
+@Module({
+	controllers: [BingController],
+})
+export class BingWebmasterInsightsModule {}

--- a/apps/api/src/modules/bing-webmaster-insights/bing.controller.ts
+++ b/apps/api/src/modules/bing-webmaster-insights/bing.controller.ts
@@ -1,0 +1,112 @@
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { BingWebmasterInsights as BWIUseCases } from '@rankpulse/application';
+import { BingWebmasterInsightsContracts } from '@rankpulse/contracts';
+import type { BingWebmasterInsights, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+@Controller()
+export class BingController {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.LinkBingProperty) private readonly linkProperty: BWIUseCases.LinkBingPropertyUseCase,
+		@Inject(Tokens.UnlinkBingProperty) private readonly unlinkProperty: BWIUseCases.UnlinkBingPropertyUseCase,
+		@Inject(Tokens.QueryBingTraffic) private readonly queryTraffic: BWIUseCases.QueryBingTrafficUseCase,
+		@Inject(Tokens.BingPropertyRepository)
+		private readonly properties: BingWebmasterInsights.BingPropertyRepository,
+		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/bing/properties')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<BingWebmasterInsightsContracts.BingPropertyDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.properties.listForProject(project.id);
+		return list.map((p) => this.serialize(p));
+	}
+
+	@Post('projects/:projectId/bing/properties')
+	async link(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(BingWebmasterInsightsContracts.LinkBingPropertyRequest))
+		body: BingWebmasterInsightsContracts.LinkBingPropertyRequest,
+	): Promise<{ bingPropertyId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.linkProperty.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			siteUrl: body.siteUrl,
+			credentialId: body.credentialId ?? null,
+		});
+	}
+
+	@Delete('bing/properties/:bingPropertyId')
+	async unlink(
+		@Principal() principal: AuthPrincipal,
+		@Param('bingPropertyId') bingPropertyId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToProperty(principal, bingPropertyId);
+		await this.unlinkProperty.execute({ bingPropertyId });
+		return { ok: true };
+	}
+
+	@Get('bing/properties/:bingPropertyId/traffic')
+	async traffic(
+		@Principal() principal: AuthPrincipal,
+		@Param('bingPropertyId') bingPropertyId: string,
+		@Query(new ZodValidationPipe(BingWebmasterInsightsContracts.BingTrafficQuery))
+		q: BingWebmasterInsightsContracts.BingTrafficQuery,
+	): Promise<BingWebmasterInsightsContracts.BingTrafficObservationDto[]> {
+		await this.requireAccessToProperty(principal, bingPropertyId);
+		const result = await this.queryTraffic.execute({ bingPropertyId, from: q.from, to: q.to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	private async requireAccessToProperty(principal: AuthPrincipal, bingPropertyId: string): Promise<void> {
+		// Same IDOR-safe 404-collapse used in web-performance / GA4 / GSC.
+		// A leaked id must not leak existence via 403 vs 404.
+		const property = await this.properties.findById(bingPropertyId as BingWebmasterInsights.BingPropertyId);
+		if (!property) throw new NotFoundError(`Bing property ${bingPropertyId} not found`);
+		const project = await this.projects.findById(property.projectId);
+		if (!project) throw new NotFoundError(`Bing property ${bingPropertyId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`Bing property ${bingPropertyId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(p: BingWebmasterInsights.BingProperty): BingWebmasterInsightsContracts.BingPropertyDto {
+		return {
+			id: p.id,
+			projectId: p.projectId,
+			siteUrl: p.siteUrl,
+			credentialId: p.credentialId,
+			linkedAt: p.linkedAt.toISOString(),
+			unlinkedAt: p.unlinkedAt ? p.unlinkedAt.toISOString() : null,
+			isActive: p.isActive(),
+		};
+	}
+}

--- a/apps/web/src/components/link-bing-drawer.tsx
+++ b/apps/web/src/components/link-bing-drawer.tsx
@@ -1,0 +1,92 @@
+import { Button, Drawer, FormField, Input } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface LinkBingDrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #20 — atomic-design organism. Mobile-first drawer to link a
+ * Bing-verified property. Bing only supports URL-prefix verification
+ * (no domain-property analogue), so we accept any absolute http(s) URL.
+ *
+ * Reminder copy spells out the prerequisite: Bing requires the
+ * site to be verified AND the API key to be generated under
+ * Settings → API Access on the same Bing Webmaster account.
+ */
+export const LinkBingDrawer = ({ projectId, open, onClose }: LinkBingDrawerProps) => {
+	const qc = useQueryClient();
+	const [siteUrl, setSiteUrl] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setSiteUrl('');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => api.bing.link(projectId, { siteUrl }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'bing'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to link Bing property'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Link Bing Webmaster"
+			description="Daily clicks, impressions and average position for a verified Bing property."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="link-bing-form" disabled={mutation.isPending || !siteUrl}>
+						{mutation.isPending ? 'Linking…' : 'Link property'}
+					</Button>
+				</>
+			}
+		>
+			<form id="link-bing-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField label="Site URL" hint="Absolute URL of the verified Bing property (https://example.com).">
+					{(id) => (
+						<Input
+							id={id}
+							value={siteUrl}
+							onChange={(e) => setSiteUrl(e.target.value.trim())}
+							placeholder="https://example.com/"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<p className="text-xs text-muted-foreground">
+					The site must be verified in Bing Webmaster, and the API key (Settings → API Access) must belong to
+					the same account that owns the verification. Without that the daily fetch fails with 401.
+				</p>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -7,6 +7,7 @@ import {
 	CalendarClock,
 	Check,
 	Gauge,
+	Globe2,
 	LineChart,
 	MapPin,
 	Plus,
@@ -20,6 +21,7 @@ import { AddDomainDrawer } from '../components/add-domain-drawer.js';
 import { AddLocationDrawer } from '../components/add-location-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
+import { LinkBingDrawer } from '../components/link-bing-drawer.js';
 import { LinkGa4Drawer } from '../components/link-ga4-drawer.js';
 import { LinkWikipediaDrawer } from '../components/link-wikipedia-drawer.js';
 import { TrackPageDrawer } from '../components/track-page-drawer.js';
@@ -28,7 +30,7 @@ import { api } from '../lib/api.js';
 export const ProjectDetailPage = () => {
 	const { id } = useParams({ from: '/projects/$id' });
 	const [openDrawer, setOpenDrawer] = useState<
-		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | 'ga4' | null
+		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | 'ga4' | 'bing' | null
 	>(null);
 
 	const projectQuery = useQuery({
@@ -69,6 +71,12 @@ export const ProjectDetailPage = () => {
 	const ga4Query = useQuery({
 		queryKey: ['project', id, 'ga4'],
 		queryFn: () => api.ga4.listForProject(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const bingQuery = useQuery({
+		queryKey: ['project', id, 'bing'],
+		queryFn: () => api.bing.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -327,6 +335,46 @@ export const ProjectDetailPage = () => {
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="flex items-center gap-2 text-base">
+								<Globe2 size={14} className="text-primary" />
+								Bing properties ({bingQuery.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('bing')}>
+								<Plus size={14} />
+								Link
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{bingQuery.isLoading ? (
+								<Spinner />
+							) : bingQuery.data && bingQuery.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{bingQuery.data.map((p) => (
+										<li key={p.id} className="break-words">
+											<Badge variant={p.isActive ? 'default' : 'secondary'}>
+												{p.isActive ? 'active' : 'unlinked'}
+											</Badge>{' '}
+											<span className="text-muted-foreground">{p.siteUrl}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No Bing property linked"
+									description="Link a Bing-verified property to track clicks, impressions, and average position from the Bing search engine."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('bing')}>
+											<Plus size={14} />
+											Link property
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
 								<Activity size={14} className="text-primary" />
 								GA4 properties ({ga4Query.data?.length ?? '…'})
 							</CardTitle>
@@ -470,6 +518,7 @@ export const ProjectDetailPage = () => {
 				onClose={() => setOpenDrawer(null)}
 			/>
 			<LinkGa4Drawer projectId={id} open={openDrawer === 'ga4'} onClose={() => setOpenDrawer(null)} />
+			<LinkBingDrawer projectId={id} open={openDrawer === 'bing'} onClose={() => setOpenDrawer(null)} />
 		</AppShell>
 	);
 };

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,6 +19,7 @@
 		"@rankpulse/contracts": "workspace:*",
 		"@rankpulse/domain": "workspace:*",
 		"@rankpulse/infrastructure": "workspace:*",
+		"@rankpulse/provider-bing": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,4 +1,5 @@
 import {
+	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
@@ -41,6 +42,10 @@ async function bootstrap(): Promise<void> {
 	const pageSpeedSnapshotRepo = new DrizzlePersistence.DrizzlePageSpeedSnapshotRepository(drizzle.db);
 	const ga4PropertyRepo = new DrizzlePersistence.DrizzleGa4PropertyRepository(drizzle.db);
 	const ga4DailyMetricRepo = new DrizzlePersistence.DrizzleGa4DailyMetricRepository(drizzle.db);
+	const bingPropertyRepo = new DrizzlePersistence.DrizzleBingPropertyRepository(drizzle.db);
+	const bingTrafficObservationRepo = new DrizzlePersistence.DrizzleBingTrafficObservationRepository(
+		drizzle.db,
+	);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -97,6 +102,12 @@ async function bootstrap(): Promise<void> {
 		eventPublisher,
 		SystemClock,
 	);
+	const ingestBingTrafficUseCase = new BingWebmasterInsightsUseCases.IngestBingTrafficUseCase(
+		bingPropertyRepo,
+		bingTrafficObservationRepo,
+		eventPublisher,
+		SystemClock,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -111,6 +122,7 @@ async function bootstrap(): Promise<void> {
 		wikipediaArticleRepo,
 		trackedPageRepo,
 		ga4PropertyRepo,
+		bingPropertyRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
@@ -120,6 +132,7 @@ async function bootstrap(): Promise<void> {
 		ingestWikipediaPageviewsUseCase,
 		recordPageSpeedSnapshotUseCase,
 		ingestGa4RowsUseCase,
+		ingestBingTrafficUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -1,4 +1,5 @@
 import type {
+	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
@@ -8,6 +9,7 @@ import type {
 	WebPerformance as WebPerformanceUseCases,
 } from '@rankpulse/application';
 import {
+	type BingWebmasterInsights as BingWebmasterInsightsDomain,
 	type EntityAwareness as EntityAwarenessDomain,
 	type ProjectManagement,
 	ProviderConnectivity,
@@ -17,6 +19,11 @@ import {
 	type WebPerformance as WebPerformanceDomain,
 } from '@rankpulse/domain';
 import type { ProviderFetchJobData } from '@rankpulse/infrastructure/queue';
+import {
+	BingApiError,
+	extractDailyRows as extractBingDailyRows,
+	type RankAndTrafficStatsResponse,
+} from '@rankpulse/provider-bing';
 import type { ProviderRegistry } from '@rankpulse/provider-core';
 import {
 	DataForSeoApiError,
@@ -76,6 +83,10 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 	// GA4 Data API returns 429 RESOURCE_EXHAUSTED when the per-property token
 	// budget (200k/day) is spent; auto-pause until reset.
 	if (err instanceof Ga4ApiError && (err.status === 402 || err.status === 429)) return true;
+	// Bing Webmaster Tools is fair-use rate-limited; 429 is the throttle
+	// signal. Treat it as quota-exhausted so the cron auto-pauses rather than
+	// retrying through the budget for the rest of the day.
+	if (err instanceof BingApiError && err.status === 429) return true;
 	return false;
 };
 
@@ -98,6 +109,7 @@ export interface ProviderFetchProcessorDeps {
 	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
 	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
 	ga4PropertyRepo: TrafficAnalyticsDomain.Ga4PropertyRepository;
+	bingPropertyRepo: BingWebmasterInsightsDomain.BingPropertyRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
@@ -107,6 +119,7 @@ export interface ProviderFetchProcessorDeps {
 	ingestWikipediaPageviewsUseCase: EntityAwarenessUseCases.IngestWikipediaPageviewsUseCase;
 	recordPageSpeedSnapshotUseCase: WebPerformanceUseCases.RecordPageSpeedSnapshotUseCase;
 	ingestGa4RowsUseCase: TrafficAnalyticsUseCases.IngestGa4RowsUseCase;
+	ingestBingTrafficUseCase: BingWebmasterInsightsUseCases.IngestBingTrafficUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -385,6 +398,31 @@ export class ProviderFetchProcessor {
 					});
 					await this.deps.ingestGscRowsUseCase.execute({
 						gscPropertyId: gscParams.gscPropertyId,
+						rawPayloadId,
+						rows,
+					});
+				}
+			}
+
+			if (
+				definition.providerId.value === 'bing-webmaster' &&
+				definition.endpointId.value === 'bing-rank-and-traffic-stats'
+			) {
+				// Issue #20 — Bing daily-traffic ingest. The job's systemParams
+				// must carry `bingPropertyId` (set by LinkBingProperty via
+				// auto-schedule on link). The query-stats endpoint uses a
+				// different aggregation shape and is wired separately when we
+				// add a query-history dispatch.
+				const bingParams = resolvedParams as { bingPropertyId?: string };
+				if (!bingParams.bingPropertyId) {
+					runLog.warn(
+						{},
+						'bing-rank-and-traffic-stats job missing bingPropertyId in systemParams; skipping ingest',
+					);
+				} else {
+					const rows = extractBingDailyRows(fetchResult as RankAndTrafficStatsResponse);
+					await this.deps.ingestBingTrafficUseCase.execute({
+						bingPropertyId: bingParams.bingPropertyId,
 						rawPayloadId,
 						rows,
 					});

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -1,3 +1,4 @@
+import { BingProvider } from '@rankpulse/provider-bing';
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
@@ -16,5 +17,6 @@ export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): P
 	registry.register(new GscProvider());
 	registry.register(new WikipediaProvider());
 	registry.register(new PageSpeedProvider());
+	registry.register(new BingProvider());
 	return registry;
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -11,6 +11,11 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
 		},
+		"./bing-webmaster-insights": {
+			"development": "./src/bing-webmaster-insights/index.ts",
+			"types": "./dist/bing-webmaster-insights/index.d.ts",
+			"default": "./dist/bing-webmaster-insights/index.js"
+		},
 		"./entity-awareness": {
 			"development": "./src/entity-awareness/index.ts",
 			"types": "./dist/entity-awareness/index.d.ts",

--- a/packages/application/src/bing-webmaster-insights/index.ts
+++ b/packages/application/src/bing-webmaster-insights/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/ingest-bing-traffic.use-case.js';
+export * from './use-cases/link-bing-property.use-case.js';
+export * from './use-cases/query-bing-traffic.use-case.js';
+export * from './use-cases/unlink-bing-property.use-case.js';

--- a/packages/application/src/bing-webmaster-insights/use-cases/ingest-bing-traffic.use-case.spec.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/ingest-bing-traffic.use-case.spec.ts
@@ -1,0 +1,148 @@
+import type { BingWebmasterInsights, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IngestBingTrafficUseCase } from './ingest-bing-traffic.use-case.js';
+import { LinkBingPropertyUseCase } from './link-bing-property.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryPropertyRepo implements BingWebmasterInsights.BingPropertyRepository {
+	readonly store = new Map<string, BingWebmasterInsights.BingProperty>();
+	readonly bySite = new Map<string, BingWebmasterInsights.BingProperty>();
+	async save(p: BingWebmasterInsights.BingProperty): Promise<void> {
+		this.store.set(p.id, p);
+		this.bySite.set(`${p.projectId}|${p.siteUrl}`, p);
+	}
+	async findById(
+		id: BingWebmasterInsights.BingPropertyId,
+	): Promise<BingWebmasterInsights.BingProperty | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndSite(
+		projectId: ProjectManagement.ProjectId,
+		siteUrl: string,
+	): Promise<BingWebmasterInsights.BingProperty | null> {
+		return this.bySite.get(`${projectId}|${siteUrl}`) ?? null;
+	}
+	async listForProject(): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		return [];
+	}
+}
+
+class InMemoryObsRepo implements BingWebmasterInsights.BingTrafficObservationRepository {
+	readonly store = new Map<string, BingWebmasterInsights.BingTrafficObservation>();
+	async saveAll(
+		observations: readonly BingWebmasterInsights.BingTrafficObservation[],
+	): Promise<{ inserted: number }> {
+		let inserted = 0;
+		for (const o of observations) {
+			const k = `${o.bingPropertyId}|${o.observedDate}`;
+			if (this.store.has(k)) continue;
+			this.store.set(k, o);
+			inserted += 1;
+		}
+		return { inserted };
+	}
+	async listForProperty(): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		return [...this.store.values()];
+	}
+	async listLatestForProject(): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		return [];
+	}
+}
+
+describe('IngestBingTrafficUseCase', () => {
+	let propRepo: InMemoryPropertyRepo;
+	let obsRepo: InMemoryObsRepo;
+	let events: RecordingEventPublisher;
+	let propertyId: string;
+
+	beforeEach(async () => {
+		propRepo = new InMemoryPropertyRepo();
+		obsRepo = new InMemoryObsRepo();
+		events = new RecordingEventPublisher();
+		const linker = new LinkBingPropertyUseCase(
+			propRepo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(['bing-prop-1' as Uuid]),
+			events,
+		);
+		const result = await linker.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			siteUrl: 'https://example.com/',
+		});
+		propertyId = result.bingPropertyId;
+		events.clear();
+	});
+
+	const baseRow = (
+		overrides: Partial<{ observedDate: string; clicks: number; impressions: number }> = {},
+	) => ({
+		observedDate: overrides.observedDate ?? '2026-05-01',
+		clicks: overrides.clicks ?? 100,
+		impressions: overrides.impressions ?? 2000,
+		avgClickPosition: 4.5,
+		avgImpressionPosition: 12.3,
+	});
+
+	const buildUseCase = () =>
+		new IngestBingTrafficUseCase(propRepo, obsRepo, events, new FakeClock('2026-05-04T11:00:00Z'));
+
+	it('persists rows and publishes BingTrafficBatchIngested with totals on first ingest', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute({
+			bingPropertyId: propertyId,
+			rows: [baseRow(), baseRow({ observedDate: '2026-05-02', clicks: 50 })],
+			rawPayloadId: null,
+		});
+		expect(result.ingested).toBe(2);
+		expect(obsRepo.store.size).toBe(2);
+		const [evt] = events.published();
+		expect(evt?.type).toBe('BingTrafficBatchIngested');
+		expect((evt as BingWebmasterInsights.BingTrafficBatchIngested).totalClicks).toBe(150);
+	});
+
+	it('reports zero ingested when re-running the same window', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute({ bingPropertyId: propertyId, rows: [baseRow()], rawPayloadId: null });
+		events.clear();
+		const second = await useCase.execute({
+			bingPropertyId: propertyId,
+			rows: [baseRow()],
+			rawPayloadId: null,
+		});
+		expect(second.ingested).toBe(0);
+		expect((events.published()[0] as BingWebmasterInsights.BingTrafficBatchIngested).rowsCount).toBe(0);
+	});
+
+	it('throws NotFoundError when the property does not exist', async () => {
+		const useCase = buildUseCase();
+		await expect(
+			useCase.execute({ bingPropertyId: 'missing', rows: [baseRow()], rawPayloadId: null }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('returns 0 and does not publish when called with an empty batch', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute({ bingPropertyId: propertyId, rows: [], rawPayloadId: null });
+		expect(result.ingested).toBe(0);
+		expect(events.published()).toEqual([]);
+	});
+
+	it('rejects rows where avg position is < 1 (Bing positions are 1-indexed)', async () => {
+		const useCase = buildUseCase();
+		await expect(
+			useCase.execute({
+				bingPropertyId: propertyId,
+				rows: [{ ...baseRow(), avgClickPosition: 0.5, avgImpressionPosition: 0.7 }],
+				rawPayloadId: null,
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/application/src/bing-webmaster-insights/use-cases/ingest-bing-traffic.use-case.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/ingest-bing-traffic.use-case.ts
@@ -1,0 +1,79 @@
+import { BingWebmasterInsights, type SharedKernel } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface BingTrafficRowInput {
+	observedDate: string; // YYYY-MM-DD
+	clicks: number;
+	impressions: number;
+	avgClickPosition: number | null;
+	avgImpressionPosition: number | null;
+}
+
+export interface IngestBingTrafficCommand {
+	bingPropertyId: string;
+	rows: readonly BingTrafficRowInput[];
+	rawPayloadId: string | null;
+}
+
+export interface IngestBingTrafficResult {
+	ingested: number;
+}
+
+/**
+ * Persists Bing daily-traffic rows for a linked property and publishes one
+ * summary event with totals. Mirrors the GSC / GA4 ingest patterns:
+ * onConflictDoNothing on the natural key (propertyId, observedDate) so a
+ * 6-month re-fetch is a no-op for already-stored days.
+ */
+export class IngestBingTrafficUseCase {
+	constructor(
+		private readonly properties: BingWebmasterInsights.BingPropertyRepository,
+		private readonly observations: BingWebmasterInsights.BingTrafficObservationRepository,
+		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: IngestBingTrafficCommand): Promise<IngestBingTrafficResult> {
+		if (cmd.rows.length === 0) return { ingested: 0 };
+
+		const property = await this.properties.findById(
+			cmd.bingPropertyId as BingWebmasterInsights.BingPropertyId,
+		);
+		if (!property) throw new NotFoundError(`BingProperty ${cmd.bingPropertyId} not found`);
+		if (!property.isActive()) return { ingested: 0 };
+
+		let totalClicks = 0;
+		let totalImpressions = 0;
+		const observations = cmd.rows.map((row) => {
+			totalClicks += row.clicks;
+			totalImpressions += row.impressions;
+			return BingWebmasterInsights.BingTrafficObservation.record({
+				bingPropertyId: property.id,
+				projectId: property.projectId,
+				observedDate: row.observedDate,
+				metrics: BingWebmasterInsights.BingTrafficMetrics.create({
+					clicks: row.clicks,
+					impressions: row.impressions,
+					avgClickPosition: row.avgClickPosition,
+					avgImpressionPosition: row.avgImpressionPosition,
+				}),
+				rawPayloadId: cmd.rawPayloadId,
+			});
+		});
+
+		const { inserted } = await this.observations.saveAll(observations);
+
+		await this.events.publish([
+			new BingWebmasterInsights.BingTrafficBatchIngested({
+				projectId: property.projectId,
+				bingPropertyId: property.id,
+				rowsCount: inserted,
+				totalClicks,
+				totalImpressions,
+				occurredAt: this.clock.now(),
+			}),
+		]);
+
+		return { ingested: inserted };
+	}
+}

--- a/packages/application/src/bing-webmaster-insights/use-cases/link-bing-property.use-case.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/link-bing-property.use-case.ts
@@ -1,0 +1,48 @@
+import {
+	BingWebmasterInsights,
+	type IdentityAccess,
+	type ProjectManagement,
+	type SharedKernel,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface LinkBingPropertyCommand {
+	organizationId: string;
+	projectId: string;
+	siteUrl: string;
+	credentialId?: string | null;
+}
+
+export interface LinkBingPropertyResult {
+	bingPropertyId: string;
+}
+
+export class LinkBingPropertyUseCase {
+	constructor(
+		private readonly properties: BingWebmasterInsights.BingPropertyRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: LinkBingPropertyCommand): Promise<LinkBingPropertyResult> {
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+		const existing = await this.properties.findByProjectAndSite(projectId, cmd.siteUrl);
+		if (existing?.isActive()) {
+			throw new ConflictError(`Bing property ${cmd.siteUrl} already linked to this project`);
+		}
+
+		const id = this.ids.generate() as BingWebmasterInsights.BingPropertyId;
+		const property = BingWebmasterInsights.BingProperty.link({
+			id,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			siteUrl: cmd.siteUrl,
+			credentialId: cmd.credentialId ?? null,
+			now: this.clock.now(),
+		});
+		await this.properties.save(property);
+		await this.events.publish(property.pullEvents());
+		return { bingPropertyId: id };
+	}
+}

--- a/packages/application/src/bing-webmaster-insights/use-cases/query-bing-traffic.use-case.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/query-bing-traffic.use-case.ts
@@ -1,0 +1,38 @@
+import type { BingWebmasterInsights } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryBingTrafficCommand {
+	bingPropertyId: string;
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface BingTrafficView {
+	observedDate: string;
+	clicks: number;
+	impressions: number;
+	avgClickPosition: number | null;
+	avgImpressionPosition: number | null;
+}
+
+export class QueryBingTrafficUseCase {
+	constructor(
+		private readonly properties: BingWebmasterInsights.BingPropertyRepository,
+		private readonly observations: BingWebmasterInsights.BingTrafficObservationRepository,
+	) {}
+
+	async execute(cmd: QueryBingTrafficCommand): Promise<readonly BingTrafficView[]> {
+		const property = await this.properties.findById(
+			cmd.bingPropertyId as BingWebmasterInsights.BingPropertyId,
+		);
+		if (!property) throw new NotFoundError(`BingProperty ${cmd.bingPropertyId} not found`);
+		const rows = await this.observations.listForProperty(property.id, { from: cmd.from, to: cmd.to });
+		return rows.map((r) => ({
+			observedDate: r.observedDate,
+			clicks: r.metrics.clicks,
+			impressions: r.metrics.impressions,
+			avgClickPosition: r.metrics.avgClickPosition,
+			avgImpressionPosition: r.metrics.avgImpressionPosition,
+		}));
+	}
+}

--- a/packages/application/src/bing-webmaster-insights/use-cases/unlink-bing-property.use-case.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/unlink-bing-property.use-case.ts
@@ -1,0 +1,23 @@
+import type { BingWebmasterInsights } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface UnlinkBingPropertyCommand {
+	bingPropertyId: string;
+}
+
+export class UnlinkBingPropertyUseCase {
+	constructor(
+		private readonly properties: BingWebmasterInsights.BingPropertyRepository,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: UnlinkBingPropertyCommand): Promise<void> {
+		const property = await this.properties.findById(
+			cmd.bingPropertyId as BingWebmasterInsights.BingPropertyId,
+		);
+		if (!property) throw new NotFoundError(`BingProperty ${cmd.bingPropertyId} not found`);
+		if (!property.isActive()) return; // idempotent
+		property.unlink(this.clock.now());
+		await this.properties.save(property);
+	}
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,3 +1,4 @@
+export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as ProjectManagement from './project-management/index.js';

--- a/packages/contracts/src/bing-webmaster-insights/index.ts
+++ b/packages/contracts/src/bing-webmaster-insights/index.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const LinkBingPropertyRequest = z.object({
+	siteUrl: z.string().url(),
+	credentialId: z.string().uuid().nullable().optional(),
+});
+export type LinkBingPropertyRequest = z.infer<typeof LinkBingPropertyRequest>;
+
+export const BingPropertyDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	siteUrl: z.string(),
+	credentialId: z.string().uuid().nullable(),
+	linkedAt: z.string().datetime(),
+	unlinkedAt: z.string().datetime().nullable(),
+	isActive: z.boolean(),
+});
+export type BingPropertyDto = z.infer<typeof BingPropertyDto>;
+
+const DateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+export const BingTrafficQuery = z.object({
+	from: DateString,
+	to: DateString,
+});
+export type BingTrafficQuery = z.infer<typeof BingTrafficQuery>;
+
+export const BingTrafficObservationDto = z.object({
+	observedDate: z.string(),
+	clicks: z.number().int().nonnegative(),
+	impressions: z.number().int().nonnegative(),
+	avgClickPosition: z.number().nullable(),
+	avgImpressionPosition: z.number().nullable(),
+});
+export type BingTrafficObservationDto = z.infer<typeof BingTrafficObservationDto>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * as BingWebmasterInsightsContracts from './bing-webmaster-insights/index.js';
 export * as EntityAwarenessContracts from './entity-awareness/index.js';
 export * as IdentityAccessContracts from './identity-access/index.js';
 export * as ProjectManagementContracts from './project-management/index.js';

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -11,6 +11,11 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
 		},
+		"./bing-webmaster-insights": {
+			"development": "./src/bing-webmaster-insights/index.ts",
+			"types": "./dist/bing-webmaster-insights/index.d.ts",
+			"default": "./dist/bing-webmaster-insights/index.js"
+		},
 		"./entity-awareness": {
 			"development": "./src/entity-awareness/index.ts",
 			"types": "./dist/entity-awareness/index.d.ts",

--- a/packages/domain/src/bing-webmaster-insights/entities/bing-property.ts
+++ b/packages/domain/src/bing-webmaster-insights/entities/bing-property.ts
@@ -1,0 +1,100 @@
+import { ConflictError, InvalidInputError } from '@rankpulse/shared';
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { BingPropertyLinked } from '../events/bing-property-linked.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+export interface BingPropertyProps {
+	id: BingPropertyId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	siteUrl: string;
+	credentialId: string | null;
+	linkedAt: Date;
+	unlinkedAt: Date | null;
+}
+
+/**
+ * A Bing-verified property linked to a RankPulse project. Bing only accepts
+ * absolute http(s) URLs (no domain-property analogue like GSC), so the
+ * factory enforces that strictly.
+ */
+export class BingProperty extends AggregateRoot {
+	private constructor(private props: BingPropertyProps) {
+		super();
+	}
+
+	static link(input: {
+		id: BingPropertyId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		siteUrl: string;
+		credentialId: string | null;
+		now: Date;
+	}): BingProperty {
+		const siteUrl = input.siteUrl.trim();
+		if (siteUrl.length === 0) {
+			throw new InvalidInputError('siteUrl cannot be empty');
+		}
+		if (!/^https?:\/\//.test(siteUrl)) {
+			throw new InvalidInputError('Bing siteUrl must include http(s)://');
+		}
+		const property = new BingProperty({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			siteUrl,
+			credentialId: input.credentialId,
+			linkedAt: input.now,
+			unlinkedAt: null,
+		});
+		property.record(
+			new BingPropertyLinked({
+				bingPropertyId: input.id,
+				projectId: input.projectId,
+				organizationId: input.organizationId,
+				siteUrl,
+				occurredAt: input.now,
+			}),
+		);
+		return property;
+	}
+
+	static rehydrate(props: BingPropertyProps): BingProperty {
+		return new BingProperty(props);
+	}
+
+	unlink(now: Date): void {
+		if (this.props.unlinkedAt) {
+			throw new ConflictError('BingProperty is already unlinked');
+		}
+		this.props = { ...this.props, unlinkedAt: now };
+	}
+
+	isActive(): boolean {
+		return this.props.unlinkedAt === null;
+	}
+
+	get id(): BingPropertyId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get siteUrl(): string {
+		return this.props.siteUrl;
+	}
+	get credentialId(): string | null {
+		return this.props.credentialId;
+	}
+	get linkedAt(): Date {
+		return this.props.linkedAt;
+	}
+	get unlinkedAt(): Date | null {
+		return this.props.unlinkedAt;
+	}
+}

--- a/packages/domain/src/bing-webmaster-insights/entities/bing-traffic-observation.ts
+++ b/packages/domain/src/bing-webmaster-insights/entities/bing-traffic-observation.ts
@@ -1,0 +1,50 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import type { BingTrafficMetrics } from '../value-objects/bing-traffic-metrics.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+export interface BingTrafficObservationProps {
+	bingPropertyId: BingPropertyId;
+	projectId: ProjectId;
+	observedDate: string; // YYYY-MM-DD
+	metrics: BingTrafficMetrics;
+	rawPayloadId: string | null;
+}
+
+/**
+ * One immutable Bing daily-traffic row at calendar-day granularity.
+ * Value-like factory, no per-row events; the ingest use case publishes
+ * one batch summary, mirroring the GSC / GA4 patterns.
+ *
+ * Surrogate id is stamped from the natural key by the repo on read; the
+ * domain only knows the natural key (propertyId, observedDate).
+ */
+export class BingTrafficObservation extends AggregateRoot {
+	private constructor(private readonly props: BingTrafficObservationProps) {
+		super();
+	}
+
+	static record(input: BingTrafficObservationProps): BingTrafficObservation {
+		return new BingTrafficObservation(input);
+	}
+
+	static rehydrate(props: BingTrafficObservationProps): BingTrafficObservation {
+		return new BingTrafficObservation(props);
+	}
+
+	get bingPropertyId(): BingPropertyId {
+		return this.props.bingPropertyId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedDate(): string {
+		return this.props.observedDate;
+	}
+	get metrics(): BingTrafficMetrics {
+		return this.props.metrics;
+	}
+	get rawPayloadId(): string | null {
+		return this.props.rawPayloadId;
+	}
+}

--- a/packages/domain/src/bing-webmaster-insights/events/bing-property-linked.ts
+++ b/packages/domain/src/bing-webmaster-insights/events/bing-property-linked.ts
@@ -1,0 +1,27 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+export class BingPropertyLinked implements DomainEvent {
+	readonly type = 'BingPropertyLinked';
+	readonly bingPropertyId: BingPropertyId;
+	readonly projectId: ProjectId;
+	readonly organizationId: OrganizationId;
+	readonly siteUrl: string;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		bingPropertyId: BingPropertyId;
+		projectId: ProjectId;
+		organizationId: OrganizationId;
+		siteUrl: string;
+		occurredAt: Date;
+	}) {
+		this.bingPropertyId = props.bingPropertyId;
+		this.projectId = props.projectId;
+		this.organizationId = props.organizationId;
+		this.siteUrl = props.siteUrl;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/bing-webmaster-insights/events/bing-traffic-batch-ingested.ts
+++ b/packages/domain/src/bing-webmaster-insights/events/bing-traffic-batch-ingested.ts
@@ -1,0 +1,34 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+/**
+ * Mirrors GscPerformanceBatchIngested / Ga4BatchIngested — one summary
+ * event per ingest call, never per row, so a 6-month back-fetch doesn't
+ * fan-out hundreds of events.
+ */
+export class BingTrafficBatchIngested implements DomainEvent {
+	readonly type = 'BingTrafficBatchIngested';
+	readonly projectId: ProjectId;
+	readonly bingPropertyId: BingPropertyId;
+	readonly rowsCount: number;
+	readonly totalClicks: number;
+	readonly totalImpressions: number;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		projectId: ProjectId;
+		bingPropertyId: BingPropertyId;
+		rowsCount: number;
+		totalClicks: number;
+		totalImpressions: number;
+		occurredAt: Date;
+	}) {
+		this.projectId = props.projectId;
+		this.bingPropertyId = props.bingPropertyId;
+		this.rowsCount = props.rowsCount;
+		this.totalClicks = props.totalClicks;
+		this.totalImpressions = props.totalImpressions;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/bing-webmaster-insights/index.ts
+++ b/packages/domain/src/bing-webmaster-insights/index.ts
@@ -1,0 +1,12 @@
+// Entities / aggregates
+export * from './entities/bing-property.js';
+export * from './entities/bing-traffic-observation.js';
+// Events
+export * from './events/bing-property-linked.js';
+export * from './events/bing-traffic-batch-ingested.js';
+// Ports
+export * from './ports/bing-property-repository.js';
+export * from './ports/bing-traffic-observation-repository.js';
+// Value objects
+export * from './value-objects/bing-traffic-metrics.js';
+export * from './value-objects/identifiers.js';

--- a/packages/domain/src/bing-webmaster-insights/ports/bing-property-repository.ts
+++ b/packages/domain/src/bing-webmaster-insights/ports/bing-property-repository.ts
@@ -1,0 +1,12 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { BingProperty } from '../entities/bing-property.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+export interface BingPropertyRepository {
+	save(property: BingProperty): Promise<void>;
+	findById(id: BingPropertyId): Promise<BingProperty | null>;
+	findByProjectAndSite(projectId: ProjectId, siteUrl: string): Promise<BingProperty | null>;
+	listForProject(projectId: ProjectId): Promise<readonly BingProperty[]>;
+	listForOrganization(orgId: OrganizationId): Promise<readonly BingProperty[]>;
+}

--- a/packages/domain/src/bing-webmaster-insights/ports/bing-traffic-observation-repository.ts
+++ b/packages/domain/src/bing-webmaster-insights/ports/bing-traffic-observation-repository.ts
@@ -1,0 +1,24 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { BingTrafficObservation } from '../entities/bing-traffic-observation.js';
+import type { BingPropertyId } from '../value-objects/identifiers.js';
+
+export interface BingTrafficObservationQuery {
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface BingTrafficObservationRepository {
+	/**
+	 * Bulk-insert observations. Implementations MUST be idempotent on the
+	 * natural key (bingPropertyId, observedDate) — a re-fetch of the same
+	 * 6-month window should not duplicate rows. Returns the count actually
+	 * inserted (excludes conflict-skipped rows) so the batch summary event
+	 * reports honest numbers.
+	 */
+	saveAll(observations: readonly BingTrafficObservation[]): Promise<{ inserted: number }>;
+	listForProperty(
+		propertyId: BingPropertyId,
+		query: BingTrafficObservationQuery,
+	): Promise<readonly BingTrafficObservation[]>;
+	listLatestForProject(projectId: ProjectId): Promise<readonly BingTrafficObservation[]>;
+}

--- a/packages/domain/src/bing-webmaster-insights/value-objects/bing-traffic-metrics.ts
+++ b/packages/domain/src/bing-webmaster-insights/value-objects/bing-traffic-metrics.ts
@@ -1,0 +1,42 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Bing rank-and-traffic stats for a single calendar day. Counts are required;
+ * average positions are optional because Bing returns null for days with no
+ * impressions (avg-of-empty is undefined).
+ */
+export class BingTrafficMetrics {
+	private constructor(
+		public readonly clicks: number,
+		public readonly impressions: number,
+		public readonly avgClickPosition: number | null,
+		public readonly avgImpressionPosition: number | null,
+	) {}
+
+	static create(input: {
+		clicks: number;
+		impressions: number;
+		avgClickPosition: number | null;
+		avgImpressionPosition: number | null;
+	}): BingTrafficMetrics {
+		if (!Number.isFinite(input.clicks) || input.clicks < 0) {
+			throw new InvalidInputError('clicks must be a non-negative number');
+		}
+		if (!Number.isFinite(input.impressions) || input.impressions < 0) {
+			throw new InvalidInputError('impressions must be a non-negative number');
+		}
+		const validatePos = (pos: number | null, label: string): number | null => {
+			if (pos === null) return null;
+			if (!Number.isFinite(pos) || pos < 1) {
+				throw new InvalidInputError(`${label} must be >= 1 when present (Bing positions are 1-indexed)`);
+			}
+			return pos;
+		};
+		return new BingTrafficMetrics(
+			Math.round(input.clicks),
+			Math.round(input.impressions),
+			validatePos(input.avgClickPosition, 'avgClickPosition'),
+			validatePos(input.avgImpressionPosition, 'avgImpressionPosition'),
+		);
+	}
+}

--- a/packages/domain/src/bing-webmaster-insights/value-objects/identifiers.ts
+++ b/packages/domain/src/bing-webmaster-insights/value-objects/identifiers.ts
@@ -1,0 +1,3 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type BingPropertyId = Uuid & { readonly __kind: 'BingPropertyId' };

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,4 @@
+export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as ProjectManagement from './project-management/index.js';

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -1,4 +1,6 @@
 export * from './client.js';
+export { DrizzleBingPropertyRepository } from './repositories/bing-webmaster-insights/bing-property.repository.js';
+export { DrizzleBingTrafficObservationRepository } from './repositories/bing-webmaster-insights/bing-traffic-observation.repository.js';
 export { DrizzleWikipediaArticleRepository } from './repositories/entity-awareness/wikipedia-article.repository.js';
 export { DrizzleWikipediaPageviewObservationRepository } from './repositories/entity-awareness/wikipedia-pageview-observation.repository.js';
 export { DrizzleApiTokenRepository } from './repositories/identity-access/api-token.repository.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0008_freezing_black_knight.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0008_freezing_black_knight.sql
@@ -1,0 +1,48 @@
+-- Issue #20 — Bing Webmaster Tools tables. Idempotent with IF NOT EXISTS +
+-- DO $$ EXCEPTION duplicate_object guards (forward-only, safe to retry).
+
+CREATE TABLE IF NOT EXISTS "bing_properties" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"site_url" text NOT NULL,
+	"credential_id" uuid,
+	"linked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"unlinked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "bing_traffic_observations" (
+	"bing_property_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_date" text NOT NULL,
+	"clicks" integer NOT NULL,
+	"impressions" integer NOT NULL,
+	"avg_click_position" double precision,
+	"avg_impression_position" double precision,
+	"raw_payload_id" uuid,
+	CONSTRAINT "bing_traffic_observations_bing_property_id_observed_date_pk" PRIMARY KEY("bing_property_id","observed_date")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "bing_properties" ADD CONSTRAINT "bing_properties_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "bing_properties" ADD CONSTRAINT "bing_properties_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "bing_properties" ADD CONSTRAINT "bing_properties_credential_id_provider_credentials_id_fk" FOREIGN KEY ("credential_id") REFERENCES "public"."provider_credentials"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "bing_traffic_observations" ADD CONSTRAINT "bing_traffic_observations_bing_property_id_bing_properties_id_fk" FOREIGN KEY ("bing_property_id") REFERENCES "public"."bing_properties"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "bing_properties_project_site_unique" ON "bing_properties" USING btree ("project_id","site_url");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "bing_properties_project_idx" ON "bing_properties" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "bing_traffic_observations_project_idx" ON "bing_traffic_observations" USING btree ("project_id","observed_date");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0008_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0008_snapshot.json
@@ -1,0 +1,3116 @@
+{
+	"id": "fa777cb8-deaa-4ed8-adda-0cda752cc0b0",
+	"prevId": "86c65c06-8d7a-44bd-b25a-bc13809039b7",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_properties": {
+			"name": "bing_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_properties_project_site_unique": {
+					"name": "bing_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"bing_properties_project_idx": {
+					"name": "bing_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_properties_organization_id_organizations_id_fk": {
+					"name": "bing_properties_organization_id_organizations_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_project_id_projects_id_fk": {
+					"name": "bing_properties_project_id_projects_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_credential_id_provider_credentials_id_fk": {
+					"name": "bing_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_traffic_observations": {
+			"name": "bing_traffic_observations",
+			"schema": "",
+			"columns": {
+				"bing_property_id": {
+					"name": "bing_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_click_position": {
+					"name": "avg_click_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_impression_position": {
+					"name": "avg_impression_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_traffic_observations_project_idx": {
+					"name": "bing_traffic_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_traffic_observations_bing_property_id_bing_properties_id_fk": {
+					"name": "bing_traffic_observations_bing_property_id_bing_properties_id_fk",
+					"tableFrom": "bing_traffic_observations",
+					"tableTo": "bing_properties",
+					"columnsFrom": ["bing_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"bing_traffic_observations_bing_property_id_observed_date_pk": {
+					"name": "bing_traffic_observations_bing_property_id_observed_date_pk",
+					"columns": ["bing_property_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_daily_metrics": {
+			"name": "ga4_daily_metrics",
+			"schema": "",
+			"columns": {
+				"ga4_property_id": {
+					"name": "ga4_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions_hash": {
+					"name": "dimensions_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions": {
+					"name": "dimensions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metrics": {
+					"name": "metrics",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_daily_metrics_project_idx": {
+					"name": "ga4_daily_metrics_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk": {
+					"name": "ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk",
+					"tableFrom": "ga4_daily_metrics",
+					"tableTo": "ga4_properties",
+					"columnsFrom": ["ga4_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk": {
+					"name": "ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk",
+					"columns": ["ga4_property_id", "observed_date", "dimensions_hash"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_properties": {
+			"name": "ga4_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_handle": {
+					"name": "property_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_properties_project_handle_unique": {
+					"name": "ga4_properties_project_handle_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "property_handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ga4_properties_project_idx": {
+					"name": "ga4_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_properties_organization_id_organizations_id_fk": {
+					"name": "ga4_properties_organization_id_organizations_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_project_id_projects_id_fk": {
+					"name": "ga4_properties_project_id_projects_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_credential_id_provider_credentials_id_fk": {
+					"name": "ga4_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_speed_snapshots": {
+			"name": "page_speed_snapshots",
+			"schema": "",
+			"columns": {
+				"tracked_page_id": {
+					"name": "tracked_page_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lcp_ms": {
+					"name": "lcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"inp_ms": {
+					"name": "inp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cls": {
+					"name": "cls",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fcp_ms": {
+					"name": "fcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ttfb_ms": {
+					"name": "ttfb_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"performance_score": {
+					"name": "performance_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seo_score": {
+					"name": "seo_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessibility_score": {
+					"name": "accessibility_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"best_practices_score": {
+					"name": "best_practices_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"page_speed_snapshots_project_idx": {
+					"name": "page_speed_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_speed_snapshots_tracked_page_id_tracked_pages_id_fk": {
+					"name": "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk",
+					"tableFrom": "page_speed_snapshots",
+					"tableTo": "tracked_pages",
+					"columnsFrom": ["tracked_page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"page_speed_snapshots_tracked_page_id_observed_at_pk": {
+					"name": "page_speed_snapshots_tracked_page_id_observed_at_pk",
+					"columns": ["tracked_page_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_pages": {
+			"name": "tracked_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"strategy": {
+					"name": "strategy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_pages_project_url_strategy_unique": {
+					"name": "tracked_pages_project_url_strategy_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "strategy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_pages_project_idx": {
+					"name": "tracked_pages_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_pages_organization_id_organizations_id_fk": {
+					"name": "tracked_pages_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_pages_project_id_projects_id_fk": {
+					"name": "tracked_pages_project_id_projects_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
 			"when": 1778015988471,
 			"tag": "0007_black_clea",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1778017481538,
+			"tag": "0008_freezing_black_knight",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/bing-webmaster-insights/bing-property.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/bing-webmaster-insights/bing-property.repository.ts
@@ -1,0 +1,103 @@
+import { BingWebmasterInsights, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { bingProperties } from '../../schema/index.js';
+
+const UNIQUE_TUPLE_CONSTRAINT = 'bing_properties_project_site_unique';
+
+const isUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_TUPLE_CONSTRAINT;
+};
+
+export class DrizzleBingPropertyRepository implements BingWebmasterInsights.BingPropertyRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(property: BingWebmasterInsights.BingProperty): Promise<void> {
+		try {
+			await this.db
+				.insert(bingProperties)
+				.values({
+					id: property.id,
+					organizationId: property.organizationId,
+					projectId: property.projectId,
+					siteUrl: property.siteUrl,
+					credentialId: property.credentialId,
+					linkedAt: property.linkedAt,
+					unlinkedAt: property.unlinkedAt,
+				})
+				.onConflictDoUpdate({
+					target: bingProperties.id,
+					set: {
+						siteUrl: property.siteUrl,
+						credentialId: property.credentialId,
+						unlinkedAt: property.unlinkedAt,
+					},
+				});
+		} catch (err) {
+			if (isUniqueViolation(err)) {
+				throw new ConflictError(
+					`Bing property "${property.siteUrl}" is already linked to project ${property.projectId}`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(
+		id: BingWebmasterInsights.BingPropertyId,
+	): Promise<BingWebmasterInsights.BingProperty | null> {
+		const [row] = await this.db.select().from(bingProperties).where(eq(bingProperties.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByProjectAndSite(
+		projectId: ProjectManagement.ProjectId,
+		siteUrl: string,
+	): Promise<BingWebmasterInsights.BingProperty | null> {
+		const [row] = await this.db
+			.select()
+			.from(bingProperties)
+			.where(and(eq(bingProperties.projectId, projectId), eq(bingProperties.siteUrl, siteUrl)))
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		const rows = await this.db
+			.select()
+			.from(bingProperties)
+			.where(eq(bingProperties.projectId, projectId))
+			.orderBy(desc(bingProperties.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listForOrganization(
+		orgId: IdentityAccess.OrganizationId,
+	): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		const rows = await this.db
+			.select()
+			.from(bingProperties)
+			.where(eq(bingProperties.organizationId, orgId))
+			.orderBy(desc(bingProperties.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof bingProperties.$inferSelect): BingWebmasterInsights.BingProperty {
+		return BingWebmasterInsights.BingProperty.rehydrate({
+			id: row.id as BingWebmasterInsights.BingPropertyId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			siteUrl: row.siteUrl,
+			credentialId: row.credentialId,
+			linkedAt: row.linkedAt,
+			unlinkedAt: row.unlinkedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/bing-webmaster-insights/bing-traffic-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/bing-webmaster-insights/bing-traffic-observation.repository.ts
@@ -1,0 +1,87 @@
+import { BingWebmasterInsights, type ProjectManagement } from '@rankpulse/domain';
+import { and, between, desc, eq, gte, sql } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { bingTrafficObservations } from '../../schema/index.js';
+
+export class DrizzleBingTrafficObservationRepository
+	implements BingWebmasterInsights.BingTrafficObservationRepository
+{
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async saveAll(
+		observations: readonly BingWebmasterInsights.BingTrafficObservation[],
+	): Promise<{ inserted: number }> {
+		if (observations.length === 0) return { inserted: 0 };
+		const inserted = await this.db
+			.insert(bingTrafficObservations)
+			.values(
+				observations.map((o) => ({
+					bingPropertyId: o.bingPropertyId,
+					projectId: o.projectId,
+					observedDate: o.observedDate,
+					clicks: o.metrics.clicks,
+					impressions: o.metrics.impressions,
+					avgClickPosition: o.metrics.avgClickPosition,
+					avgImpressionPosition: o.metrics.avgImpressionPosition,
+					rawPayloadId: o.rawPayloadId,
+				})),
+			)
+			.onConflictDoNothing({
+				target: [bingTrafficObservations.bingPropertyId, bingTrafficObservations.observedDate],
+			})
+			.returning({ bingPropertyId: bingTrafficObservations.bingPropertyId });
+		return { inserted: inserted.length };
+	}
+
+	async listForProperty(
+		propertyId: BingWebmasterInsights.BingPropertyId,
+		query: BingWebmasterInsights.BingTrafficObservationQuery,
+	): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		const rows = await this.db
+			.select()
+			.from(bingTrafficObservations)
+			.where(
+				and(
+					eq(bingTrafficObservations.bingPropertyId, propertyId),
+					between(bingTrafficObservations.observedDate, query.from, query.to),
+				),
+			)
+			.orderBy(bingTrafficObservations.observedDate);
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listLatestForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		const cutoff = sql<string>`to_char(now() - interval '14 days', 'YYYY-MM-DD')`;
+		const rows = await this.db
+			.select()
+			.from(bingTrafficObservations)
+			.where(
+				and(
+					eq(bingTrafficObservations.projectId, projectId),
+					gte(bingTrafficObservations.observedDate, cutoff),
+				),
+			)
+			.orderBy(desc(bingTrafficObservations.observedDate))
+			.limit(500);
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(
+		row: typeof bingTrafficObservations.$inferSelect,
+	): BingWebmasterInsights.BingTrafficObservation {
+		return BingWebmasterInsights.BingTrafficObservation.rehydrate({
+			bingPropertyId: row.bingPropertyId as BingWebmasterInsights.BingPropertyId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			observedDate: row.observedDate,
+			metrics: BingWebmasterInsights.BingTrafficMetrics.create({
+				clicks: row.clicks,
+				impressions: row.impressions,
+				avgClickPosition: row.avgClickPosition,
+				avgImpressionPosition: row.avgImpressionPosition,
+			}),
+			rawPayloadId: row.rawPayloadId,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -699,3 +699,62 @@ export const ga4DailyMetrics = pgTable(
 
 export type Ga4PropertyRow = typeof ga4Properties.$inferSelect;
 export type Ga4DailyMetricRow = typeof ga4DailyMetrics.$inferSelect;
+
+// ---- bing-webmaster-insights ----
+
+/**
+ * Issue #20 — Bing-verified properties linked to a project. Bing only
+ * supports URL-prefix verification (no domain-property analogue), so the
+ * unique index is straightforward: one (project, siteUrl) per linkage.
+ */
+export const bingProperties = pgTable(
+	'bing_properties',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		siteUrl: text('site_url').notNull(),
+		credentialId: uuid('credential_id').references(() => providerCredentials.id, { onDelete: 'set null' }),
+		linkedAt: timestamp('linked_at', { withTimezone: true }).notNull().defaultNow(),
+		unlinkedAt: timestamp('unlinked_at', { withTimezone: true }),
+	},
+	(t) => ({
+		uniqueByProjectSite: uniqueIndex('bing_properties_project_site_unique').on(t.projectId, t.siteUrl),
+		projectIdx: index('bing_properties_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of Bing daily traffic. Natural PK is
+ * (bing_property_id, observed_date) — re-fetching the same 6-month
+ * window swallows the duplicates via onConflictDoNothing.
+ *
+ * Avg-position columns are nullable: Bing returns null for days with no
+ * impressions (avg-of-empty is undefined).
+ */
+export const bingTrafficObservations = pgTable(
+	'bing_traffic_observations',
+	{
+		bingPropertyId: uuid('bing_property_id')
+			.notNull()
+			.references(() => bingProperties.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedDate: text('observed_date').notNull(), // YYYY-MM-DD
+		clicks: integer('clicks').notNull(),
+		impressions: integer('impressions').notNull(),
+		avgClickPosition: doublePrecision('avg_click_position'),
+		avgImpressionPosition: doublePrecision('avg_impression_position'),
+		rawPayloadId: uuid('raw_payload_id'),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.bingPropertyId, t.observedDate] }),
+		projectIdx: index('bing_traffic_observations_project_idx').on(t.projectId, t.observedDate),
+	}),
+);
+
+export type BingPropertyRow = typeof bingProperties.$inferSelect;
+export type BingTrafficObservationRow = typeof bingTrafficObservations.$inferSelect;

--- a/packages/providers/bing/package.json
+++ b/packages/providers/bing/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rankpulse/provider-bing",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/bing/src/acl/query-stats-to-rows.acl.spec.ts
+++ b/packages/providers/bing/src/acl/query-stats-to-rows.acl.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { QueryStatsResponse } from '../endpoints/query-stats.js';
+import { extractQueryRows } from './query-stats-to-rows.acl.js';
+
+describe('extractQueryRows (Bing query-stats)', () => {
+	it('projects per-query rows with trimmed query text', () => {
+		const fixture: QueryStatsResponse = {
+			d: [
+				{ Query: '  control de rondas  ', Clicks: 50, Impressions: 1200, AvgClickPosition: 5.2 },
+				{ Query: 'app rondas', Clicks: 30, Impressions: 800, AvgImpressionPosition: 12.4 },
+			],
+		};
+		const rows = extractQueryRows(fixture);
+		expect(rows).toHaveLength(2);
+		expect(rows[0]?.query).toBe('control de rondas');
+		expect(rows[0]?.clicks).toBe(50);
+		expect(rows[1]?.avgImpressionPosition).toBe(12.4);
+	});
+
+	it('drops rows with empty/whitespace queries (would collide on the natural key)', () => {
+		const fixture: QueryStatsResponse = {
+			d: [
+				{ Query: '', Clicks: 1, Impressions: 1 },
+				{ Query: '   ', Clicks: 2, Impressions: 2 },
+				{ Query: 'real query', Clicks: 3, Impressions: 3 },
+			],
+		};
+		expect(extractQueryRows(fixture)).toHaveLength(1);
+		expect(extractQueryRows(fixture)[0]?.query).toBe('real query');
+	});
+
+	it('returns empty when Bing payload has no `d` array', () => {
+		expect(extractQueryRows({})).toEqual([]);
+		expect(extractQueryRows({ d: [] })).toEqual([]);
+	});
+});

--- a/packages/providers/bing/src/acl/query-stats-to-rows.acl.ts
+++ b/packages/providers/bing/src/acl/query-stats-to-rows.acl.ts
@@ -1,0 +1,47 @@
+import type { QueryStatsResponse } from '../endpoints/query-stats.js';
+
+export interface NormalizedBingQueryRow {
+	query: string;
+	clicks: number;
+	impressions: number;
+	avgClickPosition: number | null;
+	avgImpressionPosition: number | null;
+}
+
+const toNumber = (raw: number | undefined): number => {
+	if (raw === undefined || raw === null) return 0;
+	return Number.isFinite(raw) ? raw : 0;
+};
+
+const toNullableNumber = (raw: number | undefined): number | null => {
+	if (raw === undefined || raw === null) return null;
+	if (!Number.isFinite(raw) || raw < 0) return null;
+	return raw;
+};
+
+/**
+ * Pure ACL: GetQueryStats payload → normalised query rows. Bing returns
+ * an aggregated view (no per-day granularity) so the read model stamps
+ * `observedDate` itself when persisting — this layer just shapes the
+ * row content.
+ *
+ * Empty/whitespace queries are dropped: they'd violate the natural-key
+ * uniqueness on (siteUrl, observedDate, query) by colliding under the
+ * same empty-string key.
+ */
+export const extractQueryRows = (response: QueryStatsResponse): NormalizedBingQueryRow[] => {
+	const rows = response.d ?? [];
+	const out: NormalizedBingQueryRow[] = [];
+	for (const row of rows) {
+		const q = row.Query?.trim();
+		if (!q) continue;
+		out.push({
+			query: q,
+			clicks: toNumber(row.Clicks),
+			impressions: toNumber(row.Impressions),
+			avgClickPosition: toNullableNumber(row.AvgClickPosition),
+			avgImpressionPosition: toNullableNumber(row.AvgImpressionPosition),
+		});
+	}
+	return out;
+};

--- a/packages/providers/bing/src/acl/rank-traffic-to-rows.acl.spec.ts
+++ b/packages/providers/bing/src/acl/rank-traffic-to-rows.acl.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { RankAndTrafficStatsResponse } from '../endpoints/rank-and-traffic-stats.js';
+import { extractDailyRows } from './rank-traffic-to-rows.acl.js';
+
+const fixture: RankAndTrafficStatsResponse = {
+	d: [
+		{
+			Date: '/Date(1714521600000)/', // 2024-05-01 UTC
+			Clicks: 120,
+			Impressions: 4500,
+			AvgClickPosition: 8.4,
+			AvgImpressionPosition: 18.7,
+		},
+		{
+			Date: '/Date(1714608000000)/', // 2024-05-02 UTC
+			Clicks: 88,
+			Impressions: 3200,
+			AvgClickPosition: 9.1,
+			AvgImpressionPosition: 19.5,
+		},
+	],
+};
+
+describe('extractDailyRows (Bing rank-and-traffic-stats)', () => {
+	it("parses Microsoft's /Date(<ms>)/ wrapper into ISO YYYY-MM-DD", () => {
+		const rows = extractDailyRows(fixture);
+		expect(rows[0]?.observedDate).toBe('2024-05-01');
+		expect(rows[1]?.observedDate).toBe('2024-05-02');
+	});
+
+	it('projects clicks / impressions / avg positions verbatim', () => {
+		const rows = extractDailyRows(fixture);
+		expect(rows[0]).toMatchObject({
+			clicks: 120,
+			impressions: 4500,
+			avgClickPosition: 8.4,
+			avgImpressionPosition: 18.7,
+		});
+	});
+
+	it('drops rows with a malformed /Date(...)/ wrapper rather than synthesising a fallback', () => {
+		const messy: RankAndTrafficStatsResponse = {
+			d: [
+				{ Date: 'not-a-bing-date', Clicks: 5, Impressions: 50 },
+				{ Date: '/Date(NaN)/', Clicks: 5, Impressions: 50 },
+				{ Date: '/Date(1714521600000)/', Clicks: 1, Impressions: 10 },
+			],
+		};
+		expect(extractDailyRows(messy)).toEqual([
+			{
+				observedDate: '2024-05-01',
+				clicks: 1,
+				impressions: 10,
+				avgClickPosition: null,
+				avgImpressionPosition: null,
+			},
+		]);
+	});
+
+	it('coerces missing/non-finite numeric fields to 0 (counts) and null (positions)', () => {
+		const messy: RankAndTrafficStatsResponse = {
+			d: [
+				{
+					Date: '/Date(1714521600000)/',
+					Clicks: undefined,
+					Impressions: Number.NaN,
+					AvgClickPosition: -1, // negative is nonsense for a position; drop
+					AvgImpressionPosition: undefined,
+				},
+			],
+		};
+		expect(extractDailyRows(messy)[0]).toEqual({
+			observedDate: '2024-05-01',
+			clicks: 0,
+			impressions: 0,
+			avgClickPosition: null,
+			avgImpressionPosition: null,
+		});
+	});
+
+	it('returns empty when Bing payload has no `d` array (auth or empty-account edge case)', () => {
+		expect(extractDailyRows({})).toEqual([]);
+		expect(extractDailyRows({ d: [] })).toEqual([]);
+	});
+});

--- a/packages/providers/bing/src/acl/rank-traffic-to-rows.acl.ts
+++ b/packages/providers/bing/src/acl/rank-traffic-to-rows.acl.ts
@@ -1,0 +1,62 @@
+import type { RankAndTrafficStatsResponse } from '../endpoints/rank-and-traffic-stats.js';
+
+export interface NormalizedBingDailyRow {
+	observedDate: string; // YYYY-MM-DD
+	clicks: number;
+	impressions: number;
+	avgClickPosition: number | null;
+	avgImpressionPosition: number | null;
+}
+
+/**
+ * Bing serialises dates as `/Date(<ms>)/` (Microsoft JSON Date format).
+ * Pull out the milliseconds, build a UTC date, drop to YYYY-MM-DD.
+ *
+ * Returns null for any value the regex doesn't match — we'd rather drop a
+ * malformed row than insert a poisoned date.
+ */
+const MS_DATE_REGEX = /\/Date\((-?\d+)\)\//;
+
+const parseMsDate = (raw: string | undefined): string | null => {
+	if (!raw) return null;
+	const match = MS_DATE_REGEX.exec(raw);
+	if (!match || match[1] === undefined) return null;
+	const ms = Number(match[1]);
+	if (!Number.isFinite(ms)) return null;
+	const d = new Date(ms);
+	if (!Number.isFinite(d.getTime())) return null;
+	return d.toISOString().slice(0, 10);
+};
+
+const toNumber = (raw: number | undefined): number => {
+	if (raw === undefined || raw === null) return 0;
+	return Number.isFinite(raw) ? raw : 0;
+};
+
+const toNullableNumber = (raw: number | undefined): number | null => {
+	if (raw === undefined || raw === null) return null;
+	if (!Number.isFinite(raw) || raw < 0) return null;
+	return raw;
+};
+
+/**
+ * Pure ACL: GetRankAndTrafficStats payload → normalised daily rows.
+ * Drops rows with a malformed `/Date(ms)/` value rather than synthesising
+ * a fallback — the natural-key write would otherwise create a phantom row.
+ */
+export const extractDailyRows = (response: RankAndTrafficStatsResponse): NormalizedBingDailyRow[] => {
+	const rows = response.d ?? [];
+	const out: NormalizedBingDailyRow[] = [];
+	for (const row of rows) {
+		const observedDate = parseMsDate(row.Date);
+		if (!observedDate) continue;
+		out.push({
+			observedDate,
+			clicks: toNumber(row.Clicks),
+			impressions: toNumber(row.Impressions),
+			avgClickPosition: toNullableNumber(row.AvgClickPosition),
+			avgImpressionPosition: toNullableNumber(row.AvgImpressionPosition),
+		});
+	}
+	return out;
+};

--- a/packages/providers/bing/src/credential.ts
+++ b/packages/providers/bing/src/credential.ts
@@ -1,0 +1,21 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Bing Webmaster Tools auth: a single API key, scoped to the user account
+ * that owns the verified site. The key is generated in Bing Webmaster
+ * Settings → API Access; one key gives access to every site verified by
+ * that account, so the cascade resolution maps it at the org level.
+ *
+ * Plaintext is the bare key string — no JSON envelope.
+ */
+const KEY_REGEX = /^[A-Za-z0-9]{20,}$/;
+
+export const validateBingApiKey = (plaintext: string): string => {
+	const trimmed = plaintext.trim();
+	if (!KEY_REGEX.test(trimmed)) {
+		throw new InvalidInputError(
+			'Bing Webmaster API key must be at least 20 alphanumeric characters (Settings → API Access)',
+		);
+	}
+	return trimmed;
+};

--- a/packages/providers/bing/src/endpoints/query-stats.ts
+++ b/packages/providers/bing/src/endpoints/query-stats.ts
@@ -1,0 +1,56 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { BingHttp } from '../http.js';
+
+/**
+ * `GetQueryStats` returns the top queries that drove clicks/impressions for
+ * the verified site over the last 6 months. Bing aggregates these — there's
+ * no per-day granularity per query like GSC offers; the daily timeline view
+ * lives in `bing-rank-and-traffic-stats` instead.
+ *
+ * We snapshot this once per day and keep the latest aggregation under the
+ * natural key (siteUrl, query, observed_date). Day-over-day diffs are
+ * derived in the read model.
+ */
+export const QueryStatsParams = z.object({
+	siteUrl: z.string().url(),
+});
+export type QueryStatsParams = z.infer<typeof QueryStatsParams>;
+
+export const queryStatsDescriptor: EndpointDescriptor = {
+	id: 'bing-query-stats',
+	category: 'rankings',
+	displayName: 'Bing Query Stats',
+	description:
+		'Top queries (last 6 months) that drove clicks/impressions on a verified Bing property. Free, key-authenticated.',
+	paramsSchema: QueryStatsParams,
+	cost: { unit: 'usd_cents', amount: 0 },
+	defaultCron: '0 6 * * *',
+	rateLimit: { max: 60, durationMs: 60_000 },
+};
+
+export interface QueryStatsRow {
+	Query?: string;
+	Clicks?: number;
+	Impressions?: number;
+	AvgClickPosition?: number;
+	AvgImpressionPosition?: number;
+}
+
+export interface QueryStatsResponse {
+	d?: QueryStatsRow[];
+}
+
+export const fetchQueryStats = async (
+	http: BingHttp,
+	params: QueryStatsParams,
+	ctx: FetchContext,
+): Promise<QueryStatsResponse> => {
+	const raw = (await http.get(
+		'GetQueryStats',
+		{ siteUrl: params.siteUrl },
+		ctx.credential.plaintextSecret,
+		ctx.signal,
+	)) as QueryStatsResponse;
+	return raw;
+};

--- a/packages/providers/bing/src/endpoints/rank-and-traffic-stats.ts
+++ b/packages/providers/bing/src/endpoints/rank-and-traffic-stats.ts
@@ -1,0 +1,60 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { BingHttp } from '../http.js';
+
+/**
+ * `GetRankAndTrafficStats` returns ~6 months of daily totals for a verified
+ * site: clicks, impressions, average click position, average impression
+ * position. This is the Bing equivalent of GSC's date-bucketed performance
+ * timeline — same shape, simpler call (no dimension picker, no row paging).
+ *
+ * The call returns the full 6-month window every time; we re-fetch daily
+ * and let the natural-key PK on `(siteUrl, observedDate)` swallow re-writes.
+ */
+export const RankAndTrafficStatsParams = z.object({
+	siteUrl: z.string().url(),
+});
+export type RankAndTrafficStatsParams = z.infer<typeof RankAndTrafficStatsParams>;
+
+export const rankAndTrafficStatsDescriptor: EndpointDescriptor = {
+	id: 'bing-rank-and-traffic-stats',
+	category: 'rankings',
+	displayName: 'Bing Rank & Traffic Stats',
+	description:
+		'Real Bing Webmaster traffic stats (daily clicks, impressions, average click & impression position) for a verified property. Free, key-authenticated.',
+	paramsSchema: RankAndTrafficStatsParams,
+	cost: { unit: 'usd_cents', amount: 0 },
+	defaultCron: '0 6 * * *', // daily 06:00 UTC, after Bing has rolled the previous day
+	rateLimit: { max: 60, durationMs: 60_000 },
+};
+
+/**
+ * Bing returns dates as `/Date(1709251200000)/` — that's the Microsoft JSON
+ * serialiser format, the inner value is epoch milliseconds. We carry the raw
+ * shape into the ACL and parse there so the fetcher stays a thin pass-through.
+ */
+export interface RankAndTrafficStatsRow {
+	Date?: string; // /Date(<ms>)/
+	Clicks?: number;
+	Impressions?: number;
+	AvgClickPosition?: number;
+	AvgImpressionPosition?: number;
+}
+
+export interface RankAndTrafficStatsResponse {
+	d?: RankAndTrafficStatsRow[];
+}
+
+export const fetchRankAndTrafficStats = async (
+	http: BingHttp,
+	params: RankAndTrafficStatsParams,
+	ctx: FetchContext,
+): Promise<RankAndTrafficStatsResponse> => {
+	const raw = (await http.get(
+		'GetRankAndTrafficStats',
+		{ siteUrl: params.siteUrl },
+		ctx.credential.plaintextSecret,
+		ctx.signal,
+	)) as RankAndTrafficStatsResponse;
+	return raw;
+};

--- a/packages/providers/bing/src/http.ts
+++ b/packages/providers/bing/src/http.ts
@@ -1,0 +1,84 @@
+/**
+ * Bing Webmaster Tools API client. Auth = single API key as `apikey` query
+ * parameter. The service base is `ssl.bing.com/webmaster/api.svc/json/`.
+ *
+ * Bing rate limit is undocumented but generous (Microsoft says "fair use");
+ * empirically a few hundred req/min/account work. We declare a conservative
+ * 60 req/min in the descriptor so a misconfigured cron can't burn the
+ * account.
+ */
+import { validateBingApiKey } from './credential.js';
+
+export interface BingHttpOptions {
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_BASE_URL = 'https://ssl.bing.com/webmaster/api.svc/json';
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+export class BingApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'BingApiError';
+	}
+}
+
+export class BingHttp {
+	private readonly baseUrl: string;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: BingHttpOptions = {}) {
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	}
+
+	async get(
+		method: string,
+		query: Record<string, string>,
+		plaintextCredential: string,
+		signal?: AbortSignal,
+	): Promise<unknown> {
+		const apiKey = validateBingApiKey(plaintextCredential);
+		const params = new URLSearchParams({ ...query, apikey: apiKey });
+		const url = `${this.baseUrl}/${method}?${params.toString()}`;
+		const response = await this.fetchImpl(url, {
+			method: 'GET',
+			headers: { Accept: 'application/json' },
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new BingApiError(
+				response.status,
+				null,
+				`Bing ${method} response too large: ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new BingApiError(
+				response.status,
+				null,
+				`Bing ${method} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new BingApiError(response.status, parsed, `Bing ${method} returned HTTP ${response.status}`);
+		}
+		return parsed;
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/bing/src/index.ts
+++ b/packages/providers/bing/src/index.ts
@@ -1,0 +1,7 @@
+export * from './acl/query-stats-to-rows.acl.js';
+export * from './acl/rank-traffic-to-rows.acl.js';
+export * from './credential.js';
+export * from './endpoints/query-stats.js';
+export * from './endpoints/rank-and-traffic-stats.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/bing/src/provider.spec.ts
+++ b/packages/providers/bing/src/provider.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { BingProvider } from './provider.js';
+
+const validApiKey = 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6';
+
+describe('BingProvider', () => {
+	it('exposes both rank-and-traffic-stats and query-stats endpoints via discover()', () => {
+		const ids = new BingProvider().discover().map((e) => e.id);
+		expect(ids).toContain('bing-rank-and-traffic-stats');
+		expect(ids).toContain('bing-query-stats');
+	});
+
+	it('validateCredentialPlaintext accepts a normal API key', () => {
+		expect(() => new BingProvider().validateCredentialPlaintext(validApiKey)).not.toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects empty / too-short keys', () => {
+		expect(() => new BingProvider().validateCredentialPlaintext('')).toThrow();
+		expect(() => new BingProvider().validateCredentialPlaintext('short')).toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects non-alphanumeric keys', () => {
+		expect(() => new BingProvider().validateCredentialPlaintext('has-dashes-which-bing-keys-dont')).toThrow();
+		expect(() => new BingProvider().validateCredentialPlaintext('contains spaces hereaaaaaaaaa')).toThrow();
+	});
+
+	it('paramsSchema rejects a non-URL siteUrl on rank-and-traffic-stats', () => {
+		const ep = new BingProvider().discover().find((e) => e.id === 'bing-rank-and-traffic-stats');
+		expect(ep?.paramsSchema.safeParse({ siteUrl: 'example.com' }).success).toBe(false);
+		expect(ep?.paramsSchema.safeParse({ siteUrl: 'https://example.com/' }).success).toBe(true);
+	});
+
+	it('fetch rejects an unknown endpoint id', async () => {
+		const provider = new BingProvider();
+		await expect(
+			provider.fetch('not-real', {}, {
+				credential: { plaintextSecret: validApiKey },
+				signal: new AbortController().signal,
+			} as never),
+		).rejects.toThrow();
+	});
+});

--- a/packages/providers/bing/src/provider.ts
+++ b/packages/providers/bing/src/provider.ts
@@ -1,0 +1,54 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import { validateBingApiKey } from './credential.js';
+import { fetchQueryStats, type QueryStatsParams, queryStatsDescriptor } from './endpoints/query-stats.js';
+import {
+	fetchRankAndTrafficStats,
+	type RankAndTrafficStatsParams,
+	rankAndTrafficStatsDescriptor,
+} from './endpoints/rank-and-traffic-stats.js';
+import { BingHttp } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [rankAndTrafficStatsDescriptor, queryStatsDescriptor];
+
+export class BingProvider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('bing-webmaster');
+	readonly displayName = 'Bing Webmaster Tools';
+	readonly authStrategy = 'apiKey' as const;
+
+	private readonly http: BingHttp;
+
+	constructor(options?: { fetchImpl?: typeof fetch }) {
+		this.http = new BingHttp(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		validateBingApiKey(plaintextSecret);
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case rankAndTrafficStatsDescriptor.id: {
+				const parsed = rankAndTrafficStatsDescriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(`Invalid params for ${endpointId}: ${parsed.error.message}`);
+				}
+				return await fetchRankAndTrafficStats(this.http, parsed.data as RankAndTrafficStatsParams, ctx);
+			}
+			case queryStatsDescriptor.id: {
+				const parsed = queryStatsDescriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(`Invalid params for ${endpointId}: ${parsed.error.message}`);
+				}
+				return await fetchQueryStats(this.http, parsed.data as QueryStatsParams, ctx);
+			}
+			default:
+				throw new InvalidInputError(`bing-webmaster has no endpoint "${endpointId}"`);
+		}
+	}
+}

--- a/packages/providers/bing/tsconfig.build.json
+++ b/packages/providers/bing/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/bing/tsconfig.json
+++ b/packages/providers/bing/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/bing/vitest.config.ts
+++ b/packages/providers/bing/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,5 +1,6 @@
 import { HttpClient, type HttpClientOptions } from './http.js';
 import { AuthResource } from './resources/auth.js';
+import { BingResource } from './resources/bing.js';
 import { Ga4Resource } from './resources/ga4.js';
 import { GscResource } from './resources/gsc.js';
 import { PageSpeedResource } from './resources/page-speed.js';
@@ -23,6 +24,7 @@ export class RankPulseClient {
 	readonly wikipedia: WikipediaResource;
 	readonly pageSpeed: PageSpeedResource;
 	readonly ga4: Ga4Resource;
+	readonly bing: BingResource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -36,5 +38,6 @@ export class RankPulseClient {
 		this.wikipedia = new WikipediaResource(http);
 		this.pageSpeed = new PageSpeedResource(http);
 		this.ga4 = new Ga4Resource(http);
+		this.bing = new BingResource(http);
 	}
 }

--- a/packages/sdk/src/resources/bing.ts
+++ b/packages/sdk/src/resources/bing.ts
@@ -1,0 +1,30 @@
+import type { BingWebmasterInsightsContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class BingResource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<BingWebmasterInsightsContracts.BingPropertyDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/bing/properties`);
+	}
+
+	link(
+		projectId: string,
+		body: BingWebmasterInsightsContracts.LinkBingPropertyRequest,
+	): Promise<{ bingPropertyId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/bing/properties`, body);
+	}
+
+	unlink(bingPropertyId: string): Promise<{ ok: true }> {
+		return this.http.delete(`/bing/properties/${encodeURIComponent(bingPropertyId)}`);
+	}
+
+	traffic(
+		bingPropertyId: string,
+		query: BingWebmasterInsightsContracts.BingTrafficQuery,
+	): Promise<BingWebmasterInsightsContracts.BingTrafficObservationDto[]> {
+		return this.http.get(`/bing/properties/${encodeURIComponent(bingPropertyId)}/traffic`, {
+			query: { from: query.from, to: query.to },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@rankpulse/infrastructure':
         specifier: workspace:*
         version: link:../../packages/infrastructure
+      '@rankpulse/provider-bing':
+        specifier: workspace:*
+        version: link:../../packages/providers/bing
       '@rankpulse/provider-core':
         specifier: workspace:*
         version: link:../../packages/providers/core
@@ -199,6 +202,9 @@ importers:
       '@rankpulse/infrastructure':
         specifier: workspace:*
         version: link:../../packages/infrastructure
+      '@rankpulse/provider-bing':
+        specifier: workspace:*
+        version: link:../../packages/providers/bing
       '@rankpulse/provider-core':
         specifier: workspace:*
         version: link:../../packages/providers/core
@@ -336,6 +342,28 @@ importers:
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/bing:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/providers/core:
     dependencies:


### PR DESCRIPTION
Closes #20.

## Summary
- New provider package `@rankpulse/provider-bing`: bare API-key client (Bing accepts the key as a `?apikey=` query param), 8 MB body cap. Two endpoints: `bing-rank-and-traffic-stats` for the daily-totals timeline (the GSC equivalent), `bing-query-stats` for the top-queries aggregation. Pure ACLs handle Microsoft's `/Date(<ms>)/` date wrapper and drop malformed rows rather than synthesising fallbacks.
- New `bing-webmaster-insights` bounded context: `BingProperty` aggregate (URL-prefix only — Bing has no domain-property analogue), `BingTrafficObservation` value-like with `BingTrafficMetrics` enforcing position >= 1 (1-indexed). `BingPropertyLinked` and `BingTrafficBatchIngested` events.
- Drizzle migration 0008 — `bing_properties` (uniqueness on `(project_id, site_url)`) + `bing_traffic_observations` (natural PK `(bing_property_id, observed_date)`); idempotent IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
- Application — `LinkBingProperty` (rejects re-linking active duplicates), `UnlinkBingProperty` (idempotent), `IngestBingTraffic` (mirrors GSC/GA4 ingest: `onConflictDoNothing` on the natural key, only inserted-count counts in the totals event), `QueryBingTraffic`. 5 unit tests covering: first-insert + summary event, no-op on retry, NotFound, empty-batch short-circuit, position-invariant rejection.
- Worker — provider registered, processor dispatches `bing-rank-and-traffic-stats` to ACL + ingest, classifies `429` from Bing's fair-use throttle as quota-exhausted (auto-pauses definition).
- API — `GET/POST/DELETE /bing/...` endpoints in `BingWebmasterInsightsModule` with the same IDOR-safe 404-collapse pattern used by GSC / GA4 / web-performance.
- SDK — `bing` resource (`listForProject`, `link`, `unlink`, `traffic`).
- UI — atomic-design `LinkBingDrawer` organism + new Bing card on the project detail page (mobile-first, reminder about the verified-site + same-account-API-key prerequisite — without that the daily fetch fails 401).

## Pipeline status (local)
- `pnpm lint` — clean (biome `check .`).
- `pnpm typecheck` — 18/18 packages OK.
- `pnpm test` — all 18 workspaces green; **14** new Bing provider tests + **5** new application tests added.
- `pnpm build` — full monorepo build green.

## Test plan
- [ ] CI green (format/lint/typecheck/tests/coverage).
- [ ] Migration `0008_freezing_black_knight.sql` applies cleanly on the existing prod database (forward-only, idempotent).
- [ ] After deploy, register a Bing API-key credential, link a verified property, schedule the rank-and-traffic-stats cron (with a `bingPropertyId` in systemParams), trigger run-now and confirm rows land in `bing_traffic_observations`.
- [ ] Re-run the same job and verify it does not duplicate (PK conflict swallowed, `BingTrafficBatchIngested.rowsCount === 0`).