### PR TITLE
fix(provider-connectivity): preserve systemParams on PATCH + auto-resolve gscPropertyId

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -211,6 +211,13 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		SystemClock,
 		SystemIdGenerator,
 		eventPublisher,
+		[
+			// BACKLOG bug #50 — auto-resolves gscPropertyId from
+			// (projectId, params.siteUrl) for gsc-search-analytics
+			// schedules. Other providers/endpoints: add their own
+			// resolvers here as needed.
+			new SCIUseCases.GscPropertySystemParamResolver(gscPropertyRepo),
+		],
 	);
 	const recordApiUsage = new PCUseCases.RecordApiUsageUseCase(
 		apiUsageRepo,

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
@@ -1,6 +1,6 @@
 import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	DeleteJobDefinitionUseCase,
 	GetJobDefinitionUseCase,
@@ -167,5 +167,98 @@ describe('DeleteJobDefinitionUseCase', () => {
 	it('throws NotFoundError when the definition does not exist', async () => {
 		const useCase = new DeleteJobDefinitionUseCase(new StubDefinitionRepo(), new RecordingScheduler());
 		await expect(useCase.execute('missing')).rejects.toBeInstanceOf(NotFoundError);
+	});
+});
+
+// ===== BACKLOG bug #51: PATCH preserves systemParams =====
+import { ProviderConnectivity as PC2 } from '@rankpulse/domain';
+import { UpdateJobDefinitionUseCase as UpdateJobDefUC2 } from './manage-job-definition.use-cases.js';
+
+describe('UpdateJobDefinitionUseCase — preserves systemParams (bug #51)', () => {
+	const aDefinitionWithSystemParams = (): PC2.ProviderJobDefinition =>
+		PC2.ProviderJobDefinition.schedule({
+			id: 'def-aabbcc' as PC2.ProviderJobDefinitionId,
+			projectId: 'proj-1' as never,
+			providerId: PC2.ProviderId.create('google-search-console'),
+			endpointId: PC2.EndpointId.create('gsc-search-analytics'),
+			params: {
+				siteUrl: 'sc-domain:example.com',
+				startDate: '{{today-30}}',
+				endDate: '{{today-2}}',
+				dimensions: ['date', 'query', 'page'],
+				rowLimit: 25000,
+				// systemParams mixed in (current model)
+				organizationId: 'org-1',
+				gscPropertyId: 'prop-1',
+			},
+			cron: PC2.CronExpression.create('0 5 * * *'),
+			credentialOverrideId: null,
+			now: new Date('2026-05-05T00:00:00Z'),
+		});
+
+	it('preserves organizationId and gscPropertyId when caller PATCHes only user keys', async () => {
+		const def = aDefinitionWithSystemParams();
+		const repo = {
+			save: vi.fn(),
+			findById: vi.fn().mockResolvedValue(def),
+			deactivate: vi.fn(),
+			delete: vi.fn(),
+			listForProject: vi.fn(),
+		} as unknown as PC2.JobDefinitionRepository;
+		const scheduler = {
+			register: vi.fn(),
+			unregister: vi.fn(),
+			enqueueOnce: vi.fn(),
+		} satisfies PC2.JobScheduler;
+
+		const uc = new UpdateJobDefUC2(repo, scheduler);
+		const view = await uc.execute({
+			definitionId: 'def-aabbcc',
+			params: {
+				siteUrl: 'sc-domain:example.com',
+				startDate: '2025-05-06',
+				endDate: '{{today-2}}',
+				dimensions: ['date', 'query', 'page'],
+				rowLimit: 25000,
+			},
+		});
+
+		expect(view.params.organizationId).toBe('org-1');
+		expect(view.params.gscPropertyId).toBe('prop-1');
+		expect(view.params.startDate).toBe('2025-05-06');
+	});
+
+	it('user PATCH cannot overwrite systemParams (defensive)', async () => {
+		const def = aDefinitionWithSystemParams();
+		const repo = {
+			save: vi.fn(),
+			findById: vi.fn().mockResolvedValue(def),
+			deactivate: vi.fn(),
+			delete: vi.fn(),
+			listForProject: vi.fn(),
+		} as unknown as PC2.JobDefinitionRepository;
+		const scheduler = {
+			register: vi.fn(),
+			unregister: vi.fn(),
+			enqueueOnce: vi.fn(),
+		} satisfies PC2.JobScheduler;
+
+		const uc = new UpdateJobDefUC2(repo, scheduler);
+		const view = await uc.execute({
+			definitionId: 'def-aabbcc',
+			params: {
+				siteUrl: 'sc-domain:example.com',
+				organizationId: 'EVIL-ORG',
+				gscPropertyId: 'EVIL-PROP',
+				startDate: '2025-05-06',
+				endDate: '{{today-2}}',
+				dimensions: ['date'],
+				rowLimit: 100,
+			},
+		});
+
+		// systemParams from the DB always win
+		expect(view.params.organizationId).toBe('org-1');
+		expect(view.params.gscPropertyId).toBe('prop-1');
 	});
 });

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
@@ -53,6 +53,29 @@ export interface UpdateJobDefinitionCommand {
 	enabled?: boolean;
 }
 
+/**
+ * Keys the controllers inject as systemParams when creating or
+ * auto-scheduling a JobDefinition. Listed here (instead of inferred from
+ * the existing def's params) so that adding one elsewhere fails the type
+ * check until this list is updated — keeping the contract explicit.
+ *
+ * BACKLOG bug #51.
+ */
+const SYSTEM_PARAM_KEYS = ['organizationId', 'projectId', 'gscPropertyId', 'trackedKeywordId'] as const;
+
+function mergeUserParamsPreservingSystem(
+	existing: Record<string, unknown>,
+	userPatch: Record<string, unknown>,
+): Record<string, unknown> {
+	const preserved: Record<string, unknown> = {};
+	for (const key of SYSTEM_PARAM_KEYS) {
+		if (existing[key] !== undefined) preserved[key] = existing[key];
+	}
+	// User-provided keys take precedence for non-system keys; system keys
+	// from the existing def always win to prevent accidental tamper.
+	return { ...userPatch, ...preserved };
+}
+
 export class UpdateJobDefinitionUseCase {
 	constructor(
 		private readonly definitions: ProviderConnectivity.JobDefinitionRepository,
@@ -72,7 +95,20 @@ export class UpdateJobDefinitionUseCase {
 		const snapshotBeforeUpdate = def;
 
 		if (cmd.cron !== undefined) def.updateCron(ProviderConnectivity.CronExpression.create(cmd.cron));
-		if (cmd.params !== undefined) def.updateParams(cmd.params);
+		if (cmd.params !== undefined) {
+			// BACKLOG bug #51 — PATCH used to REPLACE `params` wholesale,
+			// silently dropping any system-injected key the controller put
+			// there at create time (`organizationId`, `gscPropertyId`,
+			// `trackedKeywordId`). The next worker run then failed with
+			// "missing organizationId in systemParams" or similar.
+			//
+			// Fix: preserve the known systemParam keys from the existing
+			// def and merge the user-provided patch ON TOP. The whitelist
+			// is intentionally explicit — adding a new systemParam in
+			// downstream code requires extending this list, which forces a
+			// review of every PATCH call site.
+			def.updateParams(mergeUserParamsPreservingSystem(def.params, cmd.params));
+		}
 		if (cmd.enabled === true) def.enable();
 		if (cmd.enabled === false) def.disable();
 

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
@@ -10,6 +10,29 @@ export interface EndpointParamsValidator {
 	validate(providerId: string, endpointId: string, params: unknown): Record<string, unknown>;
 }
 
+/**
+ * Cross-context system-param resolver.
+ *
+ * BACKLOG bug #50 — some endpoints require an internal entity ID alongside
+ * the user-facing params (e.g. `gsc-search-analytics` needs `gscPropertyId`
+ * to ingest results into the right hypertable row). Hard-coding that lookup
+ * inside this use case would couple `provider-connectivity` to every other
+ * bounded context. Instead, expose a port and let composition wire in
+ * resolvers per provider/endpoint pair. Each resolver returns either:
+ *   - an object of system-params to merge, OR
+ *   - {} when the resolver doesn't apply to this command, OR
+ *   - throws `InvalidInputError` / `NotFoundError` when the prerequisite
+ *     entity is missing (caller has to link the entity first).
+ */
+export interface SystemParamResolver {
+	resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>>;
+}
+
 export interface ScheduleEndpointFetchCommand {
 	projectId: string;
 	providerId: string;
@@ -40,6 +63,7 @@ export class ScheduleEndpointFetchUseCase {
 		private readonly clock: Clock,
 		private readonly ids: IdGenerator,
 		private readonly events: SharedKernel.EventPublisher,
+		private readonly systemParamResolvers: SystemParamResolver[] = [],
 	) {}
 
 	async execute(cmd: ScheduleEndpointFetchCommand): Promise<ScheduleEndpointFetchResult> {
@@ -54,7 +78,21 @@ export class ScheduleEndpointFetchUseCase {
 				`Endpoint ${endpointId.value} paramsSchema must resolve to an object, got ${typeof validatedParams}`,
 			);
 		}
-		const finalParams: Record<string, unknown> = { ...validatedParams, ...(cmd.systemParams ?? {}) };
+
+		// Run cross-context resolvers (e.g. resolve gscPropertyId from siteUrl).
+		// Empty list in tests / when nothing is wired — the loop simply no-ops.
+		let resolvedSystemParams: Record<string, unknown> = { ...(cmd.systemParams ?? {}) };
+		for (const resolver of this.systemParamResolvers) {
+			const extra = await resolver.resolve({
+				projectId: cmd.projectId,
+				providerId: providerId.value,
+				endpointId: endpointId.value,
+				params: validatedParams,
+			});
+			resolvedSystemParams = { ...resolvedSystemParams, ...extra };
+		}
+
+		const finalParams: Record<string, unknown> = { ...validatedParams, ...resolvedSystemParams };
 
 		const id = this.ids.generate() as ProviderConnectivity.ProviderJobDefinitionId;
 		const definition = ProviderConnectivity.ProviderJobDefinition.schedule({

--- a/packages/application/src/search-console-insights/index.ts
+++ b/packages/application/src/search-console-insights/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule-on-link.handler.js';
+export * from './system-param-resolvers/gsc-property.system-param-resolver.js';
 export * from './use-cases/ingest-gsc-rows.use-case.js';
 export * from './use-cases/link-gsc-property.use-case.js';
 export * from './use-cases/query-gsc-performance.use-case.js';

--- a/packages/application/src/search-console-insights/system-param-resolvers/gsc-property.system-param-resolver.spec.ts
+++ b/packages/application/src/search-console-insights/system-param-resolvers/gsc-property.system-param-resolver.spec.ts
@@ -1,0 +1,121 @@
+import type { SearchConsoleInsights } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { GscPropertySystemParamResolver } from './gsc-property.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const propertyId = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+const siteUrl = 'sc-domain:example.com';
+
+const aLinkedProperty = (): SearchConsoleInsights.GscProperty =>
+	({
+		id: propertyId,
+		isActive: () => true,
+	}) as unknown as SearchConsoleInsights.GscProperty;
+
+const anUnlinkedProperty = (): SearchConsoleInsights.GscProperty =>
+	({
+		id: propertyId,
+		isActive: () => false,
+	}) as unknown as SearchConsoleInsights.GscProperty;
+
+describe('GscPropertySystemParamResolver', () => {
+	it('returns gscPropertyId when (project, siteUrl) match an active property', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn().mockResolvedValue(aLinkedProperty()),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		const result = await resolver.resolve({
+			projectId,
+			providerId: 'google-search-console',
+			endpointId: 'gsc-search-analytics',
+			params: { siteUrl },
+		});
+
+		expect(result).toEqual({ gscPropertyId: propertyId });
+		expect(repo.findByProjectAndSite).toHaveBeenCalledWith(projectId, siteUrl);
+	});
+
+	it('returns empty object when the request is for a different provider', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn(),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		const result = await resolver.resolve({
+			projectId,
+			providerId: 'dataforseo',
+			endpointId: 'serp-google-organic-live',
+			params: { siteUrl },
+		});
+
+		expect(result).toEqual({});
+		expect(repo.findByProjectAndSite).not.toHaveBeenCalled();
+	});
+
+	it('returns empty object for other GSC endpoints', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn(),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		const result = await resolver.resolve({
+			projectId,
+			providerId: 'google-search-console',
+			endpointId: 'gsc-other-future-endpoint',
+			params: { siteUrl },
+		});
+
+		expect(result).toEqual({});
+	});
+
+	it('throws InvalidInputError when params.siteUrl is missing', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn(),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		await expect(
+			resolver.resolve({
+				projectId,
+				providerId: 'google-search-console',
+				endpointId: 'gsc-search-analytics',
+				params: {},
+			}),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+
+	it('throws NotFoundError pointing the operator at /gsc/properties when the property is not linked', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn().mockResolvedValue(null),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		const promise = resolver.resolve({
+			projectId,
+			providerId: 'google-search-console',
+			endpointId: 'gsc-search-analytics',
+			params: { siteUrl },
+		});
+
+		await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+		await expect(promise).rejects.toThrow(/POST \/gsc\/properties/);
+	});
+
+	it('throws NotFoundError when the property exists but was unlinked', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn().mockResolvedValue(anUnlinkedProperty()),
+		} as unknown as SearchConsoleInsights.GscPropertyRepository;
+		const resolver = new GscPropertySystemParamResolver(repo);
+
+		await expect(
+			resolver.resolve({
+				projectId,
+				providerId: 'google-search-console',
+				endpointId: 'gsc-search-analytics',
+				params: { siteUrl },
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/search-console-insights/system-param-resolvers/gsc-property.system-param-resolver.ts
+++ b/packages/application/src/search-console-insights/system-param-resolvers/gsc-property.system-param-resolver.ts
@@ -1,0 +1,56 @@
+import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `gscPropertyId` for `gsc-search-analytics` schedules.
+ *
+ * BACKLOG bug #50 — when an operator hits `POST /providers/google-search-console/
+ * endpoints/gsc-search-analytics/schedule` directly (instead of going through
+ * the auto-schedule on `POST /gsc/properties`), the resulting JobDefinition
+ * lacked `gscPropertyId` in `systemParams`. The worker's processor then
+ * skipped ingest with `gsc-search-analytics job missing gscPropertyId param;
+ * skipping ingest`, silently discarding every fetched payload.
+ *
+ * This resolver looks up the GscProperty entity by `(projectId, params.siteUrl)`
+ * and injects its id. If the property isn't linked yet we bail with a clear
+ * error pointing the operator at `POST /gsc/properties` — that path runs
+ * `LinkGscPropertyUseCase` which fires `GscPropertyLinked`, which the
+ * `AutoScheduleOnGscPropertyLinkedHandler` then converts into a properly
+ * scoped JobDefinition without the operator having to think about it.
+ */
+export class GscPropertySystemParamResolver implements SystemParamResolver {
+	constructor(private readonly properties: SearchConsoleInsights.GscPropertyRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		// Tight match — only this provider/endpoint pair needs gscPropertyId.
+		// Any other request: no-op.
+		if (input.providerId !== 'google-search-console') return {};
+		if (input.endpointId !== 'gsc-search-analytics') return {};
+
+		const siteUrl = input.params.siteUrl;
+		if (typeof siteUrl !== 'string' || siteUrl.length === 0) {
+			throw new InvalidInputError(
+				'gsc-search-analytics schedule requires `params.siteUrl` (e.g. "sc-domain:example.com").',
+			);
+		}
+
+		const property = await this.properties.findByProjectAndSite(
+			input.projectId as ProjectManagement.ProjectId,
+			siteUrl,
+		);
+		if (!property?.isActive()) {
+			throw new NotFoundError(
+				`GSC property ${siteUrl} is not linked to project ${input.projectId}. ` +
+					'Link it first via POST /gsc/properties — that path auto-creates the daily schedule.',
+			);
+		}
+
+		return { gscPropertyId: property.id };
+	}
+}


### PR DESCRIPTION
Closes #50 and #51.

## What

Two bugs were silently breaking GSC data ingest in production.

### #50 — gsc-search-analytics jobs scheduled without gscPropertyId
- 15 manually-scheduled GSC job-defs all said `status: succeeded` but the worker logged `gsc-search-analytics job missing gscPropertyId param; skipping ingest` and discarded every fetched payload.
- Zero GSC rows were being persisted to the hypertable.

### #51 — PATCH job-definition wiped systemParams
- `PATCH /providers/.../job-definitions/:id` with a partial `params` body was REPLACING the entire params jsonb, dropping `organizationId`, `gscPropertyId`, `trackedKeywordId` injected at create time.
- Subsequent runs failed with `missing organizationId in systemParams`.

## How

### Fix #50 — `SystemParamResolver` port
`ScheduleEndpointFetchUseCase` now accepts an array of `SystemParamResolver`s, each of which can return additional systemParams to merge based on `(providerId, endpointId, params, projectId)`. Composition root wires `GscPropertySystemParamResolver` which looks up the GscProperty by `(projectId, params.siteUrl)` and injects `gscPropertyId`. If the property isn't linked, throws `NotFoundError` pointing at `POST /gsc/properties` (which auto-schedules via the existing `AutoScheduleOnGscPropertyLinkedHandler`).

DDD: cross-context wiring lives at the composition root, not in application. The use case stays decoupled from `search-console-insights`.

### Fix #51 — explicit systemParams whitelist on PATCH merge
`UpdateJobDefinitionUseCase` now merges user-provided params with the systemParam keys (`organizationId`, `projectId`, `gscPropertyId`, `trackedKeywordId`) preserved from the existing definition. The whitelist is explicit — adding a new systemParam elsewhere requires extending this list, which forces a review of every PATCH call site.

Defensive: user-provided PATCH cannot overwrite systemParams (existing values win in the merge), so no operator can accidentally re-scope a JobDefinition by passing a wrong organizationId in a body.

## Tests
- 6 unit tests for `GscPropertySystemParamResolver` (resolver matches/no-match, missing siteUrl, unlinked property, etc.).
- 2 unit tests for `UpdateJobDefinition` PATCH merge.
- All 130 application tests pass; `@rankpulse/api` typechecks.

## Operational notes after merge
The 15 GSC job-defs that already exist in production were created by the buggy POST schedule path and lack `gscPropertyId`. They are NOT auto-fixed by this PR. Two paths to repair:
1. (preferred) DELETE them via API; they will be re-created with the correct systemParams next time the operator hits `POST /gsc/properties` for the same site (or a one-shot script that re-links).
2. SQL UPDATE `provider_job_definitions SET params = jsonb_set(params, '{gscPropertyId}', to_jsonb(gp.id)) FROM gsc_properties gp WHERE …` — quick but bypasses domain layer.

Will run path 1 from operator side after merge.