### PR TITLE
fix(provider-connectivity): close 2 remaining bug-50 family cases (Bing string + CF Radar resolver)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -229,6 +229,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 			new WPUseCases.TrackedPageSystemParamResolver(trackedPageRepo),
 			new EAUseCases.WikipediaArticleSystemParamResolver(wikipediaArticleRepo),
 			new BWIUseCases.BingPropertySystemParamResolver(bingPropertyRepo),
+			new MCUseCases.MonitoredDomainSystemParamResolver(monitoredDomainRepo),
 		],
 	);
 	const recordApiUsage = new PCUseCases.RecordApiUsageUseCase(

--- a/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.spec.ts
+++ b/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.spec.ts
@@ -18,7 +18,7 @@ describe('BingPropertySystemParamResolver', () => {
 		const r = new BingPropertySystemParamResolver(repo);
 		const out = await r.resolve({
 			projectId,
-			providerId: 'bing-webmaster-tools',
+			providerId: 'bing-webmaster',
 			endpointId: 'bing-rank-and-traffic-stats',
 			params: { siteUrl },
 		});
@@ -39,7 +39,7 @@ describe('BingPropertySystemParamResolver', () => {
 		await expect(
 			r.resolve({
 				projectId,
-				providerId: 'bing-webmaster-tools',
+				providerId: 'bing-webmaster',
 				endpointId: 'bing-rank-and-traffic-stats',
 				params: {},
 			}),
@@ -54,7 +54,7 @@ describe('BingPropertySystemParamResolver', () => {
 		await expect(
 			r.resolve({
 				projectId,
-				providerId: 'bing-webmaster-tools',
+				providerId: 'bing-webmaster',
 				endpointId: 'bing-rank-and-traffic-stats',
 				params: { siteUrl },
 			}),

--- a/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.ts
+++ b/packages/application/src/bing-webmaster-insights/system-param-resolvers/bing-property.system-param-resolver.ts
@@ -19,7 +19,7 @@ export class BingPropertySystemParamResolver implements SystemParamResolver {
 		endpointId: string;
 		params: Record<string, unknown>;
 	}): Promise<Record<string, unknown>> {
-		if (input.providerId !== 'bing-webmaster-tools') return {};
+		if (input.providerId !== 'bing-webmaster') return {};
 		if (input.endpointId !== 'bing-rank-and-traffic-stats') return {};
 
 		const siteUrl = input.params.siteUrl;

--- a/packages/application/src/macro-context/index.ts
+++ b/packages/application/src/macro-context/index.ts
@@ -1,3 +1,4 @@
+export * from './system-param-resolvers/monitored-domain.system-param-resolver.js';
 export * from './use-cases/add-monitored-domain.use-case.js';
 export * from './use-cases/query-radar-history.use-case.js';
 export * from './use-cases/record-radar-rank.use-case.js';

--- a/packages/application/src/macro-context/system-param-resolvers/monitored-domain.system-param-resolver.spec.ts
+++ b/packages/application/src/macro-context/system-param-resolvers/monitored-domain.system-param-resolver.spec.ts
@@ -1,0 +1,58 @@
+import type { MacroContext } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { MonitoredDomainSystemParamResolver } from './monitored-domain.system-param-resolver.js';
+
+const projectId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const monitoredDomainId = 'mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm';
+const domain = 'patroltech.online';
+
+const aLinked = (): MacroContext.MonitoredDomain =>
+	({ id: monitoredDomainId, isActive: () => true }) as unknown as MacroContext.MonitoredDomain;
+
+describe('MonitoredDomainSystemParamResolver', () => {
+	it('returns monitoredDomainId on a match', async () => {
+		const repo = {
+			findByProjectAndDomain: vi.fn().mockResolvedValue(aLinked()),
+		} as unknown as MacroContext.MonitoredDomainRepository;
+		const r = new MonitoredDomainSystemParamResolver(repo);
+		const out = await r.resolve({
+			projectId,
+			providerId: 'cloudflare-radar',
+			endpointId: 'radar-domain-rank',
+			params: { domain },
+		});
+		expect(out).toEqual({ monitoredDomainId });
+	});
+
+	it('returns {} for other providers', async () => {
+		const repo = { findByProjectAndDomain: vi.fn() } as unknown as MacroContext.MonitoredDomainRepository;
+		const r = new MonitoredDomainSystemParamResolver(repo);
+		expect(await r.resolve({ projectId, providerId: 'dataforseo', endpointId: 'serp', params: {} })).toEqual(
+			{},
+		);
+	});
+
+	it('throws InvalidInputError on missing domain', async () => {
+		const repo = { findByProjectAndDomain: vi.fn() } as unknown as MacroContext.MonitoredDomainRepository;
+		const r = new MonitoredDomainSystemParamResolver(repo);
+		await expect(
+			r.resolve({ projectId, providerId: 'cloudflare-radar', endpointId: 'radar-domain-rank', params: {} }),
+		).rejects.toBeInstanceOf(InvalidInputError);
+	});
+
+	it('throws NotFoundError when not registered', async () => {
+		const repo = {
+			findByProjectAndDomain: vi.fn().mockResolvedValue(null),
+		} as unknown as MacroContext.MonitoredDomainRepository;
+		const r = new MonitoredDomainSystemParamResolver(repo);
+		await expect(
+			r.resolve({
+				projectId,
+				providerId: 'cloudflare-radar',
+				endpointId: 'radar-domain-rank',
+				params: { domain },
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/macro-context/system-param-resolvers/monitored-domain.system-param-resolver.ts
+++ b/packages/application/src/macro-context/system-param-resolvers/monitored-domain.system-param-resolver.ts
@@ -1,0 +1,45 @@
+import type { MacroContext, ProjectManagement } from '@rankpulse/domain';
+import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
+import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
+
+/**
+ * Resolves `monitoredDomainId` for `radar-domain-rank` schedules. Same
+ * pattern as `GscPropertySystemParamResolver` (BACKLOG bug #50).
+ *
+ * Looks up the MonitoredDomain entity by `(projectId, params.domain)`.
+ * If not registered, points the operator at `POST /projects/:id/macro/
+ * monitored-domains` (or whichever path the macro-context module exposes).
+ */
+export class MonitoredDomainSystemParamResolver implements SystemParamResolver {
+	constructor(private readonly domains: MacroContext.MonitoredDomainRepository) {}
+
+	async resolve(input: {
+		projectId: string;
+		providerId: string;
+		endpointId: string;
+		params: Record<string, unknown>;
+	}): Promise<Record<string, unknown>> {
+		if (input.providerId !== 'cloudflare-radar') return {};
+		if (input.endpointId !== 'radar-domain-rank') return {};
+
+		const domain = input.params.domain;
+		if (typeof domain !== 'string' || domain.length === 0) {
+			throw new InvalidInputError(
+				'radar-domain-rank schedule requires `params.domain` (bare domain, no scheme).',
+			);
+		}
+
+		const found = await this.domains.findByProjectAndDomain(
+			input.projectId as ProjectManagement.ProjectId,
+			domain,
+		);
+		if (!found?.isActive()) {
+			throw new NotFoundError(
+				`Monitored domain ${domain} is not registered for project ${input.projectId}. ` +
+					'Register it first via POST /projects/:id/macro/monitored-domains.',
+			);
+		}
+
+		return { monitoredDomainId: found.id };
+	}
+}


### PR DESCRIPTION
2 cases of bug #50 family that slipped through #55:

1. **Bing resolver string mismatch** — checked `bing-webmaster-tools` but the registered provider id is `bing-webmaster` (chosen by #52). My fault in #55. Resolver was a permanent no-op, Bing schedules silently skipped ingest.

2. **Cloudflare Radar (#54)** was merged AFTER #55 and ships another `<X>Id in systemParams` requirement (`monitoredDomainId`). No resolver, same bug.

Fix:
- Correct Bing string + spec.
- Add `MonitoredDomainSystemParamResolver` in `macro-context`.
- Wire `MCUseCases` namespace + new resolver into composition-root.

Tests: 4 new unit tests for CF Radar resolver. 154 / 154 application tests pass. Lint clean.

This is exactly the failure mode predicted in #56. PR is a defensive patch, not the architectural fix.