### PR TITLE
feat: Cloudflare Radar provider + macro-context (#25)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
 		"@rankpulse/domain": "workspace:*",
 		"@rankpulse/infrastructure": "workspace:*",
 		"@rankpulse/provider-bing": "workspace:*",
+		"@rankpulse/provider-cloudflare-radar": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { BingWebmasterInsightsModule } from './modules/bing-webmaster-insights/b
 import { EntityAwarenessModule } from './modules/entity-awareness/entity-awareness.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { IdentityAccessModule } from './modules/identity-access/identity-access.module.js';
+import { MacroContextModule } from './modules/macro-context/macro-context.module.js';
 import { ProjectManagementModule } from './modules/project-management/project-management.module.js';
 import { ProviderConnectivityModule } from './modules/provider-connectivity/provider-connectivity.module.js';
 import { RankTrackingModule } from './modules/rank-tracking/rank-tracking.module.js';
@@ -50,6 +51,7 @@ export class AppModule {
 			WebPerformanceModule,
 			TrafficAnalyticsModule,
 			BingWebmasterInsightsModule,
+			MacroContextModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -3,6 +3,7 @@ import {
 	BingWebmasterInsights as BWIUseCases,
 	EntityAwareness as EAUseCases,
 	IdentityAccess as IAUseCases,
+	MacroContext as MCUseCases,
 	ProviderConnectivity as PCUseCases,
 	ProjectManagement as PMUseCases,
 	RankTracking as RTUseCases,
@@ -13,6 +14,7 @@ import {
 import type { ProjectManagement } from '@rankpulse/domain';
 import { Crypto, DrizzlePersistence, Events, Queue as QueueAdapters } from '@rankpulse/infrastructure';
 import { BingProvider } from '@rankpulse/provider-bing';
+import { CloudflareRadarProvider } from '@rankpulse/provider-cloudflare-radar';
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
@@ -76,6 +78,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	const bingTrafficObservationRepo = new DrizzlePersistence.DrizzleBingTrafficObservationRepository(
 		drizzle.db,
 	);
+	const monitoredDomainRepo = new DrizzlePersistence.DrizzleMonitoredDomainRepository(drizzle.db);
+	const radarRankSnapshotRepo = new DrizzlePersistence.DrizzleRadarRankSnapshotRepository(drizzle.db);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -86,6 +90,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	providerRegistry.register(new GscProvider());
 	providerRegistry.register(new Ga4Provider());
 	providerRegistry.register(new BingProvider());
+	providerRegistry.register(new CloudflareRadarProvider());
 
 	const registerOrganization = new IAUseCases.RegisterOrganizationUseCase(
 		orgRepo,
@@ -302,6 +307,19 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		bingTrafficObservationRepo,
 	);
 
+	// Issue #25 — macro-context use cases
+	const addMonitoredDomain = new MCUseCases.AddMonitoredDomainUseCase(
+		monitoredDomainRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const removeMonitoredDomain = new MCUseCases.RemoveMonitoredDomainUseCase(monitoredDomainRepo, SystemClock);
+	const queryRadarHistory = new MCUseCases.QueryRadarHistoryUseCase(
+		monitoredDomainRepo,
+		radarRankSnapshotRepo,
+	);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -412,6 +430,12 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.LinkBingProperty, linkBingProperty),
 		value(Tokens.UnlinkBingProperty, unlinkBingProperty),
 		value(Tokens.QueryBingTraffic, queryBingTraffic),
+
+		value(Tokens.MonitoredDomainRepository, monitoredDomainRepo),
+		value(Tokens.RadarRankSnapshotRepository, radarRankSnapshotRepo),
+		value(Tokens.AddMonitoredDomain, addMonitoredDomain),
+		value(Tokens.RemoveMonitoredDomain, removeMonitoredDomain),
+		value(Tokens.QueryRadarHistory, queryRadarHistory),
 	];
 
 	return {

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -122,6 +122,15 @@ export const Tokens = {
 	UnlinkBingProperty: Symbol('UnlinkBingPropertyUseCase'),
 	QueryBingTraffic: Symbol('QueryBingTrafficUseCase'),
 
+	// Macro-Context (Cloudflare Radar) ports
+	MonitoredDomainRepository: Symbol('MonitoredDomainRepository'),
+	RadarRankSnapshotRepository: Symbol('RadarRankSnapshotRepository'),
+
+	// Macro-Context use cases
+	AddMonitoredDomain: Symbol('AddMonitoredDomainUseCase'),
+	RemoveMonitoredDomain: Symbol('RemoveMonitoredDomainUseCase'),
+	QueryRadarHistory: Symbol('QueryRadarHistoryUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/macro-context/macro-context.module.ts
+++ b/apps/api/src/modules/macro-context/macro-context.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { RadarController } from './radar.controller.js';
+
+@Module({
+	controllers: [RadarController],
+})
+export class MacroContextModule {}

--- a/apps/api/src/modules/macro-context/radar.controller.ts
+++ b/apps/api/src/modules/macro-context/radar.controller.ts
@@ -1,0 +1,113 @@
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { MacroContext as MCUseCases } from '@rankpulse/application';
+import { MacroContextContracts } from '@rankpulse/contracts';
+import type { IdentityAccess, MacroContext, ProjectManagement } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+@Controller()
+export class RadarController {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.AddMonitoredDomain) private readonly addDomain: MCUseCases.AddMonitoredDomainUseCase,
+		@Inject(Tokens.RemoveMonitoredDomain)
+		private readonly removeDomain: MCUseCases.RemoveMonitoredDomainUseCase,
+		@Inject(Tokens.QueryRadarHistory) private readonly queryHistory: MCUseCases.QueryRadarHistoryUseCase,
+		@Inject(Tokens.MonitoredDomainRepository)
+		private readonly domains: MacroContext.MonitoredDomainRepository,
+		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/radar/domains')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<MacroContextContracts.MonitoredDomainDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.domains.listForProject(project.id);
+		return list.map((d) => this.serialize(d));
+	}
+
+	@Post('projects/:projectId/radar/domains')
+	async add(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(MacroContextContracts.AddMonitoredDomainRequest))
+		body: MacroContextContracts.AddMonitoredDomainRequest,
+	): Promise<{ monitoredDomainId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.addDomain.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			domain: body.domain,
+			credentialId: body.credentialId ?? null,
+		});
+	}
+
+	@Delete('radar/domains/:monitoredDomainId')
+	async remove(
+		@Principal() principal: AuthPrincipal,
+		@Param('monitoredDomainId') monitoredDomainId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToDomain(principal, monitoredDomainId);
+		await this.removeDomain.execute({ monitoredDomainId });
+		return { ok: true };
+	}
+
+	@Get('radar/domains/:monitoredDomainId/history')
+	async history(
+		@Principal() principal: AuthPrincipal,
+		@Param('monitoredDomainId') monitoredDomainId: string,
+		@Query(new ZodValidationPipe(MacroContextContracts.RadarHistoryQuery))
+		q: MacroContextContracts.RadarHistoryQuery,
+	): Promise<MacroContextContracts.RadarHistoryRowDto[]> {
+		await this.requireAccessToDomain(principal, monitoredDomainId);
+		const result = await this.queryHistory.execute({ monitoredDomainId, from: q.from, to: q.to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	private async requireAccessToDomain(principal: AuthPrincipal, monitoredDomainId: string): Promise<void> {
+		// Same IDOR-safe 404-collapse used elsewhere — leaked id must not
+		// distinguish 403 from 404 on the wire.
+		const md = await this.domains.findById(monitoredDomainId as MacroContext.MonitoredDomainId);
+		if (!md) throw new NotFoundError(`MonitoredDomain ${monitoredDomainId} not found`);
+		const project = await this.projects.findById(md.projectId);
+		if (!project) throw new NotFoundError(`MonitoredDomain ${monitoredDomainId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`MonitoredDomain ${monitoredDomainId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(d: MacroContext.MonitoredDomain): MacroContextContracts.MonitoredDomainDto {
+		return {
+			id: d.id,
+			projectId: d.projectId,
+			domain: d.domain.value,
+			credentialId: d.credentialId,
+			addedAt: d.addedAt.toISOString(),
+			removedAt: d.removedAt ? d.removedAt.toISOString() : null,
+			isActive: d.isActive(),
+		};
+	}
+}

--- a/apps/web/src/components/add-radar-domain-drawer.tsx
+++ b/apps/web/src/components/add-radar-domain-drawer.tsx
@@ -1,0 +1,90 @@
+import { Button, Drawer, FormField, Input } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface AddRadarDomainDrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #25 — atomic-design organism. Mobile-first drawer to register
+ * a bare domain for Cloudflare Radar monthly rank monitoring. The
+ * domain is canonicalised (lowercased, www. stripped) on the server so
+ * "WWW.Example.com" and "example.com" collide as one row.
+ */
+export const AddRadarDomainDrawer = ({ projectId, open, onClose }: AddRadarDomainDrawerProps) => {
+	const qc = useQueryClient();
+	const [domain, setDomain] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setDomain('');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => api.radar.add(projectId, { domain }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'radar'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to add monitored domain'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Monitor a domain (Cloudflare Radar)"
+			description="Track a domain's global popularity ranking from Cloudflare's 1.1.1.1 resolver telemetry. Snapshotted monthly."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="add-radar-domain-form" disabled={mutation.isPending || !domain}>
+						{mutation.isPending ? 'Adding…' : 'Monitor'}
+					</Button>
+				</>
+			}
+		>
+			<form id="add-radar-domain-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField label="Domain" hint="Bare domain only — no scheme, no path. Example: example.com">
+					{(id) => (
+						<Input
+							id={id}
+							value={domain}
+							onChange={(e) => setDomain(e.target.value.trim())}
+							placeholder="example.com"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<p className="text-xs text-muted-foreground">
+					Long-tail domains may not have a global rank — that's fine, the snapshot stores rank: null and the
+					timeline records the gap. Once the domain enters Cloudflare's ranking, the next monthly cron picks
+					it up.
+				</p>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -11,6 +11,7 @@ import {
 	LineChart,
 	MapPin,
 	Plus,
+	Radar,
 	Search,
 	Sparkles,
 	X,
@@ -19,6 +20,7 @@ import { useState } from 'react';
 import { AddCompetitorDrawer } from '../components/add-competitor-drawer.js';
 import { AddDomainDrawer } from '../components/add-domain-drawer.js';
 import { AddLocationDrawer } from '../components/add-location-drawer.js';
+import { AddRadarDomainDrawer } from '../components/add-radar-domain-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
 import { LinkBingDrawer } from '../components/link-bing-drawer.js';
@@ -30,7 +32,16 @@ import { api } from '../lib/api.js';
 export const ProjectDetailPage = () => {
 	const { id } = useParams({ from: '/projects/$id' });
 	const [openDrawer, setOpenDrawer] = useState<
-		'competitor' | 'keywords' | 'domain' | 'location' | 'wikipedia' | 'page-speed' | 'ga4' | 'bing' | null
+		| 'competitor'
+		| 'keywords'
+		| 'domain'
+		| 'location'
+		| 'wikipedia'
+		| 'page-speed'
+		| 'ga4'
+		| 'bing'
+		| 'radar'
+		| null
 	>(null);
 
 	const projectQuery = useQuery({
@@ -77,6 +88,12 @@ export const ProjectDetailPage = () => {
 	const bingQuery = useQuery({
 		queryKey: ['project', id, 'bing'],
 		queryFn: () => api.bing.listForProject(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const radarQuery = useQuery({
+		queryKey: ['project', id, 'radar'],
+		queryFn: () => api.radar.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -335,6 +352,46 @@ export const ProjectDetailPage = () => {
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="flex items-center gap-2 text-base">
+								<Radar size={14} className="text-primary" />
+								Radar domains ({radarQuery.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('radar')}>
+								<Plus size={14} />
+								Monitor
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{radarQuery.isLoading ? (
+								<Spinner />
+							) : radarQuery.data && radarQuery.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{radarQuery.data.map((d) => (
+										<li key={d.id} className="break-words">
+											<Badge variant={d.isActive ? 'default' : 'secondary'}>
+												{d.isActive ? 'active' : 'removed'}
+											</Badge>{' '}
+											<span className="text-muted-foreground">{d.domain}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No domain monitored"
+									description="Track a domain's global popularity ranking from Cloudflare Radar — useful as a macro-trend signal beside organic search performance."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('radar')}>
+											<Plus size={14} />
+											Monitor domain
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
 								<Globe2 size={14} className="text-primary" />
 								Bing properties ({bingQuery.data?.length ?? '…'})
 							</CardTitle>
@@ -519,6 +576,11 @@ export const ProjectDetailPage = () => {
 			/>
 			<LinkGa4Drawer projectId={id} open={openDrawer === 'ga4'} onClose={() => setOpenDrawer(null)} />
 			<LinkBingDrawer projectId={id} open={openDrawer === 'bing'} onClose={() => setOpenDrawer(null)} />
+			<AddRadarDomainDrawer
+				projectId={id}
+				open={openDrawer === 'radar'}
+				onClose={() => setOpenDrawer(null)}
+			/>
 		</AppShell>
 	);
 };

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -20,6 +20,7 @@
 		"@rankpulse/domain": "workspace:*",
 		"@rankpulse/infrastructure": "workspace:*",
 		"@rankpulse/provider-bing": "workspace:*",
+		"@rankpulse/provider-cloudflare-radar": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,7 @@
 import {
 	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
+	MacroContext as MacroContextUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
@@ -46,6 +47,8 @@ async function bootstrap(): Promise<void> {
 	const bingTrafficObservationRepo = new DrizzlePersistence.DrizzleBingTrafficObservationRepository(
 		drizzle.db,
 	);
+	const monitoredDomainRepo = new DrizzlePersistence.DrizzleMonitoredDomainRepository(drizzle.db);
+	const radarRankSnapshotRepo = new DrizzlePersistence.DrizzleRadarRankSnapshotRepository(drizzle.db);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -108,6 +111,12 @@ async function bootstrap(): Promise<void> {
 		eventPublisher,
 		SystemClock,
 	);
+	const recordRadarRankUseCase = new MacroContextUseCases.RecordRadarRankUseCase(
+		monitoredDomainRepo,
+		radarRankSnapshotRepo,
+		eventPublisher,
+		SystemClock,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -123,6 +132,7 @@ async function bootstrap(): Promise<void> {
 		trackedPageRepo,
 		ga4PropertyRepo,
 		bingPropertyRepo,
+		monitoredDomainRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
@@ -133,6 +143,7 @@ async function bootstrap(): Promise<void> {
 		recordPageSpeedSnapshotUseCase,
 		ingestGa4RowsUseCase,
 		ingestBingTrafficUseCase,
+		recordRadarRankUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -1,6 +1,7 @@
 import type {
 	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
+	MacroContext as MacroContextUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
 	RankTracking as RankTrackingUseCases,
@@ -11,6 +12,7 @@ import type {
 import {
 	type BingWebmasterInsights as BingWebmasterInsightsDomain,
 	type EntityAwareness as EntityAwarenessDomain,
+	type MacroContext as MacroContextDomain,
 	type ProjectManagement,
 	ProviderConnectivity,
 	type RankTracking as RankTrackingDomain,
@@ -24,6 +26,11 @@ import {
 	extractDailyRows as extractBingDailyRows,
 	type RankAndTrafficStatsResponse,
 } from '@rankpulse/provider-bing';
+import {
+	CloudflareRadarApiError,
+	type DomainRankResponse,
+	extractSnapshot as extractRadarSnapshot,
+} from '@rankpulse/provider-cloudflare-radar';
 import type { ProviderRegistry } from '@rankpulse/provider-core';
 import {
 	DataForSeoApiError,
@@ -87,6 +94,9 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 	// signal. Treat it as quota-exhausted so the cron auto-pauses rather than
 	// retrying through the budget for the rest of the day.
 	if (err instanceof BingApiError && err.status === 429) return true;
+	// Cloudflare Radar enforces per-account rate limits at the platform edge;
+	// 429 is the throttle signal. Auto-pause until the operator topples up.
+	if (err instanceof CloudflareRadarApiError && (err.status === 402 || err.status === 429)) return true;
 	return false;
 };
 
@@ -110,6 +120,7 @@ export interface ProviderFetchProcessorDeps {
 	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
 	ga4PropertyRepo: TrafficAnalyticsDomain.Ga4PropertyRepository;
 	bingPropertyRepo: BingWebmasterInsightsDomain.BingPropertyRepository;
+	monitoredDomainRepo: MacroContextDomain.MonitoredDomainRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
@@ -120,6 +131,7 @@ export interface ProviderFetchProcessorDeps {
 	recordPageSpeedSnapshotUseCase: WebPerformanceUseCases.RecordPageSpeedSnapshotUseCase;
 	ingestGa4RowsUseCase: TrafficAnalyticsUseCases.IngestGa4RowsUseCase;
 	ingestBingTrafficUseCase: BingWebmasterInsightsUseCases.IngestBingTrafficUseCase;
+	recordRadarRankUseCase: MacroContextUseCases.RecordRadarRankUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -400,6 +412,30 @@ export class ProviderFetchProcessor {
 						gscPropertyId: gscParams.gscPropertyId,
 						rawPayloadId,
 						rows,
+					});
+				}
+			}
+
+			if (
+				definition.providerId.value === 'cloudflare-radar' &&
+				definition.endpointId.value === 'radar-domain-rank'
+			) {
+				// Issue #25 — macro-context (Cloudflare Radar) ingest. The job's
+				// systemParams must carry `monitoredDomainId` (set by AddMonitored
+				// Domain via auto-schedule on add). Missing-id case logs warn +
+				// skips, mirroring the other providers.
+				const cfParams = resolvedParams as { monitoredDomainId?: string };
+				if (!cfParams.monitoredDomainId) {
+					runLog.warn({}, 'radar-domain-rank job missing monitoredDomainId in systemParams; skipping ingest');
+				} else {
+					const snap = extractRadarSnapshot(fetchResult as DomainRankResponse, this.deps.clock.now());
+					await this.deps.recordRadarRankUseCase.execute({
+						monitoredDomainId: cfParams.monitoredDomainId,
+						observedDate: snap.observedDate,
+						rank: snap.rank,
+						bucket: snap.bucket,
+						categories: snap.categories,
+						rawPayloadId,
 					});
 				}
 			}

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -1,4 +1,5 @@
 import { BingProvider } from '@rankpulse/provider-bing';
+import { CloudflareRadarProvider } from '@rankpulse/provider-cloudflare-radar';
 import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
@@ -18,5 +19,6 @@ export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): P
 	registry.register(new WikipediaProvider());
 	registry.register(new PageSpeedProvider());
 	registry.register(new BingProvider());
+	registry.register(new CloudflareRadarProvider());
 	return registry;
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -26,6 +26,11 @@
 			"types": "./dist/identity-access/index.d.ts",
 			"default": "./dist/identity-access/index.js"
 		},
+		"./macro-context": {
+			"development": "./src/macro-context/index.ts",
+			"types": "./dist/macro-context/index.d.ts",
+			"default": "./dist/macro-context/index.js"
+		},
 		"./project-management": {
 			"development": "./src/project-management/index.ts",
 			"types": "./dist/project-management/index.d.ts",

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,6 +1,7 @@
 export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
+export * as MacroContext from './macro-context/index.js';
 export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';

--- a/packages/application/src/macro-context/index.ts
+++ b/packages/application/src/macro-context/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/add-monitored-domain.use-case.js';
+export * from './use-cases/query-radar-history.use-case.js';
+export * from './use-cases/record-radar-rank.use-case.js';
+export * from './use-cases/remove-monitored-domain.use-case.js';

--- a/packages/application/src/macro-context/use-cases/add-monitored-domain.use-case.ts
+++ b/packages/application/src/macro-context/use-cases/add-monitored-domain.use-case.ts
@@ -1,0 +1,50 @@
+import {
+	type IdentityAccess,
+	MacroContext,
+	type ProjectManagement,
+	type SharedKernel,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface AddMonitoredDomainCommand {
+	organizationId: string;
+	projectId: string;
+	domain: string;
+	credentialId?: string | null;
+}
+
+export interface AddMonitoredDomainResult {
+	monitoredDomainId: string;
+}
+
+export class AddMonitoredDomainUseCase {
+	constructor(
+		private readonly domains: MacroContext.MonitoredDomainRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: AddMonitoredDomainCommand): Promise<AddMonitoredDomainResult> {
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+		// Canonicalise via the VO so the lookup matches the row we'd write.
+		const canonical = MacroContext.DomainName.create(cmd.domain);
+		const existing = await this.domains.findByProjectAndDomain(projectId, canonical.value);
+		if (existing?.isActive()) {
+			throw new ConflictError(`Domain ${canonical.value} is already monitored for this project`);
+		}
+
+		const id = this.ids.generate() as MacroContext.MonitoredDomainId;
+		const md = MacroContext.MonitoredDomain.add({
+			id,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			domain: canonical.value,
+			credentialId: cmd.credentialId ?? null,
+			now: this.clock.now(),
+		});
+		await this.domains.save(md);
+		await this.events.publish(md.pullEvents());
+		return { monitoredDomainId: id };
+	}
+}

--- a/packages/application/src/macro-context/use-cases/query-radar-history.use-case.ts
+++ b/packages/application/src/macro-context/use-cases/query-radar-history.use-case.ts
@@ -1,0 +1,34 @@
+import type { MacroContext } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryRadarHistoryCommand {
+	monitoredDomainId: string;
+	from: string;
+	to: string;
+}
+
+export interface RadarHistoryView {
+	observedDate: string;
+	rank: number | null;
+	bucket: string | null;
+	categories: Record<string, number>;
+}
+
+export class QueryRadarHistoryUseCase {
+	constructor(
+		private readonly domains: MacroContext.MonitoredDomainRepository,
+		private readonly snapshots: MacroContext.RadarRankSnapshotRepository,
+	) {}
+
+	async execute(cmd: QueryRadarHistoryCommand): Promise<readonly RadarHistoryView[]> {
+		const md = await this.domains.findById(cmd.monitoredDomainId as MacroContext.MonitoredDomainId);
+		if (!md) throw new NotFoundError(`MonitoredDomain ${cmd.monitoredDomainId} not found`);
+		const rows = await this.snapshots.listForDomain(md.id, { from: cmd.from, to: cmd.to });
+		return rows.map((r) => ({
+			observedDate: r.observedDate,
+			rank: r.rank.rank,
+			bucket: r.rank.bucket,
+			categories: { ...r.rank.categories },
+		}));
+	}
+}

--- a/packages/application/src/macro-context/use-cases/record-radar-rank.use-case.spec.ts
+++ b/packages/application/src/macro-context/use-cases/record-radar-rank.use-case.spec.ts
@@ -1,0 +1,124 @@
+import type { IdentityAccess, MacroContext, ProjectManagement } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AddMonitoredDomainUseCase } from './add-monitored-domain.use-case.js';
+import { RecordRadarRankUseCase } from './record-radar-rank.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryDomainRepo implements MacroContext.MonitoredDomainRepository {
+	readonly store = new Map<string, MacroContext.MonitoredDomain>();
+	readonly byTuple = new Map<string, MacroContext.MonitoredDomain>();
+	async save(md: MacroContext.MonitoredDomain): Promise<void> {
+		this.store.set(md.id, md);
+		this.byTuple.set(`${md.projectId}|${md.domain.value}`, md);
+	}
+	async findById(id: MacroContext.MonitoredDomainId): Promise<MacroContext.MonitoredDomain | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndDomain(
+		projectId: ProjectManagement.ProjectId,
+		domain: string,
+	): Promise<MacroContext.MonitoredDomain | null> {
+		return this.byTuple.get(`${projectId}|${domain}`) ?? null;
+	}
+	async listForProject(): Promise<readonly MacroContext.MonitoredDomain[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly MacroContext.MonitoredDomain[]> {
+		return [];
+	}
+}
+
+class InMemorySnapshotRepo implements MacroContext.RadarRankSnapshotRepository {
+	readonly store = new Map<string, MacroContext.RadarRankSnapshot>();
+	async save(snap: MacroContext.RadarRankSnapshot): Promise<{ inserted: boolean }> {
+		const k = `${snap.monitoredDomainId}|${snap.observedDate}`;
+		if (this.store.has(k)) return { inserted: false };
+		this.store.set(k, snap);
+		return { inserted: true };
+	}
+	async listForDomain(): Promise<readonly MacroContext.RadarRankSnapshot[]> {
+		return [...this.store.values()];
+	}
+}
+
+describe('RecordRadarRankUseCase', () => {
+	let domainRepo: InMemoryDomainRepo;
+	let snapshotRepo: InMemorySnapshotRepo;
+	let events: RecordingEventPublisher;
+	let monitoredDomainId: string;
+
+	beforeEach(async () => {
+		domainRepo = new InMemoryDomainRepo();
+		snapshotRepo = new InMemorySnapshotRepo();
+		events = new RecordingEventPublisher();
+		const adder = new AddMonitoredDomainUseCase(
+			domainRepo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(['md-1' as Uuid]),
+			events,
+		);
+		const result = await adder.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			domain: 'example.com',
+		});
+		monitoredDomainId = result.monitoredDomainId;
+		events.clear();
+	});
+
+	const baseCommand = (overrides: Partial<{ rank: number | null; observedDate: string }> = {}) => ({
+		monitoredDomainId,
+		observedDate: overrides.observedDate ?? '2026-05-01',
+		// Use `'rank' in overrides` rather than `??` so an explicit `rank: null`
+		// override is preserved instead of being coerced to the default.
+		rank: 'rank' in overrides ? (overrides.rank as number | null) : 142,
+		bucket: '200',
+		categories: { Technology: 8 },
+		rawPayloadId: null,
+	});
+
+	const buildUseCase = () =>
+		new RecordRadarRankUseCase(domainRepo, snapshotRepo, events, new FakeClock('2026-05-04T11:00:00Z'));
+
+	it('persists the snapshot and publishes RadarRankRecorded on first insert', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute(baseCommand());
+		expect(result.inserted).toBe(true);
+		expect(snapshotRepo.store.size).toBe(1);
+		expect(events.publishedTypes()).toContain('RadarRankRecorded');
+	});
+
+	it('does NOT publish event on idempotent re-fetch (same observedDate)', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute(baseCommand());
+		events.clear();
+		const second = await useCase.execute(baseCommand());
+		expect(second.inserted).toBe(false);
+		expect(events.published()).toEqual([]);
+	});
+
+	it('persists rank: null for an unranked long-tail domain', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute(baseCommand({ rank: null }));
+		const [stored] = snapshotRepo.store.values();
+		expect(stored?.rank.rank).toBeNull();
+	});
+
+	it('throws NotFoundError when the monitored domain does not exist', async () => {
+		const useCase = buildUseCase();
+		await expect(useCase.execute({ ...baseCommand(), monitoredDomainId: 'missing' })).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+
+	it('rejects negative or non-integer ranks at the aggregate boundary', async () => {
+		const useCase = buildUseCase();
+		await expect(useCase.execute({ ...baseCommand(), rank: -5 })).rejects.toThrow();
+		await expect(useCase.execute({ ...baseCommand(), rank: 1.5 })).rejects.toThrow();
+		expect(snapshotRepo.store.size).toBe(0);
+	});
+});

--- a/packages/application/src/macro-context/use-cases/record-radar-rank.use-case.ts
+++ b/packages/application/src/macro-context/use-cases/record-radar-rank.use-case.ts
@@ -1,0 +1,65 @@
+import { MacroContext, type SharedKernel } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface RecordRadarRankCommand {
+	monitoredDomainId: string;
+	observedDate: string;
+	rank: number | null;
+	bucket: string | null;
+	categories: Record<string, number>;
+	rawPayloadId: string | null;
+}
+
+export interface RecordRadarRankResult {
+	inserted: boolean;
+}
+
+/**
+ * Persist a single Cloudflare Radar rank snapshot for a monitored domain.
+ * Mirrors the PageSpeed `record` shape (one snapshot per call) — the
+ * monthly cron schedules one job per monitored domain.
+ *
+ * Returns `inserted` so the caller (worker) only emits the
+ * `RadarRankRecorded` event on the first write, never on idempotent
+ * re-fetches of the same `(domain, observedDate)` pair.
+ */
+export class RecordRadarRankUseCase {
+	constructor(
+		private readonly domains: MacroContext.MonitoredDomainRepository,
+		private readonly snapshots: MacroContext.RadarRankSnapshotRepository,
+		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: RecordRadarRankCommand): Promise<RecordRadarRankResult> {
+		const md = await this.domains.findById(cmd.monitoredDomainId as MacroContext.MonitoredDomainId);
+		if (!md) throw new NotFoundError(`MonitoredDomain ${cmd.monitoredDomainId} not found`);
+		if (!md.isActive()) return { inserted: false };
+
+		const snapshot = MacroContext.RadarRankSnapshot.record({
+			monitoredDomainId: md.id,
+			projectId: md.projectId,
+			observedDate: cmd.observedDate,
+			rank: MacroContext.RadarRank.create({
+				rank: cmd.rank,
+				bucket: cmd.bucket,
+				categories: cmd.categories,
+			}),
+			rawPayloadId: cmd.rawPayloadId,
+		});
+
+		const { inserted } = await this.snapshots.save(snapshot);
+		if (inserted) {
+			await this.events.publish([
+				new MacroContext.RadarRankRecorded({
+					monitoredDomainId: md.id,
+					projectId: md.projectId,
+					observedDate: cmd.observedDate,
+					rank: cmd.rank,
+					occurredAt: this.clock.now(),
+				}),
+			]);
+		}
+		return { inserted };
+	}
+}

--- a/packages/application/src/macro-context/use-cases/remove-monitored-domain.use-case.ts
+++ b/packages/application/src/macro-context/use-cases/remove-monitored-domain.use-case.ts
@@ -1,0 +1,21 @@
+import type { MacroContext } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface RemoveMonitoredDomainCommand {
+	monitoredDomainId: string;
+}
+
+export class RemoveMonitoredDomainUseCase {
+	constructor(
+		private readonly domains: MacroContext.MonitoredDomainRepository,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: RemoveMonitoredDomainCommand): Promise<void> {
+		const md = await this.domains.findById(cmd.monitoredDomainId as MacroContext.MonitoredDomainId);
+		if (!md) throw new NotFoundError(`MonitoredDomain ${cmd.monitoredDomainId} not found`);
+		if (!md.isActive()) return; // idempotent
+		md.remove(this.clock.now());
+		await this.domains.save(md);
+	}
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,7 @@
 export * as BingWebmasterInsightsContracts from './bing-webmaster-insights/index.js';
 export * as EntityAwarenessContracts from './entity-awareness/index.js';
 export * as IdentityAccessContracts from './identity-access/index.js';
+export * as MacroContextContracts from './macro-context/index.js';
 export * as ProjectManagementContracts from './project-management/index.js';
 export * as ProviderConnectivityContracts from './provider-connectivity/index.js';
 export * as RankTrackingContracts from './rank-tracking/index.js';

--- a/packages/contracts/src/macro-context/index.ts
+++ b/packages/contracts/src/macro-context/index.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+const Domain = z
+	.string()
+	.regex(
+		/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/,
+		'must be a bare domain (no scheme, no path)',
+	);
+
+export const AddMonitoredDomainRequest = z.object({
+	domain: Domain,
+	credentialId: z.string().uuid().nullable().optional(),
+});
+export type AddMonitoredDomainRequest = z.infer<typeof AddMonitoredDomainRequest>;
+
+export const MonitoredDomainDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	domain: z.string(),
+	credentialId: z.string().uuid().nullable(),
+	addedAt: z.string().datetime(),
+	removedAt: z.string().datetime().nullable(),
+	isActive: z.boolean(),
+});
+export type MonitoredDomainDto = z.infer<typeof MonitoredDomainDto>;
+
+const DateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+export const RadarHistoryQuery = z.object({
+	from: DateString,
+	to: DateString,
+});
+export type RadarHistoryQuery = z.infer<typeof RadarHistoryQuery>;
+
+export const RadarHistoryRowDto = z.object({
+	observedDate: z.string(),
+	rank: z.number().int().nullable(),
+	bucket: z.string().nullable(),
+	categories: z.record(z.string(), z.number().int()),
+});
+export type RadarHistoryRowDto = z.infer<typeof RadarHistoryRowDto>;

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -26,6 +26,11 @@
 			"types": "./dist/identity-access/index.d.ts",
 			"default": "./dist/identity-access/index.js"
 		},
+		"./macro-context": {
+			"development": "./src/macro-context/index.ts",
+			"types": "./dist/macro-context/index.d.ts",
+			"default": "./dist/macro-context/index.js"
+		},
 		"./project-management": {
 			"development": "./src/project-management/index.ts",
 			"types": "./dist/project-management/index.d.ts",

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,6 +1,7 @@
 export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
 export * as IdentityAccess from './identity-access/index.js';
+export * as MacroContext from './macro-context/index.js';
 export * as ProjectManagement from './project-management/index.js';
 export * as ProviderConnectivity from './provider-connectivity/index.js';
 export * as RankTracking from './rank-tracking/index.js';

--- a/packages/domain/src/macro-context/entities/monitored-domain.ts
+++ b/packages/domain/src/macro-context/entities/monitored-domain.ts
@@ -1,0 +1,96 @@
+import { ConflictError } from '@rankpulse/shared';
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { MonitoredDomainAdded } from '../events/monitored-domain-added.js';
+import { DomainName } from '../value-objects/domain-name.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+
+export interface MonitoredDomainProps {
+	id: MonitoredDomainId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	domain: DomainName;
+	credentialId: string | null;
+	addedAt: Date;
+	removedAt: Date | null;
+}
+
+/**
+ * A bare domain whose macro-context (Cloudflare Radar rank, in v1) is
+ * snapshotted monthly. The aggregate is the parent of the snapshot
+ * time-series, but snapshots themselves are value-like rows that don't
+ * fan-out events per-row (mirrors GSC / GA4 / Bing aggregations).
+ */
+export class MonitoredDomain extends AggregateRoot {
+	private constructor(private props: MonitoredDomainProps) {
+		super();
+	}
+
+	static add(input: {
+		id: MonitoredDomainId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		domain: string;
+		credentialId: string | null;
+		now: Date;
+	}): MonitoredDomain {
+		const domain = DomainName.create(input.domain);
+		const md = new MonitoredDomain({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			domain,
+			credentialId: input.credentialId,
+			addedAt: input.now,
+			removedAt: null,
+		});
+		md.record(
+			new MonitoredDomainAdded({
+				monitoredDomainId: input.id,
+				projectId: input.projectId,
+				organizationId: input.organizationId,
+				domain: domain.value,
+				occurredAt: input.now,
+			}),
+		);
+		return md;
+	}
+
+	static rehydrate(props: MonitoredDomainProps): MonitoredDomain {
+		return new MonitoredDomain(props);
+	}
+
+	remove(now: Date): void {
+		if (this.props.removedAt) {
+			throw new ConflictError('MonitoredDomain is already removed');
+		}
+		this.props = { ...this.props, removedAt: now };
+	}
+
+	isActive(): boolean {
+		return this.props.removedAt === null;
+	}
+
+	get id(): MonitoredDomainId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get domain(): DomainName {
+		return this.props.domain;
+	}
+	get credentialId(): string | null {
+		return this.props.credentialId;
+	}
+	get addedAt(): Date {
+		return this.props.addedAt;
+	}
+	get removedAt(): Date | null {
+		return this.props.removedAt;
+	}
+}

--- a/packages/domain/src/macro-context/entities/radar-rank-snapshot.ts
+++ b/packages/domain/src/macro-context/entities/radar-rank-snapshot.ts
@@ -1,0 +1,48 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+import type { RadarRank } from '../value-objects/radar-rank.js';
+
+export interface RadarRankSnapshotProps {
+	monitoredDomainId: MonitoredDomainId;
+	projectId: ProjectId;
+	observedDate: string; // YYYY-MM-DD
+	rank: RadarRank;
+	rawPayloadId: string | null;
+}
+
+/**
+ * One immutable Cloudflare Radar rank snapshot at calendar-day granularity.
+ * Value-like factory; the record use case publishes one summary event per
+ * call, never per row (we typically write 1-N rows per fetch — one per
+ * monitored domain).
+ */
+export class RadarRankSnapshot extends AggregateRoot {
+	private constructor(private readonly props: RadarRankSnapshotProps) {
+		super();
+	}
+
+	static record(input: RadarRankSnapshotProps): RadarRankSnapshot {
+		return new RadarRankSnapshot(input);
+	}
+
+	static rehydrate(props: RadarRankSnapshotProps): RadarRankSnapshot {
+		return new RadarRankSnapshot(props);
+	}
+
+	get monitoredDomainId(): MonitoredDomainId {
+		return this.props.monitoredDomainId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedDate(): string {
+		return this.props.observedDate;
+	}
+	get rank(): RadarRank {
+		return this.props.rank;
+	}
+	get rawPayloadId(): string | null {
+		return this.props.rawPayloadId;
+	}
+}

--- a/packages/domain/src/macro-context/events/monitored-domain-added.ts
+++ b/packages/domain/src/macro-context/events/monitored-domain-added.ts
@@ -1,0 +1,27 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+
+export class MonitoredDomainAdded implements DomainEvent {
+	readonly type = 'MonitoredDomainAdded';
+	readonly monitoredDomainId: MonitoredDomainId;
+	readonly projectId: ProjectId;
+	readonly organizationId: OrganizationId;
+	readonly domain: string;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		monitoredDomainId: MonitoredDomainId;
+		projectId: ProjectId;
+		organizationId: OrganizationId;
+		domain: string;
+		occurredAt: Date;
+	}) {
+		this.monitoredDomainId = props.monitoredDomainId;
+		this.projectId = props.projectId;
+		this.organizationId = props.organizationId;
+		this.domain = props.domain;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/macro-context/events/radar-rank-recorded.ts
+++ b/packages/domain/src/macro-context/events/radar-rank-recorded.ts
@@ -1,0 +1,26 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+
+export class RadarRankRecorded implements DomainEvent {
+	readonly type = 'RadarRankRecorded';
+	readonly monitoredDomainId: MonitoredDomainId;
+	readonly projectId: ProjectId;
+	readonly observedDate: string;
+	readonly rank: number | null;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		monitoredDomainId: MonitoredDomainId;
+		projectId: ProjectId;
+		observedDate: string;
+		rank: number | null;
+		occurredAt: Date;
+	}) {
+		this.monitoredDomainId = props.monitoredDomainId;
+		this.projectId = props.projectId;
+		this.observedDate = props.observedDate;
+		this.rank = props.rank;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/macro-context/index.ts
+++ b/packages/domain/src/macro-context/index.ts
@@ -1,0 +1,13 @@
+// Entities / aggregates
+export * from './entities/monitored-domain.js';
+export * from './entities/radar-rank-snapshot.js';
+// Events
+export * from './events/monitored-domain-added.js';
+export * from './events/radar-rank-recorded.js';
+// Ports
+export * from './ports/monitored-domain-repository.js';
+export * from './ports/radar-rank-snapshot-repository.js';
+// Value objects
+export * from './value-objects/domain-name.js';
+export * from './value-objects/identifiers.js';
+export * from './value-objects/radar-rank.js';

--- a/packages/domain/src/macro-context/ports/monitored-domain-repository.ts
+++ b/packages/domain/src/macro-context/ports/monitored-domain-repository.ts
@@ -1,0 +1,12 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { MonitoredDomain } from '../entities/monitored-domain.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+
+export interface MonitoredDomainRepository {
+	save(monitoredDomain: MonitoredDomain): Promise<void>;
+	findById(id: MonitoredDomainId): Promise<MonitoredDomain | null>;
+	findByProjectAndDomain(projectId: ProjectId, domain: string): Promise<MonitoredDomain | null>;
+	listForProject(projectId: ProjectId): Promise<readonly MonitoredDomain[]>;
+	listForOrganization(orgId: OrganizationId): Promise<readonly MonitoredDomain[]>;
+}

--- a/packages/domain/src/macro-context/ports/radar-rank-snapshot-repository.ts
+++ b/packages/domain/src/macro-context/ports/radar-rank-snapshot-repository.ts
@@ -1,0 +1,19 @@
+import type { RadarRankSnapshot } from '../entities/radar-rank-snapshot.js';
+import type { MonitoredDomainId } from '../value-objects/identifiers.js';
+
+export interface RadarRankSnapshotQuery {
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface RadarRankSnapshotRepository {
+	/**
+	 * Idempotent on the natural key (monitored_domain_id, observed_date).
+	 * Returns inserted count so the use case can publish accurate metrics.
+	 */
+	save(snapshot: RadarRankSnapshot): Promise<{ inserted: boolean }>;
+	listForDomain(
+		monitoredDomainId: MonitoredDomainId,
+		query: RadarRankSnapshotQuery,
+	): Promise<readonly RadarRankSnapshot[]>;
+}

--- a/packages/domain/src/macro-context/value-objects/domain-name.ts
+++ b/packages/domain/src/macro-context/value-objects/domain-name.ts
@@ -1,0 +1,25 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+const DOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+/**
+ * Bare DNS domain name, lowercased and stripped of `www.` for canonical
+ * comparison. We reject schemes/paths/ports — Cloudflare Radar's domain
+ * ranking is about the registrable apex (or a labelled subdomain), and
+ * other macro-context APIs we'll add later use the same shape.
+ */
+export class DomainName {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): DomainName {
+		const trimmed = raw.trim().toLowerCase();
+		if (trimmed.length === 0) throw new InvalidInputError('domain cannot be empty');
+		// Strip a leading "www." for canonicalisation. Cloudflare Radar
+		// returns the same rank for `example.com` and `www.example.com`.
+		const stripped = trimmed.startsWith('www.') ? trimmed.slice(4) : trimmed;
+		if (!DOMAIN_REGEX.test(stripped)) {
+			throw new InvalidInputError(`"${raw}" is not a valid bare domain (no scheme, no path, no port)`);
+		}
+		return new DomainName(stripped);
+	}
+}

--- a/packages/domain/src/macro-context/value-objects/identifiers.ts
+++ b/packages/domain/src/macro-context/value-objects/identifiers.ts
@@ -1,0 +1,3 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type MonitoredDomainId = Uuid & { readonly __kind: 'MonitoredDomainId' };

--- a/packages/domain/src/macro-context/value-objects/radar-rank.ts
+++ b/packages/domain/src/macro-context/value-objects/radar-rank.ts
@@ -1,0 +1,35 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Cloudflare Radar's domain rank — a positive integer position in the
+ * global popularity list. Long-tail / unranked domains return null. We
+ * reject negative or non-integer values defensively, even though the
+ * provider should never emit them.
+ */
+export class RadarRank {
+	private constructor(
+		public readonly rank: number | null,
+		public readonly bucket: string | null,
+		public readonly categories: Readonly<Record<string, number>>,
+	) {}
+
+	static create(input: {
+		rank: number | null;
+		bucket: string | null;
+		categories: Record<string, number>;
+	}): RadarRank {
+		if (input.rank !== null) {
+			if (!Number.isFinite(input.rank) || input.rank < 1 || !Number.isInteger(input.rank)) {
+				throw new InvalidInputError('rank must be a positive integer when present');
+			}
+		}
+		const cats: Record<string, number> = {};
+		for (const [k, v] of Object.entries(input.categories ?? {})) {
+			if (!Number.isFinite(v) || v < 1 || !Number.isInteger(v)) {
+				throw new InvalidInputError(`category rank "${k}" must be a positive integer`);
+			}
+			cats[k] = v;
+		}
+		return new RadarRank(input.rank, input.bucket, cats);
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -7,6 +7,8 @@ export { DrizzleApiTokenRepository } from './repositories/identity-access/api-to
 export { DrizzleMembershipRepository } from './repositories/identity-access/membership.repository.js';
 export { DrizzleOrganizationRepository } from './repositories/identity-access/organization.repository.js';
 export { DrizzleUserRepository } from './repositories/identity-access/user.repository.js';
+export { DrizzleMonitoredDomainRepository } from './repositories/macro-context/monitored-domain.repository.js';
+export { DrizzleRadarRankSnapshotRepository } from './repositories/macro-context/radar-rank-snapshot.repository.js';
 export { DrizzleCompetitorRepository } from './repositories/project-management/competitor.repository.js';
 export { DrizzleCompetitorSuggestionRepository } from './repositories/project-management/competitor-suggestion.repository.js';
 export { DrizzleKeywordListRepository } from './repositories/project-management/keyword-list.repository.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0009_harsh_mattie_franklin.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0009_harsh_mattie_franklin.sql
@@ -1,0 +1,47 @@
+-- Issue #25 — Cloudflare Radar (macro-context) tables. Idempotent with
+-- IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
+
+CREATE TABLE IF NOT EXISTS "monitored_domains" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"domain" text NOT NULL,
+	"credential_id" uuid,
+	"added_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"removed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "radar_rank_snapshots" (
+	"monitored_domain_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_date" text NOT NULL,
+	"rank" integer,
+	"bucket" text,
+	"categories" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"raw_payload_id" uuid,
+	CONSTRAINT "radar_rank_snapshots_monitored_domain_id_observed_date_pk" PRIMARY KEY("monitored_domain_id","observed_date")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "monitored_domains" ADD CONSTRAINT "monitored_domains_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "monitored_domains" ADD CONSTRAINT "monitored_domains_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "monitored_domains" ADD CONSTRAINT "monitored_domains_credential_id_provider_credentials_id_fk" FOREIGN KEY ("credential_id") REFERENCES "public"."provider_credentials"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "radar_rank_snapshots" ADD CONSTRAINT "radar_rank_snapshots_monitored_domain_id_monitored_domains_id_fk" FOREIGN KEY ("monitored_domain_id") REFERENCES "public"."monitored_domains"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "monitored_domains_project_domain_unique" ON "monitored_domains" USING btree ("project_id","domain");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "monitored_domains_project_idx" ON "monitored_domains" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "radar_rank_snapshots_project_idx" ON "radar_rank_snapshots" USING btree ("project_id","observed_date");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0009_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,3330 @@
+{
+	"id": "2179c398-b677-4c12-8882-6af39dead0a0",
+	"prevId": "fa777cb8-deaa-4ed8-adda-0cda752cc0b0",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_properties": {
+			"name": "bing_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_properties_project_site_unique": {
+					"name": "bing_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"bing_properties_project_idx": {
+					"name": "bing_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_properties_organization_id_organizations_id_fk": {
+					"name": "bing_properties_organization_id_organizations_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_project_id_projects_id_fk": {
+					"name": "bing_properties_project_id_projects_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_credential_id_provider_credentials_id_fk": {
+					"name": "bing_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_traffic_observations": {
+			"name": "bing_traffic_observations",
+			"schema": "",
+			"columns": {
+				"bing_property_id": {
+					"name": "bing_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_click_position": {
+					"name": "avg_click_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_impression_position": {
+					"name": "avg_impression_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_traffic_observations_project_idx": {
+					"name": "bing_traffic_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_traffic_observations_bing_property_id_bing_properties_id_fk": {
+					"name": "bing_traffic_observations_bing_property_id_bing_properties_id_fk",
+					"tableFrom": "bing_traffic_observations",
+					"tableTo": "bing_properties",
+					"columnsFrom": ["bing_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"bing_traffic_observations_bing_property_id_observed_date_pk": {
+					"name": "bing_traffic_observations_bing_property_id_observed_date_pk",
+					"columns": ["bing_property_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_daily_metrics": {
+			"name": "ga4_daily_metrics",
+			"schema": "",
+			"columns": {
+				"ga4_property_id": {
+					"name": "ga4_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions_hash": {
+					"name": "dimensions_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions": {
+					"name": "dimensions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metrics": {
+					"name": "metrics",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_daily_metrics_project_idx": {
+					"name": "ga4_daily_metrics_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk": {
+					"name": "ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk",
+					"tableFrom": "ga4_daily_metrics",
+					"tableTo": "ga4_properties",
+					"columnsFrom": ["ga4_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk": {
+					"name": "ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk",
+					"columns": ["ga4_property_id", "observed_date", "dimensions_hash"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_properties": {
+			"name": "ga4_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_handle": {
+					"name": "property_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_properties_project_handle_unique": {
+					"name": "ga4_properties_project_handle_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "property_handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ga4_properties_project_idx": {
+					"name": "ga4_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_properties_organization_id_organizations_id_fk": {
+					"name": "ga4_properties_organization_id_organizations_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_project_id_projects_id_fk": {
+					"name": "ga4_properties_project_id_projects_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_credential_id_provider_credentials_id_fk": {
+					"name": "ga4_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.monitored_domains": {
+			"name": "monitored_domains",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"monitored_domains_project_domain_unique": {
+					"name": "monitored_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"monitored_domains_project_idx": {
+					"name": "monitored_domains_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"monitored_domains_organization_id_organizations_id_fk": {
+					"name": "monitored_domains_organization_id_organizations_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"monitored_domains_project_id_projects_id_fk": {
+					"name": "monitored_domains_project_id_projects_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"monitored_domains_credential_id_provider_credentials_id_fk": {
+					"name": "monitored_domains_credential_id_provider_credentials_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_speed_snapshots": {
+			"name": "page_speed_snapshots",
+			"schema": "",
+			"columns": {
+				"tracked_page_id": {
+					"name": "tracked_page_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lcp_ms": {
+					"name": "lcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"inp_ms": {
+					"name": "inp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cls": {
+					"name": "cls",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fcp_ms": {
+					"name": "fcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ttfb_ms": {
+					"name": "ttfb_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"performance_score": {
+					"name": "performance_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seo_score": {
+					"name": "seo_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessibility_score": {
+					"name": "accessibility_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"best_practices_score": {
+					"name": "best_practices_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"page_speed_snapshots_project_idx": {
+					"name": "page_speed_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_speed_snapshots_tracked_page_id_tracked_pages_id_fk": {
+					"name": "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk",
+					"tableFrom": "page_speed_snapshots",
+					"tableTo": "tracked_pages",
+					"columnsFrom": ["tracked_page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"page_speed_snapshots_tracked_page_id_observed_at_pk": {
+					"name": "page_speed_snapshots_tracked_page_id_observed_at_pk",
+					"columns": ["tracked_page_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.radar_rank_snapshots": {
+			"name": "radar_rank_snapshots",
+			"schema": "",
+			"columns": {
+				"monitored_domain_id": {
+					"name": "monitored_domain_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"categories": {
+					"name": "categories",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"radar_rank_snapshots_project_idx": {
+					"name": "radar_rank_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"radar_rank_snapshots_monitored_domain_id_monitored_domains_id_fk": {
+					"name": "radar_rank_snapshots_monitored_domain_id_monitored_domains_id_fk",
+					"tableFrom": "radar_rank_snapshots",
+					"tableTo": "monitored_domains",
+					"columnsFrom": ["monitored_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"radar_rank_snapshots_monitored_domain_id_observed_date_pk": {
+					"name": "radar_rank_snapshots_monitored_domain_id_observed_date_pk",
+					"columns": ["monitored_domain_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_pages": {
+			"name": "tracked_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"strategy": {
+					"name": "strategy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_pages_project_url_strategy_unique": {
+					"name": "tracked_pages_project_url_strategy_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "strategy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_pages_project_idx": {
+					"name": "tracked_pages_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_pages_organization_id_organizations_id_fk": {
+					"name": "tracked_pages_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_pages_project_id_projects_id_fk": {
+					"name": "tracked_pages_project_id_projects_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1778017481538,
 			"tag": "0008_freezing_black_knight",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1778052907781,
+			"tag": "0009_harsh_mattie_franklin",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/macro-context/monitored-domain.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/macro-context/monitored-domain.repository.ts
@@ -1,0 +1,102 @@
+import { type IdentityAccess, MacroContext, type ProjectManagement } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { monitoredDomains } from '../../schema/index.js';
+
+const UNIQUE_TUPLE_CONSTRAINT = 'monitored_domains_project_domain_unique';
+
+const isUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_TUPLE_CONSTRAINT;
+};
+
+export class DrizzleMonitoredDomainRepository implements MacroContext.MonitoredDomainRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(md: MacroContext.MonitoredDomain): Promise<void> {
+		try {
+			await this.db
+				.insert(monitoredDomains)
+				.values({
+					id: md.id,
+					organizationId: md.organizationId,
+					projectId: md.projectId,
+					domain: md.domain.value,
+					credentialId: md.credentialId,
+					addedAt: md.addedAt,
+					removedAt: md.removedAt,
+				})
+				.onConflictDoUpdate({
+					target: monitoredDomains.id,
+					set: {
+						domain: md.domain.value,
+						credentialId: md.credentialId,
+						removedAt: md.removedAt,
+					},
+				});
+		} catch (err) {
+			if (isUniqueViolation(err)) {
+				throw new ConflictError(
+					`Monitored domain "${md.domain.value}" is already registered for project ${md.projectId}`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(id: MacroContext.MonitoredDomainId): Promise<MacroContext.MonitoredDomain | null> {
+		const [row] = await this.db.select().from(monitoredDomains).where(eq(monitoredDomains.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByProjectAndDomain(
+		projectId: ProjectManagement.ProjectId,
+		domain: string,
+	): Promise<MacroContext.MonitoredDomain | null> {
+		const canonical = MacroContext.DomainName.create(domain);
+		const [row] = await this.db
+			.select()
+			.from(monitoredDomains)
+			.where(and(eq(monitoredDomains.projectId, projectId), eq(monitoredDomains.domain, canonical.value)))
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly MacroContext.MonitoredDomain[]> {
+		const rows = await this.db
+			.select()
+			.from(monitoredDomains)
+			.where(eq(monitoredDomains.projectId, projectId))
+			.orderBy(desc(monitoredDomains.addedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listForOrganization(
+		orgId: IdentityAccess.OrganizationId,
+	): Promise<readonly MacroContext.MonitoredDomain[]> {
+		const rows = await this.db
+			.select()
+			.from(monitoredDomains)
+			.where(eq(monitoredDomains.organizationId, orgId))
+			.orderBy(desc(monitoredDomains.addedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof monitoredDomains.$inferSelect): MacroContext.MonitoredDomain {
+		return MacroContext.MonitoredDomain.rehydrate({
+			id: row.id as MacroContext.MonitoredDomainId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			domain: MacroContext.DomainName.create(row.domain),
+			credentialId: row.credentialId,
+			addedAt: row.addedAt,
+			removedAt: row.removedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/macro-context/radar-rank-snapshot.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/macro-context/radar-rank-snapshot.repository.ts
@@ -1,0 +1,56 @@
+import { MacroContext, type ProjectManagement } from '@rankpulse/domain';
+import { and, between, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { radarRankSnapshots } from '../../schema/index.js';
+
+export class DrizzleRadarRankSnapshotRepository implements MacroContext.RadarRankSnapshotRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(snapshot: MacroContext.RadarRankSnapshot): Promise<{ inserted: boolean }> {
+		const result = await this.db
+			.insert(radarRankSnapshots)
+			.values({
+				monitoredDomainId: snapshot.monitoredDomainId,
+				projectId: snapshot.projectId,
+				observedDate: snapshot.observedDate,
+				rank: snapshot.rank.rank,
+				bucket: snapshot.rank.bucket,
+				categories: { ...snapshot.rank.categories },
+				rawPayloadId: snapshot.rawPayloadId,
+			})
+			.onConflictDoNothing({
+				target: [radarRankSnapshots.monitoredDomainId, radarRankSnapshots.observedDate],
+			})
+			.returning({ monitoredDomainId: radarRankSnapshots.monitoredDomainId });
+		return { inserted: result.length > 0 };
+	}
+
+	async listForDomain(
+		monitoredDomainId: MacroContext.MonitoredDomainId,
+		query: MacroContext.RadarRankSnapshotQuery,
+	): Promise<readonly MacroContext.RadarRankSnapshot[]> {
+		const rows = await this.db
+			.select()
+			.from(radarRankSnapshots)
+			.where(
+				and(
+					eq(radarRankSnapshots.monitoredDomainId, monitoredDomainId),
+					between(radarRankSnapshots.observedDate, query.from, query.to),
+				),
+			)
+			.orderBy(radarRankSnapshots.observedDate);
+		return rows.map((r) =>
+			MacroContext.RadarRankSnapshot.rehydrate({
+				monitoredDomainId: r.monitoredDomainId as MacroContext.MonitoredDomainId,
+				projectId: r.projectId as ProjectManagement.ProjectId,
+				observedDate: r.observedDate,
+				rank: MacroContext.RadarRank.create({
+					rank: r.rank,
+					bucket: r.bucket,
+					categories: r.categories ?? {},
+				}),
+				rawPayloadId: r.rawPayloadId,
+			}),
+		);
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -758,3 +758,62 @@ export const bingTrafficObservations = pgTable(
 
 export type BingPropertyRow = typeof bingProperties.$inferSelect;
 export type BingTrafficObservationRow = typeof bingTrafficObservations.$inferSelect;
+
+// ---- macro-context (Cloudflare Radar) ----
+
+/**
+ * Issue #25 — domains whose macro-context (Cloudflare Radar global rank,
+ * for now) is snapshotted monthly. Same shape as the other "linked third-
+ * party identity" tables: a (project, domain) tuple uniqueness, soft-delete
+ * via `removed_at` so historic rank rows stay queryable.
+ */
+export const monitoredDomains = pgTable(
+	'monitored_domains',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		domain: text('domain').notNull(),
+		credentialId: uuid('credential_id').references(() => providerCredentials.id, { onDelete: 'set null' }),
+		addedAt: timestamp('added_at', { withTimezone: true }).notNull().defaultNow(),
+		removedAt: timestamp('removed_at', { withTimezone: true }),
+	},
+	(t) => ({
+		uniqueByProjectDomain: uniqueIndex('monitored_domains_project_domain_unique').on(t.projectId, t.domain),
+		projectIdx: index('monitored_domains_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of Cloudflare Radar rank snapshots. Natural PK
+ * (monitored_domain_id, observed_date) — monthly cron writes one row per
+ * domain per month. `rank` is nullable to honour Radar's "domain not in
+ * the global ranking" outcome (long-tail). Categories are jsonb because
+ * the cardinality is bounded (low single digits) and we never query INTO
+ * the JSON.
+ */
+export const radarRankSnapshots = pgTable(
+	'radar_rank_snapshots',
+	{
+		monitoredDomainId: uuid('monitored_domain_id')
+			.notNull()
+			.references(() => monitoredDomains.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedDate: text('observed_date').notNull(), // YYYY-MM-DD
+		rank: integer('rank'),
+		bucket: text('bucket'),
+		categories: jsonb('categories').notNull().$type<Record<string, number>>().default({}),
+		rawPayloadId: uuid('raw_payload_id'),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.monitoredDomainId, t.observedDate] }),
+		projectIdx: index('radar_rank_snapshots_project_idx').on(t.projectId, t.observedDate),
+	}),
+);
+
+export type MonitoredDomainRow = typeof monitoredDomains.$inferSelect;
+export type RadarRankSnapshotRow = typeof radarRankSnapshots.$inferSelect;

--- a/packages/providers/cloudflare-radar/package.json
+++ b/packages/providers/cloudflare-radar/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rankpulse/provider-cloudflare-radar",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/cloudflare-radar/src/acl/domain-rank-to-snapshot.acl.spec.ts
+++ b/packages/providers/cloudflare-radar/src/acl/domain-rank-to-snapshot.acl.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { DomainRankResponse } from '../endpoints/domain-rank.js';
+import { extractSnapshot } from './domain-rank-to-snapshot.acl.js';
+
+const FALLBACK = new Date('2026-05-04T12:00:00Z');
+
+describe('extractSnapshot (Cloudflare Radar domain-rank)', () => {
+	it('parses rank, categories, bucket and meta.lastUpdated', () => {
+		const response: DomainRankResponse = {
+			success: true,
+			result: {
+				details_0: {
+					rank: 142,
+					domain: 'example.com',
+					categories: [
+						{ name: 'Technology', rank: 8 },
+						{ name: 'Search Engines', rank: 3 },
+					],
+					bucket: '200',
+				},
+				meta: { lastUpdated: '2026-05-01T00:00:00Z' },
+			},
+		};
+		const snap = extractSnapshot(response, FALLBACK);
+		expect(snap.observedDate).toBe('2026-05-01');
+		expect(snap.rank).toBe(142);
+		expect(snap.bucket).toBe('200');
+		expect(snap.categories).toEqual({ Technology: 8, 'Search Engines': 3 });
+	});
+
+	it('surfaces an unranked long-tail domain as rank: null without dropping the snapshot', () => {
+		const response: DomainRankResponse = {
+			success: true,
+			result: {
+				details_0: { domain: 'unknown-blog.example' },
+				meta: { lastUpdated: '2026-05-01T00:00:00Z' },
+			},
+		};
+		const snap = extractSnapshot(response, FALLBACK);
+		expect(snap.rank).toBeNull();
+		expect(snap.categories).toEqual({});
+		expect(snap.bucket).toBeNull();
+	});
+
+	it('falls back to today when meta.lastUpdated is missing', () => {
+		const response: DomainRankResponse = { success: true, result: { details_0: { rank: 1 } } };
+		const snap = extractSnapshot(response, FALLBACK);
+		expect(snap.observedDate).toBe('2026-05-04');
+	});
+
+	it('drops malformed category entries (non-finite rank, missing name)', () => {
+		const response: DomainRankResponse = {
+			success: true,
+			result: {
+				details_0: {
+					rank: 100,
+					categories: [
+						{ name: 'OK', rank: 5 },
+						{ name: 'Broken', rank: Number.NaN },
+						{ rank: 7 }, // missing name
+					],
+				},
+			},
+		};
+		const snap = extractSnapshot(response, FALLBACK);
+		expect(snap.categories).toEqual({ OK: 5 });
+	});
+});

--- a/packages/providers/cloudflare-radar/src/acl/domain-rank-to-snapshot.acl.ts
+++ b/packages/providers/cloudflare-radar/src/acl/domain-rank-to-snapshot.acl.ts
@@ -1,0 +1,42 @@
+import type { DomainRankResponse } from '../endpoints/domain-rank.js';
+
+export interface DomainRankSnapshot {
+	observedDate: string; // YYYY-MM-DD — always the meta.lastUpdated date or today as fallback
+	rank: number | null; // null when Cloudflare has no rank for the domain (long-tail, unranked)
+	categories: Record<string, number>; // category name -> per-category rank
+	bucket: string | null; // e.g. "200" / "200,000" — the order-of-magnitude bucket the domain falls in
+}
+
+/**
+ * Pure ACL: `/radar/ranking/domain/<domain>` payload → a single typed
+ * snapshot row. Long-tail domains return a 200 OK with `rank` undefined
+ * (the domain isn't ranked); we surface that as `rank: null` rather than
+ * dropping the row, because the absence is itself a signal worth tracking.
+ */
+export const extractSnapshot = (response: DomainRankResponse, fallbackToday: Date): DomainRankSnapshot => {
+	const details = response.result?.details_0;
+	const lastUpdated = response.result?.meta?.lastUpdated;
+	const observedDate = parseLastUpdated(lastUpdated, fallbackToday);
+
+	const categories: Record<string, number> = {};
+	for (const c of details?.categories ?? []) {
+		if (typeof c.name === 'string' && typeof c.rank === 'number' && Number.isFinite(c.rank)) {
+			categories[c.name] = c.rank;
+		}
+	}
+
+	return {
+		observedDate,
+		rank: typeof details?.rank === 'number' && Number.isFinite(details.rank) ? details.rank : null,
+		categories,
+		bucket: typeof details?.bucket === 'string' ? details.bucket : null,
+	};
+};
+
+const parseLastUpdated = (raw: string | undefined, fallback: Date): string => {
+	if (typeof raw === 'string' && raw.length > 0) {
+		const d = new Date(raw);
+		if (Number.isFinite(d.getTime())) return d.toISOString().slice(0, 10);
+	}
+	return fallback.toISOString().slice(0, 10);
+};

--- a/packages/providers/cloudflare-radar/src/credential.ts
+++ b/packages/providers/cloudflare-radar/src/credential.ts
@@ -1,0 +1,19 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Cloudflare Radar auth: a single API token (not the legacy API key).
+ * The token must have the `Radar:Read` permission scope. Tokens are 40
+ * alphanumerics including underscore/dash; we validate length+charset
+ * and otherwise pass through opaque.
+ */
+const TOKEN_REGEX = /^[A-Za-z0-9_-]{20,}$/;
+
+export const validateCloudflareToken = (plaintext: string): string => {
+	const trimmed = plaintext.trim();
+	if (!TOKEN_REGEX.test(trimmed)) {
+		throw new InvalidInputError(
+			'Cloudflare API token must be 20+ alphanumeric characters (incl. _ -). Generate one with the Radar:Read scope at dash.cloudflare.com → My Profile → API Tokens',
+		);
+	}
+	return trimmed;
+};

--- a/packages/providers/cloudflare-radar/src/endpoints/domain-rank.ts
+++ b/packages/providers/cloudflare-radar/src/endpoints/domain-rank.ts
@@ -1,0 +1,68 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { CloudflareRadarHttp } from '../http.js';
+
+/**
+ * `/radar/ranking/domain/{domain}` returns Cloudflare's global popularity
+ * ranking for a domain — both the all-categories rank and per-category
+ * splits when available. The `rankingType` query param is required:
+ *   - `POPULAR` (default): traffic-popularity ranking, daily snapshot
+ *   - `TRENDING_RISE` / `TRENDING_STEADY`: trending lists
+ *
+ * We always pull POPULAR for the macro-context use-case ("is our domain
+ * gaining or losing global mindshare?"). Cron is monthly because the
+ * underlying ranking is itself a 30-day rolling aggregation.
+ */
+const DomainRegex =
+	/^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/;
+
+export const DomainRankParams = z.object({
+	domain: z.string().regex(DomainRegex, 'must be a bare domain (no scheme, no path)'),
+	rankingType: z.enum(['POPULAR', 'TRENDING_RISE', 'TRENDING_STEADY']).default('POPULAR'),
+});
+export type DomainRankParams = z.infer<typeof DomainRankParams>;
+
+export const domainRankDescriptor: EndpointDescriptor = {
+	id: 'radar-domain-rank',
+	category: 'rankings',
+	displayName: 'Cloudflare Radar Domain Rank',
+	description:
+		'Global popularity ranking for a domain via Cloudflare Radar (1.1.1.1 resolver telemetry). Free, monthly snapshot — useful as a macro-trend signal beside Google/Bing rankings.',
+	paramsSchema: DomainRankParams,
+	cost: { unit: 'usd_cents', amount: 0 },
+	defaultCron: '0 7 1 * *', // 07:00 UTC on the 1st of each month
+	rateLimit: { max: 60, durationMs: 60_000 },
+};
+
+export interface DomainRankCategoryRow {
+	name?: string;
+	rank?: number;
+}
+export interface DomainRankDetails {
+	rank?: number;
+	domain?: string;
+	categories?: DomainRankCategoryRow[];
+	bucket?: string;
+}
+export interface DomainRankResponse {
+	success?: boolean;
+	result?: {
+		details_0?: DomainRankDetails;
+		meta?: { lastUpdated?: string };
+	};
+}
+
+export const fetchDomainRank = async (
+	http: CloudflareRadarHttp,
+	params: DomainRankParams,
+	ctx: FetchContext,
+): Promise<DomainRankResponse> => {
+	const path = `/radar/ranking/domain/${encodeURIComponent(params.domain)}`;
+	const raw = (await http.get(
+		path,
+		{ rankingType: params.rankingType, format: 'json' },
+		ctx.credential.plaintextSecret,
+		ctx.signal,
+	)) as DomainRankResponse;
+	return raw;
+};

--- a/packages/providers/cloudflare-radar/src/http.ts
+++ b/packages/providers/cloudflare-radar/src/http.ts
@@ -1,0 +1,91 @@
+/**
+ * Cloudflare Radar API client. Auth = Bearer token in `Authorization` header.
+ * The free tier is generous (1.2k req/5min/account) but we declare a tighter
+ * 60 req/min in descriptors so a misconfigured cron can't drain it.
+ */
+import { validateCloudflareToken } from './credential.js';
+
+export interface CloudflareRadarHttpOptions {
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_BASE_URL = 'https://api.cloudflare.com/client/v4';
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+export class CloudflareRadarApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'CloudflareRadarApiError';
+	}
+}
+
+export class CloudflareRadarHttp {
+	private readonly baseUrl: string;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: CloudflareRadarHttpOptions = {}) {
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	}
+
+	async get(
+		path: string,
+		query: Record<string, string | string[]>,
+		plaintextCredential: string,
+		signal?: AbortSignal,
+	): Promise<unknown> {
+		const token = validateCloudflareToken(plaintextCredential);
+		const params = new URLSearchParams();
+		for (const [k, v] of Object.entries(query)) {
+			if (Array.isArray(v)) for (const item of v) params.append(k, item);
+			else params.append(k, v);
+		}
+		const url = `${this.baseUrl}${path}${params.size > 0 ? `?${params.toString()}` : ''}`;
+		const response = await this.fetchImpl(url, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: 'application/json',
+			},
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new CloudflareRadarApiError(
+				response.status,
+				null,
+				`Cloudflare ${path} response too large: ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new CloudflareRadarApiError(
+				response.status,
+				null,
+				`Cloudflare ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new CloudflareRadarApiError(
+				response.status,
+				parsed,
+				`Cloudflare ${path} returned HTTP ${response.status}`,
+			);
+		}
+		return parsed;
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/cloudflare-radar/src/index.ts
+++ b/packages/providers/cloudflare-radar/src/index.ts
@@ -1,0 +1,5 @@
+export * from './acl/domain-rank-to-snapshot.acl.js';
+export * from './credential.js';
+export * from './endpoints/domain-rank.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/cloudflare-radar/src/provider.spec.ts
+++ b/packages/providers/cloudflare-radar/src/provider.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { CloudflareRadarProvider } from './provider.js';
+
+const validToken = 'cf_test_TokenValue1234567890_abcXYZ';
+
+describe('CloudflareRadarProvider', () => {
+	it('exposes radar-domain-rank via discover()', () => {
+		const ids = new CloudflareRadarProvider().discover().map((e) => e.id);
+		expect(ids).toEqual(['radar-domain-rank']);
+	});
+
+	it('validateCredentialPlaintext accepts a normal Cloudflare API token', () => {
+		expect(() => new CloudflareRadarProvider().validateCredentialPlaintext(validToken)).not.toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects empty or too-short tokens', () => {
+		expect(() => new CloudflareRadarProvider().validateCredentialPlaintext('')).toThrow();
+		expect(() => new CloudflareRadarProvider().validateCredentialPlaintext('too-short')).toThrow();
+	});
+
+	it('paramsSchema rejects a domain that includes a scheme', () => {
+		const ep = new CloudflareRadarProvider().discover().find((e) => e.id === 'radar-domain-rank');
+		expect(ep?.paramsSchema.safeParse({ domain: 'https://example.com' }).success).toBe(false);
+	});
+
+	it('paramsSchema accepts a bare domain and applies POPULAR default', () => {
+		const ep = new CloudflareRadarProvider().discover().find((e) => e.id === 'radar-domain-rank');
+		const parsed = ep?.paramsSchema.safeParse({ domain: 'example.com' });
+		expect(parsed?.success).toBe(true);
+	});
+
+	it('fetch rejects an unknown endpoint id', async () => {
+		const provider = new CloudflareRadarProvider();
+		await expect(
+			provider.fetch('not-real', {}, {
+				credential: { plaintextSecret: validToken },
+				signal: new AbortController().signal,
+			} as never),
+		).rejects.toThrow();
+	});
+});

--- a/packages/providers/cloudflare-radar/src/provider.ts
+++ b/packages/providers/cloudflare-radar/src/provider.ts
@@ -1,0 +1,42 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import { validateCloudflareToken } from './credential.js';
+import { type DomainRankParams, domainRankDescriptor, fetchDomainRank } from './endpoints/domain-rank.js';
+import { CloudflareRadarHttp } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [domainRankDescriptor];
+
+export class CloudflareRadarProvider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('cloudflare-radar');
+	readonly displayName = 'Cloudflare Radar';
+	readonly authStrategy = 'apiKey' as const;
+
+	private readonly http: CloudflareRadarHttp;
+
+	constructor(options?: { fetchImpl?: typeof fetch }) {
+		this.http = new CloudflareRadarHttp(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		validateCloudflareToken(plaintextSecret);
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case domainRankDescriptor.id: {
+				const parsed = domainRankDescriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(`Invalid params for ${endpointId}: ${parsed.error.message}`);
+				}
+				return await fetchDomainRank(this.http, parsed.data as DomainRankParams, ctx);
+			}
+			default:
+				throw new InvalidInputError(`cloudflare-radar has no endpoint "${endpointId}"`);
+		}
+	}
+}

--- a/packages/providers/cloudflare-radar/tsconfig.build.json
+++ b/packages/providers/cloudflare-radar/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/cloudflare-radar/tsconfig.json
+++ b/packages/providers/cloudflare-radar/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/cloudflare-radar/vitest.config.ts
+++ b/packages/providers/cloudflare-radar/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -6,6 +6,7 @@ import { GscResource } from './resources/gsc.js';
 import { PageSpeedResource } from './resources/page-speed.js';
 import { ProjectsResource } from './resources/projects.js';
 import { ProvidersResource } from './resources/providers.js';
+import { RadarResource } from './resources/radar.js';
 import { RankTrackingResource } from './resources/rank-tracking.js';
 import { WikipediaResource } from './resources/wikipedia.js';
 
@@ -25,6 +26,7 @@ export class RankPulseClient {
 	readonly pageSpeed: PageSpeedResource;
 	readonly ga4: Ga4Resource;
 	readonly bing: BingResource;
+	readonly radar: RadarResource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -39,5 +41,6 @@ export class RankPulseClient {
 		this.pageSpeed = new PageSpeedResource(http);
 		this.ga4 = new Ga4Resource(http);
 		this.bing = new BingResource(http);
+		this.radar = new RadarResource(http);
 	}
 }

--- a/packages/sdk/src/resources/radar.ts
+++ b/packages/sdk/src/resources/radar.ts
@@ -1,0 +1,30 @@
+import type { MacroContextContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class RadarResource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<MacroContextContracts.MonitoredDomainDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/radar/domains`);
+	}
+
+	add(
+		projectId: string,
+		body: MacroContextContracts.AddMonitoredDomainRequest,
+	): Promise<{ monitoredDomainId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/radar/domains`, body);
+	}
+
+	remove(monitoredDomainId: string): Promise<{ ok: true }> {
+		return this.http.delete(`/radar/domains/${encodeURIComponent(monitoredDomainId)}`);
+	}
+
+	history(
+		monitoredDomainId: string,
+		query: MacroContextContracts.RadarHistoryQuery,
+	): Promise<MacroContextContracts.RadarHistoryRowDto[]> {
+		return this.http.get(`/radar/domains/${encodeURIComponent(monitoredDomainId)}/history`, {
+			query: { from: query.from, to: query.to },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@rankpulse/provider-bing':
         specifier: workspace:*
         version: link:../../packages/providers/bing
+      '@rankpulse/provider-cloudflare-radar':
+        specifier: workspace:*
+        version: link:../../packages/providers/cloudflare-radar
       '@rankpulse/provider-core':
         specifier: workspace:*
         version: link:../../packages/providers/core
@@ -205,6 +208,9 @@ importers:
       '@rankpulse/provider-bing':
         specifier: workspace:*
         version: link:../../packages/providers/bing
+      '@rankpulse/provider-cloudflare-radar':
+        specifier: workspace:*
+        version: link:../../packages/providers/cloudflare-radar
       '@rankpulse/provider-core':
         specifier: workspace:*
         version: link:../../packages/providers/core
@@ -344,6 +350,28 @@ importers:
         version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/providers/bing:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/cloudflare-radar:
     dependencies:
       '@rankpulse/domain':
         specifier: workspace:*


### PR DESCRIPTION
Closes #25.

## Summary
- New provider `@rankpulse/provider-cloudflare-radar`: Bearer-token client (`Authorization: Bearer <CF token>` with `Radar:Read` scope), 8 MB body cap. Single endpoint `radar-domain-rank` (cron `0 7 1 * *`, monthly because Radar's underlying ranking is itself a 30-day rolling aggregation). Pure ACL surfaces unranked long-tail domains as `rank: null` rather than dropping the row, drops malformed category entries.
- New `macro-context` bounded context: `MonitoredDomain` aggregate with `DomainName` VO that lowercases and strips `www.` for canonical comparison; `RadarRank` value-like enforcing positive-integer rank invariant; `RadarRankSnapshot` value-like; `MonitoredDomainAdded` and `RadarRankRecorded` events.
- Drizzle migration 0009 — `monitored_domains` (uniqueness on `(project_id, domain)`) + `radar_rank_snapshots` (natural PK `(monitored_domain_id, observed_date)`); idempotent IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
- Application — `AddMonitoredDomain` (canonicalises before lookup so `WWW.Example.com` and `example.com` collide as duplicates), `RemoveMonitoredDomain` (idempotent), `RecordRadarRank` (returns inserted boolean, only emits event on first insert), `QueryRadarHistory`. 5 unit tests covering happy path, idempotency, NotFound, null-rank for long-tail domains, rank-invariant rejection.
- Worker — provider registered, processor dispatches `radar-domain-rank` to ACL + record use case, classifies `402`/`429` as quota-exhausted (auto-pause).
- API — `GET/POST/DELETE /radar/...` endpoints in `MacroContextModule` with the same IDOR-safe 404-collapse pattern.
- SDK — `radar` resource (`listForProject`, `add`, `remove`, `history`).
- UI — atomic-design `AddRadarDomainDrawer` + new Radar card on the project detail page (mobile-first, copy explaining the null-rank long-tail outcome).

## Pipeline status (local)
- `pnpm lint` — clean (biome `check .`).
- `pnpm typecheck` — 19/19 packages OK.
- `pnpm test` — all 19 workspaces green; **10** new provider tests + **5** new application tests added.
- `pnpm build` — full monorepo build green.

## Test plan
- [ ] CI green (format/lint/typecheck/tests/coverage).
- [ ] Migration `0009_harsh_mattie_franklin.sql` applies cleanly on the existing prod database.
- [ ] After deploy, register a Cloudflare API token credential, add a monitored domain, schedule the cron (with a `monitoredDomainId` in systemParams), trigger run-now and confirm a row lands in `radar_rank_snapshots`.
- [ ] Re-run the same job and verify it does not duplicate (PK conflict swallowed, no duplicate event).