### PR TITLE
fix(provider-connectivity): SystemParamResolver for GA4/PSI/Wikipedia/Bing (continuation of #53)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -212,11 +212,18 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		SystemIdGenerator,
 		eventPublisher,
 		[
-			// BACKLOG bug #50 — auto-resolves gscPropertyId from
-			// (projectId, params.siteUrl) for gsc-search-analytics
-			// schedules. Other providers/endpoints: add their own
-			// resolvers here as needed.
+			// BACKLOG bug #50 (and family) — these resolvers map a user-
+			// facing identifier in `params` (siteUrl, propertyId, url,
+			// article slug...) to the internal entity id the worker's
+			// processor needs in `systemParams` for ingest. Without this,
+			// every scheduled fetch was logging "missing <X>Id; skipping
+			// ingest" and discarding the response. Each bounded context
+			// owns its resolver; this module just wires them up.
 			new SCIUseCases.GscPropertySystemParamResolver(gscPropertyRepo),
+			new TAUseCases.Ga4PropertySystemParamResolver(ga4PropertyRepo),
+			new WPUseCases.TrackedPageSystemParamResolver(trackedPageRepo),
+			new EAUseCases.WikipediaArticleSystemParamResolver(wikipediaArticleRepo),
+			new BWIUseCases.BingPropertySystemParamResolver(bingPropertyRepo),
 		],
 	);
 	const recordApiUsage = new PCUseCases.RecordApiUsageUseCase(

--- a/packages/application/src/bing-webmaster-insights/index.ts
+++ b/packages/application/src/bing-webmaster-insights/index.ts
@@ -1,3 +1,4 @@
+export * from './system-param-resolvers/bing-property.system-param-resolver.js';
 export * from './use-cases/ingest-bing-traffic.use-case.js';
 export * from './use-cases/link-bing-property.use-case.js';
 export * from './use-cases/query-bing-traffic.use-case.js';

--- a/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.spec.ts
+++ b/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.spec.ts
@@ -1,0 +1,63 @@
+import type { BingWebmasterInsights } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { BingPropertySystemParamResolver } from './bing-property.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const propId = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+const siteUrl = 'https://example.com';
+
+const aLinkedProperty = (): BingWebmasterInsights.BingProperty =>
+	({ id: propId, isActive: () => true }) as unknown as BingWebmasterInsights.BingProperty;
+
+describe('BingPropertySystemParamResolver', () => {
+	it('returns bingPropertyId on a match', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn().mockResolvedValue(aLinkedProperty()),
+		} as unknown as BingWebmasterInsights.BingPropertyRepository;
+		const r = new BingPropertySystemParamResolver(repo);
+		const out = await r.resolve({
+			projectId,
+			providerId: 'bing-webmaster-tools',
+			endpointId: 'bing-rank-and-traffic-stats',
+			params: { siteUrl },
+		});
+		expect(out).toEqual({ bingPropertyId: propId });
+	});
+
+	it('returns {} for other providers', async () => {
+		const repo = { findByProjectAndSite: vi.fn() } as unknown as BingWebmasterInsights.BingPropertyRepository;
+		const r = new BingPropertySystemParamResolver(repo);
+		expect(await r.resolve({ projectId, providerId: 'dataforseo', endpointId: 'serp', params: {} })).toEqual(
+			{},
+		);
+	});
+
+	it('throws InvalidInputError when siteUrl missing', async () => {
+		const repo = { findByProjectAndSite: vi.fn() } as unknown as BingWebmasterInsights.BingPropertyRepository;
+		const r = new BingPropertySystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'bing-webmaster-tools',
+				endpointId: 'bing-rank-and-traffic-stats',
+				params: {},
+			}),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+
+	it('throws NotFoundError when not linked', async () => {
+		const repo = {
+			findByProjectAndSite: vi.fn().mockResolvedValue(null),
+		} as unknown as BingWebmasterInsights.BingPropertyRepository;
+		const r = new BingPropertySystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'bing-webmaster-tools',
+				endpointId: 'bing-rank-and-traffic-stats',
+				params: { siteUrl },
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.ts
+++ b/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.ts
@@ -1,0 +1,45 @@
+import type { BingWebmasterInsights, ProjectManagement } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `bingPropertyId` for `bing-rank-and-traffic-stats` schedules.
+ * Same pattern as `GscPropertySystemParamResolver` (BACKLOG bug #50).
+ *
+ * Looks up the BingProperty entity by `(projectId, params.siteUrl)`.
+ * If not linked yet, points the operator at `POST /projects/:id/bing/properties`
+ * (or whichever path the bing-webmaster-insights module exposes).
+ */
+export class BingPropertySystemParamResolver implements SystemParamResolver {
+	constructor(private readonly properties: BingWebmasterInsights.BingPropertyRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		if (input.providerId !== 'bing-webmaster-tools') return {};
+		if (input.endpointId !== 'bing-rank-and-traffic-stats') return {};
+
+		const siteUrl = input.params.siteUrl;
+		if (typeof siteUrl !== 'string' || siteUrl.length === 0) {
+			throw new InvalidInputError(
+				'bing-rank-and-traffic-stats schedule requires `params.siteUrl` (e.g. "https://example.com").',
+			);
+		}
+
+		const property = await this.properties.findByProjectAndSite(
+			input.projectId as ProjectManagement.ProjectId,
+			siteUrl,
+		);
+		if (!property?.isActive()) {
+			throw new NotFoundError(
+				`Bing property ${siteUrl} is not linked to project ${input.projectId}. ` +
+					'Link it first via POST /projects/:id/bing/properties.',
+			);
+		}
+
+		return { bingPropertyId: property.id };
+	}
+}

--- a/packages/application/src/entity-awareness/index.ts
+++ b/packages/application/src/entity-awareness/index.ts
@@ -1,3 +1,4 @@
+export * from './system-param-resolvers/wikipedia-article.system-param-resolver.js';
 export * from './use-cases/ingest-wikipedia-pageviews.use-case.js';
 export * from './use-cases/link-wikipedia-article.use-case.js';
 export * from './use-cases/query-wikipedia-pageviews.use-case.js';

--- a/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.spec.ts
+++ b/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.spec.ts
@@ -1,0 +1,47 @@
+import type { EntityAwareness } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { WikipediaArticleSystemParamResolver } from './wikipedia-article.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const articleId = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+
+const aLinked = (): EntityAwareness.WikipediaArticle =>
+	({ id: articleId, isActive: () => true }) as unknown as EntityAwareness.WikipediaArticle;
+
+describe('WikipediaArticleSystemParamResolver', () => {
+	it('returns wikipediaArticleId on match', async () => {
+		const repo = {
+			findByProjectAndSlug: vi.fn().mockResolvedValue(aLinked()),
+		} as unknown as EntityAwareness.WikipediaArticleRepository;
+		const r = new WikipediaArticleSystemParamResolver(repo);
+		const out = await r.resolve({
+			projectId,
+			providerId: 'wikipedia',
+			endpointId: 'wikipedia-pageviews-per-article',
+			params: { project: 'en.wikipedia.org', article: 'PatrolTech' },
+		});
+		expect(out).toEqual({ wikipediaArticleId: articleId });
+	});
+
+	it('returns {} for other endpoints', async () => {
+		const repo = { findByProjectAndSlug: vi.fn() } as unknown as EntityAwareness.WikipediaArticleRepository;
+		const r = new WikipediaArticleSystemParamResolver(repo);
+		expect(await r.resolve({ projectId, providerId: 'dataforseo', endpointId: 'serp', params: {} })).toEqual(
+			{},
+		);
+	});
+
+	it('throws InvalidInputError on missing project or article', async () => {
+		const repo = { findByProjectAndSlug: vi.fn() } as unknown as EntityAwareness.WikipediaArticleRepository;
+		const r = new WikipediaArticleSystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'wikipedia',
+				endpointId: 'wikipedia-pageviews-per-article',
+				params: { article: 'X' },
+			}),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+});

--- a/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.ts
+++ b/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.ts
@@ -1,0 +1,54 @@
+import type { EntityAwareness, ProjectManagement } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `wikipediaArticleId` for `wikipedia-pageviews-per-article`
+ * schedules. Same pattern as `GscPropertySystemParamResolver`
+ * (BACKLOG bug #50).
+ *
+ * Looks up the WikipediaArticle entity by
+ * `(projectId, params.project, params.article)`. The Wikipedia REST API
+ * keys articles on (project, slug) where project is e.g. `en.wikipedia.org`
+ * and slug is the title with underscores.
+ */
+export class WikipediaArticleSystemParamResolver implements SystemParamResolver {
+	constructor(private readonly articles: EntityAwareness.WikipediaArticleRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		if (input.providerId !== 'wikipedia') return {};
+		if (input.endpointId !== 'wikipedia-pageviews-per-article') return {};
+
+		const wpProject = input.params.project;
+		const article = input.params.article;
+		if (typeof wpProject !== 'string' || wpProject.length === 0) {
+			throw new InvalidInputError(
+				'wikipedia-pageviews schedule requires `params.project` (e.g. "en.wikipedia.org").',
+			);
+		}
+		if (typeof article !== 'string' || article.length === 0) {
+			throw new InvalidInputError(
+				'wikipedia-pageviews schedule requires `params.article` (URL-encoded slug).',
+			);
+		}
+
+		const found = await this.articles.findByProjectAndSlug(
+			input.projectId as ProjectManagement.ProjectId,
+			wpProject as unknown as EntityAwareness.WikipediaProject,
+			article as unknown as EntityAwareness.ArticleSlug,
+		);
+		if (!found?.isActive()) {
+			throw new NotFoundError(
+				`Wikipedia article ${wpProject}/${article} is not linked to project ${input.projectId}. ` +
+					'Link it first via POST /projects/:id/wikipedia/articles.',
+			);
+		}
+
+		return { wikipediaArticleId: found.id };
+	}
+}

--- a/packages/application/src/traffic-analytics/index.ts
+++ b/packages/application/src/traffic-analytics/index.ts
@@ -1,3 +1,4 @@
+export * from './system-param-resolvers/ga4-property.system-param-resolver.js';
 export * from './use-cases/ingest-ga4-rows.use-case.js';
 export * from './use-cases/link-ga4-property.use-case.js';
 export * from './use-cases/query-ga4-metrics.use-case.js';

--- a/packages/application/src/traffic-analytics/system-param-resolvers/ga4-property.system-param-resolver.spec.ts
+++ b/packages/application/src/traffic-analytics/system-param-resolvers/ga4-property.system-param-resolver.spec.ts
@@ -1,0 +1,68 @@
+import type { TrafficAnalytics } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { Ga4PropertySystemParamResolver } from './ga4-property.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const propertyId = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+const propertyHandle = '460868003';
+
+const aLinkedProperty = (): TrafficAnalytics.Ga4Property =>
+	({ id: propertyId, isActive: () => true }) as unknown as TrafficAnalytics.Ga4Property;
+
+describe('Ga4PropertySystemParamResolver', () => {
+	it('returns ga4PropertyId when (project, propertyHandle) match an active property', async () => {
+		const repo = {
+			findByProjectAndHandle: vi.fn().mockResolvedValue(aLinkedProperty()),
+		} as unknown as TrafficAnalytics.Ga4PropertyRepository;
+		const resolver = new Ga4PropertySystemParamResolver(repo);
+		const result = await resolver.resolve({
+			projectId,
+			providerId: 'google-analytics-4',
+			endpointId: 'ga4-run-report',
+			params: { propertyId: propertyHandle },
+		});
+		expect(result).toEqual({ ga4PropertyId: propertyId });
+	});
+
+	it('returns {} for non-GA4 endpoints (no-op)', async () => {
+		const repo = { findByProjectAndHandle: vi.fn() } as unknown as TrafficAnalytics.Ga4PropertyRepository;
+		const resolver = new Ga4PropertySystemParamResolver(repo);
+		const result = await resolver.resolve({
+			projectId,
+			providerId: 'google-search-console',
+			endpointId: 'gsc-search-analytics',
+			params: { siteUrl: 'sc-domain:x' },
+		});
+		expect(result).toEqual({});
+		expect(repo.findByProjectAndHandle).not.toHaveBeenCalled();
+	});
+
+	it('throws InvalidInputError when params.propertyId is missing', async () => {
+		const repo = { findByProjectAndHandle: vi.fn() } as unknown as TrafficAnalytics.Ga4PropertyRepository;
+		const resolver = new Ga4PropertySystemParamResolver(repo);
+		await expect(
+			resolver.resolve({
+				projectId,
+				providerId: 'google-analytics-4',
+				endpointId: 'ga4-run-report',
+				params: {},
+			}),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+
+	it('throws NotFoundError pointing the operator at /ga4/properties when not linked', async () => {
+		const repo = {
+			findByProjectAndHandle: vi.fn().mockResolvedValue(null),
+		} as unknown as TrafficAnalytics.Ga4PropertyRepository;
+		const resolver = new Ga4PropertySystemParamResolver(repo);
+		await expect(
+			resolver.resolve({
+				projectId,
+				providerId: 'google-analytics-4',
+				endpointId: 'ga4-run-report',
+				params: { propertyId: propertyHandle },
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/traffic-analytics/system-param-resolvers/ga4-property.system-param-resolver.ts
+++ b/packages/application/src/traffic-analytics/system-param-resolvers/ga4-property.system-param-resolver.ts
@@ -1,0 +1,48 @@
+import type { ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `ga4PropertyId` for `ga4-run-report` schedules. Same pattern
+ * as `GscPropertySystemParamResolver` (BACKLOG bug #50). Without this,
+ * every GA4 scheduled fetch logs `ga4-run-report job missing
+ * ga4PropertyId param; skipping ingest` and discards the response.
+ *
+ * Looks up the Ga4Property entity by `(projectId, params.propertyId)`.
+ * If not linked yet, points the operator at `POST /projects/:id/ga4/properties`.
+ */
+export class Ga4PropertySystemParamResolver implements SystemParamResolver {
+	constructor(private readonly properties: TrafficAnalytics.Ga4PropertyRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		if (input.providerId !== 'google-analytics-4') return {};
+		if (input.endpointId !== 'ga4-run-report') return {};
+
+		const propertyId = input.params.propertyId;
+		if (typeof propertyId !== 'string' || propertyId.length === 0) {
+			throw new InvalidInputError(
+				'ga4-run-report schedule requires `params.propertyId` (numeric or "properties/<id>" form).',
+			);
+		}
+
+		// GA4 accepts both `123456` and `properties/123456`; the repo finder
+		// is keyed on the raw handle so we pass it through unchanged.
+		const property = await this.properties.findByProjectAndHandle(
+			input.projectId as ProjectManagement.ProjectId,
+			propertyId,
+		);
+		if (!property?.isActive()) {
+			throw new NotFoundError(
+				`GA4 property ${propertyId} is not linked to project ${input.projectId}. ` +
+					'Link it first via POST /projects/:id/ga4/properties — that path auto-creates the daily schedule.',
+			);
+		}
+
+		return { ga4PropertyId: property.id };
+	}
+}

--- a/packages/application/src/web-performance/index.ts
+++ b/packages/application/src/web-performance/index.ts
@@ -1,3 +1,4 @@
+export * from './system-param-resolvers/tracked-page.system-param-resolver.js';
 export * from './use-cases/query-page-speed-history.use-case.js';
 export * from './use-cases/record-page-speed-snapshot.use-case.js';
 export * from './use-cases/track-page.use-case.js';

--- a/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.spec.ts
+++ b/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.spec.ts
@@ -1,0 +1,63 @@
+import type { WebPerformance } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { TrackedPageSystemParamResolver } from './tracked-page.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const pageId = 'pppppppp-pppp-pppp-pppp-pppppppppppp';
+const url = 'https://example.com';
+
+const aTrackedPage = (): WebPerformance.TrackedPage =>
+	({ id: pageId }) as unknown as WebPerformance.TrackedPage;
+
+describe('TrackedPageSystemParamResolver', () => {
+	it('returns trackedPageId on tuple match', async () => {
+		const repo = {
+			findByTuple: vi.fn().mockResolvedValue(aTrackedPage()),
+		} as unknown as WebPerformance.TrackedPageRepository;
+		const r = new TrackedPageSystemParamResolver(repo);
+		const out = await r.resolve({
+			projectId,
+			providerId: 'pagespeed',
+			endpointId: 'psi-runpagespeed',
+			params: { url, strategy: 'mobile' },
+		});
+		expect(out).toEqual({ trackedPageId: pageId });
+	});
+
+	it('returns {} for other providers', async () => {
+		const repo = { findByTuple: vi.fn() } as unknown as WebPerformance.TrackedPageRepository;
+		const r = new TrackedPageSystemParamResolver(repo);
+		expect(await r.resolve({ projectId, providerId: 'dataforseo', endpointId: 'serp', params: {} })).toEqual(
+			{},
+		);
+	});
+
+	it('throws InvalidInputError on missing url or invalid strategy', async () => {
+		const repo = { findByTuple: vi.fn() } as unknown as WebPerformance.TrackedPageRepository;
+		const r = new TrackedPageSystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'pagespeed',
+				endpointId: 'psi-runpagespeed',
+				params: { url, strategy: 'not-real' },
+			}),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+
+	it('throws NotFoundError when page not tracked', async () => {
+		const repo = {
+			findByTuple: vi.fn().mockResolvedValue(null),
+		} as unknown as WebPerformance.TrackedPageRepository;
+		const r = new TrackedPageSystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'pagespeed',
+				endpointId: 'psi-runpagespeed',
+				params: { url, strategy: 'mobile' },
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.ts
+++ b/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.ts
@@ -1,0 +1,54 @@
+import type { ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `trackedPageId` for `psi-runpagespeed` schedules. Same
+ * pattern as `GscPropertySystemParamResolver` (BACKLOG bug #50).
+ *
+ * Looks up the TrackedPage entity by `(projectId, params.url, params.strategy)`.
+ * `strategy` (mobile|desktop) is part of the natural key because the
+ * same URL is tracked twice — once per device class — to align with
+ * Google's CWV split.
+ */
+export class TrackedPageSystemParamResolver implements SystemParamResolver {
+	constructor(private readonly pages: WebPerformance.TrackedPageRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		if (input.providerId !== 'pagespeed') return {};
+		if (input.endpointId !== 'psi-runpagespeed') return {};
+
+		const url = input.params.url;
+		const strategy = input.params.strategy;
+		if (typeof url !== 'string' || url.length === 0) {
+			throw new InvalidInputError('psi-runpagespeed schedule requires `params.url` (full URL with scheme).');
+		}
+		if (strategy !== 'mobile' && strategy !== 'desktop') {
+			throw new InvalidInputError(
+				'psi-runpagespeed schedule requires `params.strategy` of "mobile" or "desktop".',
+			);
+		}
+
+		// The repo `findByTuple` accepts the raw primitives; value-objects
+		// are constructed inside the infrastructure adapter to keep this
+		// resolver minimal-surface.
+		const page = await this.pages.findByTuple(
+			input.projectId as ProjectManagement.ProjectId,
+			url as unknown as WebPerformance.PageUrl,
+			strategy as unknown as WebPerformance.PageSpeedStrategy,
+		);
+		if (!page) {
+			throw new NotFoundError(
+				`PSI tracked page ${strategy}|${url} is not registered for project ${input.projectId}. ` +
+					'Track it first via POST /projects/:id/page-speed/pages.',
+			);
+		}
+
+		return { trackedPageId: page.id };
+	}
+}


### PR DESCRIPTION
Continuation of #53 / closes the rest of bug #50 family.

While testing in production after #53 merged, the worker logs revealed the same `missing <X>Id; skipping ingest` pattern in 4 more bounded contexts:

```
ga4-run-report job missing ga4PropertyId param; skipping ingest
psi-runpagespeed job missing trackedPageId in systemParams; skipping ingest
wikipedia-pageviews job missing wikipediaArticleId in systemParams; skipping ingest
bing-rank-and-traffic-stats job missing bingPropertyId in systemParams; skipping ingest
```

#53 fixed only GSC. This PR replicates the exact resolver pattern for the other 4 providers — purely additive: 4 new `SystemParamResolver` classes, 16 new tests, no modifications to existing code beyond exporting from index files and wiring in composition root.

| Provider | Endpoint | systemParam injected | Resolved from |
|---|---|---|---|
| google-analytics-4 | ga4-run-report | ga4PropertyId | (projectId, params.propertyId) |
| pagespeed | psi-runpagespeed | trackedPageId | (projectId, params.url, params.strategy) |
| wikipedia | wikipedia-pageviews-per-article | wikipediaArticleId | (projectId, params.project, params.article) |
| bing-webmaster-tools | bing-rank-and-traffic-stats | bingPropertyId | (projectId, params.siteUrl) |

Each resolver follows the GSC reference exactly: returns {} for non-matching provider/endpoint pairs, throws `InvalidInputError` for missing params, throws `NotFoundError` with a pointer to the correct `POST /projects/:id/<context>/<entity>` link path if the entity isn't registered yet.

## Tests
- 16 new unit tests across the 4 resolvers (4 each: happy path, no-op for other providers, invalid params, unlinked entity).
- 145 / 145 application tests pass.
- Lint clean, typecheck OK on api + application.

## Operational follow-up after merge
Same pattern as #53: any existing JobDefinitions of these endpoints created via the buggy POST .../schedule path lack their entity id and will keep skipping ingest. After deploy, I'll DELETE + re-create them via the fixed code path.