### PR TITLE
feat: Microsoft Clarity provider + experience-analytics (#43)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
+		"@rankpulse/provider-microsoft-clarity": "workspace:*",
 		"@rankpulse/shared": "workspace:*",
 		"drizzle-orm": "0.45.2",
 		"helmet": "8.1.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { Tokens } from './composition/tokens.js';
 import type { AppEnv } from './config/env.js';
 import { BingWebmasterInsightsModule } from './modules/bing-webmaster-insights/bing-webmaster-insights.module.js';
 import { EntityAwarenessModule } from './modules/entity-awareness/entity-awareness.module.js';
+import { ExperienceAnalyticsModule } from './modules/experience-analytics/experience-analytics.module.js';
 import { HealthModule } from './modules/health/health.module.js';
 import { IdentityAccessModule } from './modules/identity-access/identity-access.module.js';
 import { MacroContextModule } from './modules/macro-context/macro-context.module.js';
@@ -52,6 +53,7 @@ export class AppModule {
 			TrafficAnalyticsModule,
 			BingWebmasterInsightsModule,
 			MacroContextModule,
+			ExperienceAnalyticsModule,
 		];
 		if (env.OPENAPI_ENABLED) imports.push(OpenApiModule);
 

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -2,6 +2,7 @@ import type { Provider, ValueProvider } from '@nestjs/common';
 import {
 	BingWebmasterInsights as BWIUseCases,
 	EntityAwareness as EAUseCases,
+	ExperienceAnalytics as EXAUseCases,
 	IdentityAccess as IAUseCases,
 	MacroContext as MCUseCases,
 	ProviderConnectivity as PCUseCases,
@@ -19,6 +20,7 @@ import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
 import { GscProvider } from '@rankpulse/provider-gsc';
+import { ClarityProvider } from '@rankpulse/provider-microsoft-clarity';
 import { InvalidInputError, SystemClock, SystemIdGenerator } from '@rankpulse/shared';
 import { JwtService } from '../common/auth/jwt.service.js';
 import type { AppEnv } from '../config/env.js';
@@ -80,6 +82,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	);
 	const monitoredDomainRepo = new DrizzlePersistence.DrizzleMonitoredDomainRepository(drizzle.db);
 	const radarRankSnapshotRepo = new DrizzlePersistence.DrizzleRadarRankSnapshotRepository(drizzle.db);
+	const clarityProjectRepo = new DrizzlePersistence.DrizzleClarityProjectRepository(drizzle.db);
+	const experienceSnapshotRepo = new DrizzlePersistence.DrizzleExperienceSnapshotRepository(drizzle.db);
 
 	const jobScheduler = new QueueAdapters.BullMqJobScheduler({
 		connection: { url: env.REDIS_URL },
@@ -91,6 +95,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	providerRegistry.register(new Ga4Provider());
 	providerRegistry.register(new BingProvider());
 	providerRegistry.register(new CloudflareRadarProvider());
+	providerRegistry.register(new ClarityProvider());
 
 	const registerOrganization = new IAUseCases.RegisterOrganizationUseCase(
 		orgRepo,
@@ -327,6 +332,19 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		radarRankSnapshotRepo,
 	);
 
+	// Issue #43 — experience-analytics use cases
+	const linkClarityProject = new EXAUseCases.LinkClarityProjectUseCase(
+		clarityProjectRepo,
+		SystemClock,
+		SystemIdGenerator,
+		eventPublisher,
+	);
+	const unlinkClarityProject = new EXAUseCases.UnlinkClarityProjectUseCase(clarityProjectRepo, SystemClock);
+	const queryExperienceHistory = new EXAUseCases.QueryExperienceHistoryUseCase(
+		clarityProjectRepo,
+		experienceSnapshotRepo,
+	);
+
 	// BACKLOG #23 / #21 — auto-schedule daily GSC fetch on property link.
 	// Subscribes to the in-memory event bus; the handler is fire-and-forget,
 	// errors are swallowed and logged so a scheduler outage doesn't 500 the
@@ -443,6 +461,12 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.AddMonitoredDomain, addMonitoredDomain),
 		value(Tokens.RemoveMonitoredDomain, removeMonitoredDomain),
 		value(Tokens.QueryRadarHistory, queryRadarHistory),
+
+		value(Tokens.ClarityProjectRepository, clarityProjectRepo),
+		value(Tokens.ExperienceSnapshotRepository, experienceSnapshotRepo),
+		value(Tokens.LinkClarityProject, linkClarityProject),
+		value(Tokens.UnlinkClarityProject, unlinkClarityProject),
+		value(Tokens.QueryExperienceHistory, queryExperienceHistory),
 	];
 
 	return {

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -131,6 +131,15 @@ export const Tokens = {
 	RemoveMonitoredDomain: Symbol('RemoveMonitoredDomainUseCase'),
 	QueryRadarHistory: Symbol('QueryRadarHistoryUseCase'),
 
+	// Experience-Analytics (Microsoft Clarity) ports
+	ClarityProjectRepository: Symbol('ClarityProjectRepository'),
+	ExperienceSnapshotRepository: Symbol('ExperienceSnapshotRepository'),
+
+	// Experience-Analytics use cases
+	LinkClarityProject: Symbol('LinkClarityProjectUseCase'),
+	UnlinkClarityProject: Symbol('UnlinkClarityProjectUseCase'),
+	QueryExperienceHistory: Symbol('QueryExperienceHistoryUseCase'),
+
 	// Infrastructure handles
 	DrizzleClient: Symbol('DrizzleClient'),
 	JwtService: Symbol('JwtService'),

--- a/apps/api/src/modules/experience-analytics/clarity.controller.ts
+++ b/apps/api/src/modules/experience-analytics/clarity.controller.ts
@@ -1,0 +1,116 @@
+import { Body, Controller, Delete, Get, Inject, Param, Post, Query } from '@nestjs/common';
+import type { ExperienceAnalytics as EXAUseCases } from '@rankpulse/application';
+import { ExperienceAnalyticsContracts } from '@rankpulse/contracts';
+import type { ExperienceAnalytics, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ForbiddenError, NotFoundError } from '@rankpulse/shared';
+import type { AuthPrincipal } from '../../common/auth/jwt.service.js';
+import { OrgMembership } from '../../common/auth/org-membership.guard.js';
+import { Principal } from '../../common/auth/principal.decorator.js';
+import { ZodValidationPipe } from '../../common/zod-validation.pipe.js';
+import { Tokens } from '../../composition/tokens.js';
+
+@Controller()
+export class ClarityController {
+	private readonly orgMembership: OrgMembership;
+
+	constructor(
+		@Inject(Tokens.LinkClarityProject) private readonly linkProject: EXAUseCases.LinkClarityProjectUseCase,
+		@Inject(Tokens.UnlinkClarityProject)
+		private readonly unlinkProject: EXAUseCases.UnlinkClarityProjectUseCase,
+		@Inject(Tokens.QueryExperienceHistory)
+		private readonly queryHistory: EXAUseCases.QueryExperienceHistoryUseCase,
+		@Inject(Tokens.ClarityProjectRepository)
+		private readonly projectsRepo: ExperienceAnalytics.ClarityProjectRepository,
+		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
+		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
+	) {
+		this.orgMembership = new OrgMembership(memberships);
+	}
+
+	@Get('projects/:projectId/clarity/projects')
+	async listForProject(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<ExperienceAnalyticsContracts.ClarityProjectDto[]> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		const list = await this.projectsRepo.listForProject(project.id);
+		return list.map((c) => this.serialize(c));
+	}
+
+	@Post('projects/:projectId/clarity/projects')
+	async link(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Body(new ZodValidationPipe(ExperienceAnalyticsContracts.LinkClarityProjectRequest))
+		body: ExperienceAnalyticsContracts.LinkClarityProjectRequest,
+	): Promise<{ clarityProjectId: string }> {
+		const project = await this.loadProject(projectId);
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.linkProject.execute({
+			organizationId: project.organizationId,
+			projectId: project.id,
+			clarityHandle: body.clarityHandle,
+			credentialId: body.credentialId ?? null,
+		});
+	}
+
+	@Delete('clarity/projects/:clarityProjectId')
+	async unlink(
+		@Principal() principal: AuthPrincipal,
+		@Param('clarityProjectId') clarityProjectId: string,
+	): Promise<{ ok: true }> {
+		await this.requireAccessToClarityProject(principal, clarityProjectId);
+		await this.unlinkProject.execute({ clarityProjectId });
+		return { ok: true };
+	}
+
+	@Get('clarity/projects/:clarityProjectId/history')
+	async history(
+		@Principal() principal: AuthPrincipal,
+		@Param('clarityProjectId') clarityProjectId: string,
+		@Query(new ZodValidationPipe(ExperienceAnalyticsContracts.ExperienceHistoryQuery))
+		q: ExperienceAnalyticsContracts.ExperienceHistoryQuery,
+	): Promise<ExperienceAnalyticsContracts.ExperienceHistoryRowDto[]> {
+		await this.requireAccessToClarityProject(principal, clarityProjectId);
+		const result = await this.queryHistory.execute({ clarityProjectId, from: q.from, to: q.to });
+		return [...result];
+	}
+
+	private async loadProject(id: string): Promise<ProjectManagement.Project> {
+		const project = await this.projects.findById(id as ProjectManagement.ProjectId);
+		if (!project) throw new NotFoundError(`Project ${id} not found`);
+		return project;
+	}
+
+	private async requireAccessToClarityProject(
+		principal: AuthPrincipal,
+		clarityProjectId: string,
+	): Promise<void> {
+		// Same IDOR-safe 404-collapse used elsewhere.
+		const cp = await this.projectsRepo.findById(clarityProjectId as ExperienceAnalytics.ClarityProjectId);
+		if (!cp) throw new NotFoundError(`ClarityProject ${clarityProjectId} not found`);
+		const project = await this.projects.findById(cp.projectId);
+		if (!project) throw new NotFoundError(`ClarityProject ${clarityProjectId} not found`);
+		try {
+			await this.orgMembership.require(principal, project.organizationId);
+		} catch (err) {
+			if (err instanceof ForbiddenError) {
+				throw new NotFoundError(`ClarityProject ${clarityProjectId} not found`);
+			}
+			throw err;
+		}
+	}
+
+	private serialize(c: ExperienceAnalytics.ClarityProject): ExperienceAnalyticsContracts.ClarityProjectDto {
+		return {
+			id: c.id,
+			projectId: c.projectId,
+			clarityHandle: c.clarityHandle.value,
+			credentialId: c.credentialId,
+			linkedAt: c.linkedAt.toISOString(),
+			unlinkedAt: c.unlinkedAt ? c.unlinkedAt.toISOString() : null,
+			isActive: c.isActive(),
+		};
+	}
+}

--- a/apps/api/src/modules/experience-analytics/experience-analytics.module.ts
+++ b/apps/api/src/modules/experience-analytics/experience-analytics.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ClarityController } from './clarity.controller.js';
+
+@Module({
+	controllers: [ClarityController],
+})
+export class ExperienceAnalyticsModule {}

--- a/apps/web/src/components/link-clarity-drawer.tsx
+++ b/apps/web/src/components/link-clarity-drawer.tsx
@@ -1,0 +1,92 @@
+import { Button, Drawer, FormField, Input } from '@rankpulse/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { type FormEvent, useState } from 'react';
+import { api } from '../lib/api.js';
+
+export interface LinkClarityDrawerProps {
+	projectId: string;
+	open: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Issue #43 — atomic-design organism. Mobile-first drawer to link a
+ * Microsoft Clarity project so RankPulse can pull daily UX metrics
+ * (sessions, distinct users, rage clicks, dead clicks, scroll depth,
+ * engagement time).
+ */
+export const LinkClarityDrawer = ({ projectId, open, onClose }: LinkClarityDrawerProps) => {
+	const qc = useQueryClient();
+	const [clarityHandle, setClarityHandle] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = (): void => {
+		setClarityHandle('');
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => api.clarity.link(projectId, { clarityHandle }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ['project', projectId, 'clarity'] });
+			reset();
+			onClose();
+		},
+		onError: (err) => setError(err instanceof Error ? err.message : 'Failed to link Clarity project'),
+	});
+
+	const onSubmit = (e: FormEvent): void => {
+		e.preventDefault();
+		setError(null);
+		mutation.mutate();
+	};
+
+	return (
+		<Drawer
+			open={open}
+			onClose={() => {
+				reset();
+				onClose();
+			}}
+			title="Link Microsoft Clarity"
+			description="Daily UX metrics — sessions, distinct users, rage clicks, dead clicks, scroll depth, engagement time."
+			footer={
+				<>
+					<Button variant="ghost" type="button" onClick={onClose} disabled={mutation.isPending}>
+						Cancel
+					</Button>
+					<Button type="submit" form="link-clarity-form" disabled={mutation.isPending || !clarityHandle}>
+						{mutation.isPending ? 'Linking…' : 'Link project'}
+					</Button>
+				</>
+			}
+		>
+			<form id="link-clarity-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+				<FormField
+					label="Clarity project handle"
+					hint="The 8-32 character slug from your Clarity dashboard URL (clarity.microsoft.com/projects/<handle>)."
+				>
+					{(id) => (
+						<Input
+							id={id}
+							value={clarityHandle}
+							onChange={(e) => setClarityHandle(e.target.value.trim())}
+							placeholder="claritySlug42"
+							required
+							autoFocus
+						/>
+					)}
+				</FormField>
+				<p className="text-xs text-muted-foreground">
+					Generate the API token in Clarity → Settings → Data Export → Generate Token. The free tier gives 10
+					req/day per project, plenty for one daily ingest cron.
+				</p>
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+			</form>
+		</Drawer>
+	);
+};

--- a/apps/web/src/pages/project-detail.page.tsx
+++ b/apps/web/src/pages/project-detail.page.tsx
@@ -10,6 +10,7 @@ import {
 	Globe2,
 	LineChart,
 	MapPin,
+	MousePointerClick,
 	Plus,
 	Radar,
 	Search,
@@ -24,6 +25,7 @@ import { AddRadarDomainDrawer } from '../components/add-radar-domain-drawer.js';
 import { AppShell } from '../components/app-shell.js';
 import { ImportKeywordsDrawer } from '../components/import-keywords-drawer.js';
 import { LinkBingDrawer } from '../components/link-bing-drawer.js';
+import { LinkClarityDrawer } from '../components/link-clarity-drawer.js';
 import { LinkGa4Drawer } from '../components/link-ga4-drawer.js';
 import { LinkWikipediaDrawer } from '../components/link-wikipedia-drawer.js';
 import { TrackPageDrawer } from '../components/track-page-drawer.js';
@@ -41,6 +43,7 @@ export const ProjectDetailPage = () => {
 		| 'ga4'
 		| 'bing'
 		| 'radar'
+		| 'clarity'
 		| null
 	>(null);
 
@@ -94,6 +97,12 @@ export const ProjectDetailPage = () => {
 	const radarQuery = useQuery({
 		queryKey: ['project', id, 'radar'],
 		queryFn: () => api.radar.listForProject(id),
+		enabled: Boolean(projectQuery.data),
+	});
+
+	const clarityQuery = useQuery({
+		queryKey: ['project', id, 'clarity'],
+		queryFn: () => api.clarity.listForProject(id),
 		enabled: Boolean(projectQuery.data),
 	});
 
@@ -392,6 +401,46 @@ export const ProjectDetailPage = () => {
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between gap-2">
 							<CardTitle className="flex items-center gap-2 text-base">
+								<MousePointerClick size={14} className="text-primary" />
+								Clarity ({clarityQuery.data?.length ?? '…'})
+							</CardTitle>
+							<Button variant="ghost" size="sm" onClick={() => setOpenDrawer('clarity')}>
+								<Plus size={14} />
+								Link
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{clarityQuery.isLoading ? (
+								<Spinner />
+							) : clarityQuery.data && clarityQuery.data.length > 0 ? (
+								<ul className="space-y-1 text-sm">
+									{clarityQuery.data.map((c) => (
+										<li key={c.id} className="break-words">
+											<Badge variant={c.isActive ? 'default' : 'secondary'}>
+												{c.isActive ? 'active' : 'unlinked'}
+											</Badge>{' '}
+											<span className="text-muted-foreground">{c.clarityHandle}</span>
+										</li>
+									))}
+								</ul>
+							) : (
+								<EmptyState
+									title="No Clarity project linked"
+									description="Link a Microsoft Clarity project to track sessions, rage clicks, dead clicks, scroll depth, and engagement time as UX behavioural signals."
+									action={
+										<Button size="sm" onClick={() => setOpenDrawer('clarity')}>
+											<Plus size={14} />
+											Link project
+										</Button>
+									}
+								/>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between gap-2">
+							<CardTitle className="flex items-center gap-2 text-base">
 								<Globe2 size={14} className="text-primary" />
 								Bing properties ({bingQuery.data?.length ?? '…'})
 							</CardTitle>
@@ -581,6 +630,7 @@ export const ProjectDetailPage = () => {
 				open={openDrawer === 'radar'}
 				onClose={() => setOpenDrawer(null)}
 			/>
+			<LinkClarityDrawer projectId={id} open={openDrawer === 'clarity'} onClose={() => setOpenDrawer(null)} />
 		</AppShell>
 	);
 };

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -25,6 +25,7 @@
 		"@rankpulse/provider-dataforseo": "workspace:*",
 		"@rankpulse/provider-ga4": "workspace:*",
 		"@rankpulse/provider-gsc": "workspace:*",
+		"@rankpulse/provider-microsoft-clarity": "workspace:*",
 		"@rankpulse/provider-pagespeed": "workspace:*",
 		"@rankpulse/provider-wikipedia": "workspace:*",
 		"@rankpulse/shared": "workspace:*",

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,7 @@
 import {
 	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
+	ExperienceAnalytics as ExperienceAnalyticsUseCases,
 	MacroContext as MacroContextUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
@@ -49,6 +50,8 @@ async function bootstrap(): Promise<void> {
 	);
 	const monitoredDomainRepo = new DrizzlePersistence.DrizzleMonitoredDomainRepository(drizzle.db);
 	const radarRankSnapshotRepo = new DrizzlePersistence.DrizzleRadarRankSnapshotRepository(drizzle.db);
+	const clarityProjectRepo = new DrizzlePersistence.DrizzleClarityProjectRepository(drizzle.db);
+	const experienceSnapshotRepo = new DrizzlePersistence.DrizzleExperienceSnapshotRepository(drizzle.db);
 
 	const vault = new Crypto.LibsodiumCredentialVault(env.RANKPULSE_MASTER_KEY);
 	const eventPublisher = new Events.InMemoryEventPublisher();
@@ -117,6 +120,12 @@ async function bootstrap(): Promise<void> {
 		eventPublisher,
 		SystemClock,
 	);
+	const recordExperienceSnapshotUseCase = new ExperienceAnalyticsUseCases.RecordExperienceSnapshotUseCase(
+		clarityProjectRepo,
+		experienceSnapshotRepo,
+		eventPublisher,
+		SystemClock,
+	);
 
 	const processor = new ProviderFetchProcessor({
 		registry,
@@ -133,6 +142,7 @@ async function bootstrap(): Promise<void> {
 		ga4PropertyRepo,
 		bingPropertyRepo,
 		monitoredDomainRepo,
+		clarityProjectRepo,
 		vault,
 		resolveCredentialUseCase,
 		recordApiUsageUseCase,
@@ -144,6 +154,7 @@ async function bootstrap(): Promise<void> {
 		ingestGa4RowsUseCase,
 		ingestBingTrafficUseCase,
 		recordRadarRankUseCase,
+		recordExperienceSnapshotUseCase,
 		clock: SystemClock,
 		ids: SystemIdGenerator,
 		logger,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -1,6 +1,7 @@
 import type {
 	BingWebmasterInsights as BingWebmasterInsightsUseCases,
 	EntityAwareness as EntityAwarenessUseCases,
+	ExperienceAnalytics as ExperienceAnalyticsUseCases,
 	MacroContext as MacroContextUseCases,
 	ProjectManagement as ProjectManagementUseCases,
 	ProviderConnectivity as ProviderConnectivityUseCases,
@@ -12,6 +13,7 @@ import type {
 import {
 	type BingWebmasterInsights as BingWebmasterInsightsDomain,
 	type EntityAwareness as EntityAwarenessDomain,
+	type ExperienceAnalytics as ExperienceAnalyticsDomain,
 	type MacroContext as MacroContextDomain,
 	type ProjectManagement,
 	ProviderConnectivity,
@@ -49,6 +51,11 @@ import {
 	type SearchAnalyticsParams,
 	type SearchAnalyticsResponse,
 } from '@rankpulse/provider-gsc';
+import {
+	ClarityApiError,
+	type DataExportResponse,
+	extractSnapshot as extractClaritySnapshot,
+} from '@rankpulse/provider-microsoft-clarity';
 import { extractSnapshot, PageSpeedApiError, type RunPagespeedResponse } from '@rankpulse/provider-pagespeed';
 import {
 	extractPageviews,
@@ -97,6 +104,9 @@ const isQuotaExhaustedError = (err: unknown): boolean => {
 	// Cloudflare Radar enforces per-account rate limits at the platform edge;
 	// 429 is the throttle signal. Auto-pause until the operator topples up.
 	if (err instanceof CloudflareRadarApiError && (err.status === 402 || err.status === 429)) return true;
+	// Microsoft Clarity allows 10 req/day per project on the free tier;
+	// 429 once the budget is spent. Auto-pause until the next day window.
+	if (err instanceof ClarityApiError && (err.status === 402 || err.status === 429)) return true;
 	return false;
 };
 
@@ -121,6 +131,7 @@ export interface ProviderFetchProcessorDeps {
 	ga4PropertyRepo: TrafficAnalyticsDomain.Ga4PropertyRepository;
 	bingPropertyRepo: BingWebmasterInsightsDomain.BingPropertyRepository;
 	monitoredDomainRepo: MacroContextDomain.MonitoredDomainRepository;
+	clarityProjectRepo: ExperienceAnalyticsDomain.ClarityProjectRepository;
 	vault: ProviderConnectivity.CredentialVault;
 	resolveCredentialUseCase: ProviderConnectivityUseCases.ResolveProviderCredentialUseCase;
 	recordApiUsageUseCase: ProviderConnectivityUseCases.RecordApiUsageUseCase;
@@ -132,6 +143,7 @@ export interface ProviderFetchProcessorDeps {
 	ingestGa4RowsUseCase: TrafficAnalyticsUseCases.IngestGa4RowsUseCase;
 	ingestBingTrafficUseCase: BingWebmasterInsightsUseCases.IngestBingTrafficUseCase;
 	recordRadarRankUseCase: MacroContextUseCases.RecordRadarRankUseCase;
+	recordExperienceSnapshotUseCase: ExperienceAnalyticsUseCases.RecordExperienceSnapshotUseCase;
 	clock: Clock;
 	ids: IdGenerator;
 	logger: Logger;
@@ -412,6 +424,40 @@ export class ProviderFetchProcessor {
 						gscPropertyId: gscParams.gscPropertyId,
 						rawPayloadId,
 						rows,
+					});
+				}
+			}
+
+			if (
+				definition.providerId.value === 'microsoft-clarity' &&
+				definition.endpointId.value === 'clarity-data-export'
+			) {
+				// Issue #43 — experience-analytics ingest. The job's systemParams
+				// must carry `clarityProjectId`. The ACL needs an observed date,
+				// which we pin to the cron's wall-clock day (Clarity returns
+				// aggregated metrics over the requested numOfDays window — we
+				// stamp it as the day the cron fired).
+				const clarityParams = resolvedParams as { clarityProjectId?: string };
+				if (!clarityParams.clarityProjectId) {
+					runLog.warn(
+						{},
+						'clarity-data-export job missing clarityProjectId in systemParams; skipping ingest',
+					);
+				} else {
+					const observedDate = this.deps.clock.now().toISOString().slice(0, 10);
+					const snap = extractClaritySnapshot(fetchResult as DataExportResponse, observedDate);
+					await this.deps.recordExperienceSnapshotUseCase.execute({
+						clarityProjectId: clarityParams.clarityProjectId,
+						observedDate: snap.observedDate,
+						sessionsCount: snap.sessionsCount,
+						botSessionsCount: snap.botSessionsCount,
+						distinctUserCount: snap.distinctUserCount,
+						pagesPerSession: snap.pagesPerSession,
+						rageClicks: snap.rageClicks,
+						deadClicks: snap.deadClicks,
+						avgEngagementSeconds: snap.avgEngagementSeconds,
+						avgScrollDepth: snap.avgScrollDepth,
+						rawPayloadId,
 					});
 				}
 			}

--- a/apps/worker/src/providers/registry.ts
+++ b/apps/worker/src/providers/registry.ts
@@ -4,6 +4,7 @@ import { ProviderRegistry } from '@rankpulse/provider-core';
 import { DataForSeoProvider } from '@rankpulse/provider-dataforseo';
 import { Ga4Provider } from '@rankpulse/provider-ga4';
 import { GscProvider } from '@rankpulse/provider-gsc';
+import { ClarityProvider } from '@rankpulse/provider-microsoft-clarity';
 import { PageSpeedProvider } from '@rankpulse/provider-pagespeed';
 import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
 
@@ -20,5 +21,6 @@ export function buildProviderRegistry(options: { dataforseoBaseUrl: string }): P
 	registry.register(new PageSpeedProvider());
 	registry.register(new BingProvider());
 	registry.register(new CloudflareRadarProvider());
+	registry.register(new ClarityProvider());
 	return registry;
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -21,6 +21,11 @@
 			"types": "./dist/entity-awareness/index.d.ts",
 			"default": "./dist/entity-awareness/index.js"
 		},
+		"./experience-analytics": {
+			"development": "./src/experience-analytics/index.ts",
+			"types": "./dist/experience-analytics/index.d.ts",
+			"default": "./dist/experience-analytics/index.js"
+		},
 		"./identity-access": {
 			"development": "./src/identity-access/index.ts",
 			"types": "./dist/identity-access/index.d.ts",

--- a/packages/application/src/experience-analytics/index.ts
+++ b/packages/application/src/experience-analytics/index.ts
@@ -1,0 +1,4 @@
+export * from './use-cases/link-clarity-project.use-case.js';
+export * from './use-cases/query-experience-history.use-case.js';
+export * from './use-cases/record-experience-snapshot.use-case.js';
+export * from './use-cases/unlink-clarity-project.use-case.js';

--- a/packages/application/src/experience-analytics/use-cases/link-clarity-project.use-case.ts
+++ b/packages/application/src/experience-analytics/use-cases/link-clarity-project.use-case.ts
@@ -1,0 +1,50 @@
+import {
+	ExperienceAnalytics,
+	type IdentityAccess,
+	type ProjectManagement,
+	type SharedKernel,
+} from '@rankpulse/domain';
+import { type Clock, ConflictError, type IdGenerator } from '@rankpulse/shared';
+
+export interface LinkClarityProjectCommand {
+	organizationId: string;
+	projectId: string;
+	clarityHandle: string;
+	credentialId?: string | null;
+}
+
+export interface LinkClarityProjectResult {
+	clarityProjectId: string;
+}
+
+export class LinkClarityProjectUseCase {
+	constructor(
+		private readonly projects: ExperienceAnalytics.ClarityProjectRepository,
+		private readonly clock: Clock,
+		private readonly ids: IdGenerator,
+		private readonly events: SharedKernel.EventPublisher,
+	) {}
+
+	async execute(cmd: LinkClarityProjectCommand): Promise<LinkClarityProjectResult> {
+		const projectId = cmd.projectId as ProjectManagement.ProjectId;
+		// Canonicalise via the VO so the lookup matches the row we'd write.
+		const handle = ExperienceAnalytics.ClarityProjectHandle.create(cmd.clarityHandle);
+		const existing = await this.projects.findByProjectAndHandle(projectId, handle.value);
+		if (existing?.isActive()) {
+			throw new ConflictError(`Clarity project ${handle.value} is already linked to this project`);
+		}
+
+		const id = this.ids.generate() as ExperienceAnalytics.ClarityProjectId;
+		const cp = ExperienceAnalytics.ClarityProject.link({
+			id,
+			organizationId: cmd.organizationId as IdentityAccess.OrganizationId,
+			projectId,
+			clarityHandle: handle.value,
+			credentialId: cmd.credentialId ?? null,
+			now: this.clock.now(),
+		});
+		await this.projects.save(cp);
+		await this.events.publish(cp.pullEvents());
+		return { clarityProjectId: id };
+	}
+}

--- a/packages/application/src/experience-analytics/use-cases/query-experience-history.use-case.ts
+++ b/packages/application/src/experience-analytics/use-cases/query-experience-history.use-case.ts
@@ -1,0 +1,44 @@
+import type { ExperienceAnalytics } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryExperienceHistoryCommand {
+	clarityProjectId: string;
+	from: string;
+	to: string;
+}
+
+export interface ExperienceHistoryView {
+	observedDate: string;
+	sessionsCount: number;
+	botSessionsCount: number;
+	distinctUserCount: number;
+	pagesPerSession: number;
+	rageClicks: number;
+	deadClicks: number;
+	avgEngagementSeconds: number;
+	avgScrollDepth: number;
+}
+
+export class QueryExperienceHistoryUseCase {
+	constructor(
+		private readonly projects: ExperienceAnalytics.ClarityProjectRepository,
+		private readonly snapshots: ExperienceAnalytics.ExperienceSnapshotRepository,
+	) {}
+
+	async execute(cmd: QueryExperienceHistoryCommand): Promise<readonly ExperienceHistoryView[]> {
+		const cp = await this.projects.findById(cmd.clarityProjectId as ExperienceAnalytics.ClarityProjectId);
+		if (!cp) throw new NotFoundError(`ClarityProject ${cmd.clarityProjectId} not found`);
+		const rows = await this.snapshots.listForClarityProject(cp.id, { from: cmd.from, to: cmd.to });
+		return rows.map((r) => ({
+			observedDate: r.observedDate,
+			sessionsCount: r.metrics.sessionsCount,
+			botSessionsCount: r.metrics.botSessionsCount,
+			distinctUserCount: r.metrics.distinctUserCount,
+			pagesPerSession: r.metrics.pagesPerSession,
+			rageClicks: r.metrics.rageClicks,
+			deadClicks: r.metrics.deadClicks,
+			avgEngagementSeconds: r.metrics.avgEngagementSeconds,
+			avgScrollDepth: r.metrics.avgScrollDepth,
+		}));
+	}
+}

--- a/packages/application/src/experience-analytics/use-cases/record-experience-snapshot.use-case.spec.ts
+++ b/packages/application/src/experience-analytics/use-cases/record-experience-snapshot.use-case.spec.ts
@@ -1,0 +1,132 @@
+import type { ExperienceAnalytics, IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LinkClarityProjectUseCase } from './link-clarity-project.use-case.js';
+import { RecordExperienceSnapshotUseCase } from './record-experience-snapshot.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+class InMemoryProjectRepo implements ExperienceAnalytics.ClarityProjectRepository {
+	readonly store = new Map<string, ExperienceAnalytics.ClarityProject>();
+	readonly byTuple = new Map<string, ExperienceAnalytics.ClarityProject>();
+	async save(cp: ExperienceAnalytics.ClarityProject): Promise<void> {
+		this.store.set(cp.id, cp);
+		this.byTuple.set(`${cp.projectId}|${cp.clarityHandle.value}`, cp);
+	}
+	async findById(
+		id: ExperienceAnalytics.ClarityProjectId,
+	): Promise<ExperienceAnalytics.ClarityProject | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(
+		projectId: ProjectManagement.ProjectId,
+		handle: string,
+	): Promise<ExperienceAnalytics.ClarityProject | null> {
+		return this.byTuple.get(`${projectId}|${handle}`) ?? null;
+	}
+	async listForProject(): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		return [];
+	}
+}
+
+class InMemorySnapshotRepo implements ExperienceAnalytics.ExperienceSnapshotRepository {
+	readonly store = new Map<string, ExperienceAnalytics.ExperienceSnapshot>();
+	async save(snap: ExperienceAnalytics.ExperienceSnapshot): Promise<{ inserted: boolean }> {
+		const k = `${snap.clarityProjectId}|${snap.observedDate}`;
+		if (this.store.has(k)) return { inserted: false };
+		this.store.set(k, snap);
+		return { inserted: true };
+	}
+	async listForClarityProject(): Promise<readonly ExperienceAnalytics.ExperienceSnapshot[]> {
+		return [...this.store.values()];
+	}
+}
+
+describe('RecordExperienceSnapshotUseCase', () => {
+	let projectRepo: InMemoryProjectRepo;
+	let snapshotRepo: InMemorySnapshotRepo;
+	let events: RecordingEventPublisher;
+	let clarityProjectId: string;
+
+	beforeEach(async () => {
+		projectRepo = new InMemoryProjectRepo();
+		snapshotRepo = new InMemorySnapshotRepo();
+		events = new RecordingEventPublisher();
+		const linker = new LinkClarityProjectUseCase(
+			projectRepo,
+			new FakeClock('2026-05-04T10:00:00Z'),
+			new FixedIdGenerator(['cp-1' as Uuid]),
+			events,
+		);
+		const result = await linker.execute({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+			clarityHandle: 'claritySlug42',
+		});
+		clarityProjectId = result.clarityProjectId;
+		events.clear();
+	});
+
+	const baseCommand = (overrides: Partial<{ avgScrollDepth: number; sessionsCount: number }> = {}) => ({
+		clarityProjectId,
+		observedDate: '2026-05-01',
+		sessionsCount: overrides.sessionsCount ?? 12_500,
+		botSessionsCount: 1_200,
+		distinctUserCount: 8_400,
+		pagesPerSession: 3.4,
+		rageClicks: 47,
+		deadClicks: 19,
+		avgEngagementSeconds: 142.7,
+		avgScrollDepth: overrides.avgScrollDepth ?? 0.62,
+		rawPayloadId: null,
+	});
+
+	const buildUseCase = () =>
+		new RecordExperienceSnapshotUseCase(
+			projectRepo,
+			snapshotRepo,
+			events,
+			new FakeClock('2026-05-04T11:00:00Z'),
+		);
+
+	it('persists the snapshot and publishes ExperienceSnapshotRecorded on first insert', async () => {
+		const useCase = buildUseCase();
+		const result = await useCase.execute(baseCommand());
+		expect(result.inserted).toBe(true);
+		expect(snapshotRepo.store.size).toBe(1);
+		expect(events.publishedTypes()).toContain('ExperienceSnapshotRecorded');
+	});
+
+	it('does NOT publish event on idempotent re-fetch (same observedDate)', async () => {
+		const useCase = buildUseCase();
+		await useCase.execute(baseCommand());
+		events.clear();
+		const second = await useCase.execute(baseCommand());
+		expect(second.inserted).toBe(false);
+		expect(events.published()).toEqual([]);
+	});
+
+	it('throws NotFoundError when the clarity project does not exist', async () => {
+		const useCase = buildUseCase();
+		await expect(useCase.execute({ ...baseCommand(), clarityProjectId: 'missing' })).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+
+	it('rejects scroll depth outside [0, 1] at the aggregate boundary', async () => {
+		const useCase = buildUseCase();
+		await expect(useCase.execute({ ...baseCommand(), avgScrollDepth: 1.5 })).rejects.toThrow();
+		await expect(useCase.execute({ ...baseCommand(), avgScrollDepth: -0.1 })).rejects.toThrow();
+		expect(snapshotRepo.store.size).toBe(0);
+	});
+
+	it('rejects negative session counts at the aggregate boundary', async () => {
+		const useCase = buildUseCase();
+		await expect(useCase.execute({ ...baseCommand(), sessionsCount: -1 })).rejects.toThrow();
+	});
+});

--- a/packages/application/src/experience-analytics/use-cases/record-experience-snapshot.use-case.ts
+++ b/packages/application/src/experience-analytics/use-cases/record-experience-snapshot.use-case.ts
@@ -1,0 +1,72 @@
+import { ExperienceAnalytics, type SharedKernel } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface RecordExperienceSnapshotCommand {
+	clarityProjectId: string;
+	observedDate: string;
+	sessionsCount: number;
+	botSessionsCount: number;
+	distinctUserCount: number;
+	pagesPerSession: number;
+	rageClicks: number;
+	deadClicks: number;
+	avgEngagementSeconds: number;
+	avgScrollDepth: number;
+	rawPayloadId: string | null;
+}
+
+export interface RecordExperienceSnapshotResult {
+	inserted: boolean;
+}
+
+/**
+ * Record a single Clarity daily-metrics snapshot. Returns `inserted` so the
+ * worker only emits the `ExperienceSnapshotRecorded` event on first write —
+ * idempotent re-fetches on the same `(project, observedDate)` are no-ops.
+ */
+export class RecordExperienceSnapshotUseCase {
+	constructor(
+		private readonly projects: ExperienceAnalytics.ClarityProjectRepository,
+		private readonly snapshots: ExperienceAnalytics.ExperienceSnapshotRepository,
+		private readonly events: SharedKernel.EventPublisher,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: RecordExperienceSnapshotCommand): Promise<RecordExperienceSnapshotResult> {
+		const cp = await this.projects.findById(cmd.clarityProjectId as ExperienceAnalytics.ClarityProjectId);
+		if (!cp) throw new NotFoundError(`ClarityProject ${cmd.clarityProjectId} not found`);
+		if (!cp.isActive()) return { inserted: false };
+
+		const snapshot = ExperienceAnalytics.ExperienceSnapshot.record({
+			clarityProjectId: cp.id,
+			projectId: cp.projectId,
+			observedDate: cmd.observedDate,
+			metrics: ExperienceAnalytics.ExperienceMetrics.create({
+				sessionsCount: cmd.sessionsCount,
+				botSessionsCount: cmd.botSessionsCount,
+				distinctUserCount: cmd.distinctUserCount,
+				pagesPerSession: cmd.pagesPerSession,
+				rageClicks: cmd.rageClicks,
+				deadClicks: cmd.deadClicks,
+				avgEngagementSeconds: cmd.avgEngagementSeconds,
+				avgScrollDepth: cmd.avgScrollDepth,
+			}),
+			rawPayloadId: cmd.rawPayloadId,
+		});
+
+		const { inserted } = await this.snapshots.save(snapshot);
+		if (inserted) {
+			await this.events.publish([
+				new ExperienceAnalytics.ExperienceSnapshotRecorded({
+					clarityProjectId: cp.id,
+					projectId: cp.projectId,
+					observedDate: cmd.observedDate,
+					sessionsCount: cmd.sessionsCount,
+					rageClicks: cmd.rageClicks,
+					occurredAt: this.clock.now(),
+				}),
+			]);
+		}
+		return { inserted };
+	}
+}

--- a/packages/application/src/experience-analytics/use-cases/unlink-clarity-project.use-case.ts
+++ b/packages/application/src/experience-analytics/use-cases/unlink-clarity-project.use-case.ts
@@ -1,0 +1,21 @@
+import type { ExperienceAnalytics } from '@rankpulse/domain';
+import { type Clock, NotFoundError } from '@rankpulse/shared';
+
+export interface UnlinkClarityProjectCommand {
+	clarityProjectId: string;
+}
+
+export class UnlinkClarityProjectUseCase {
+	constructor(
+		private readonly projects: ExperienceAnalytics.ClarityProjectRepository,
+		private readonly clock: Clock,
+	) {}
+
+	async execute(cmd: UnlinkClarityProjectCommand): Promise<void> {
+		const cp = await this.projects.findById(cmd.clarityProjectId as ExperienceAnalytics.ClarityProjectId);
+		if (!cp) throw new NotFoundError(`ClarityProject ${cmd.clarityProjectId} not found`);
+		if (!cp.isActive()) return; // idempotent
+		cp.unlink(this.clock.now());
+		await this.projects.save(cp);
+	}
+}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,5 +1,6 @@
 export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
+export * as ExperienceAnalytics from './experience-analytics/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as MacroContext from './macro-context/index.js';
 export * as ProjectManagement from './project-management/index.js';

--- a/packages/contracts/src/experience-analytics/index.ts
+++ b/packages/contracts/src/experience-analytics/index.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+const ClarityHandle = z.string().regex(/^[a-zA-Z0-9]{8,32}$/, 'must be 8-32 alphanumeric characters');
+
+export const LinkClarityProjectRequest = z.object({
+	clarityHandle: ClarityHandle,
+	credentialId: z.string().uuid().nullable().optional(),
+});
+export type LinkClarityProjectRequest = z.infer<typeof LinkClarityProjectRequest>;
+
+export const ClarityProjectDto = z.object({
+	id: z.string().uuid(),
+	projectId: z.string().uuid(),
+	clarityHandle: z.string(),
+	credentialId: z.string().uuid().nullable(),
+	linkedAt: z.string().datetime(),
+	unlinkedAt: z.string().datetime().nullable(),
+	isActive: z.boolean(),
+});
+export type ClarityProjectDto = z.infer<typeof ClarityProjectDto>;
+
+const DateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'must be YYYY-MM-DD');
+
+export const ExperienceHistoryQuery = z.object({
+	from: DateString,
+	to: DateString,
+});
+export type ExperienceHistoryQuery = z.infer<typeof ExperienceHistoryQuery>;
+
+export const ExperienceHistoryRowDto = z.object({
+	observedDate: z.string(),
+	sessionsCount: z.number().int().nonnegative(),
+	botSessionsCount: z.number().int().nonnegative(),
+	distinctUserCount: z.number().int().nonnegative(),
+	pagesPerSession: z.number().nonnegative(),
+	rageClicks: z.number().int().nonnegative(),
+	deadClicks: z.number().int().nonnegative(),
+	avgEngagementSeconds: z.number().nonnegative(),
+	avgScrollDepth: z.number().min(0).max(1),
+});
+export type ExperienceHistoryRowDto = z.infer<typeof ExperienceHistoryRowDto>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export * as BingWebmasterInsightsContracts from './bing-webmaster-insights/index.js';
 export * as EntityAwarenessContracts from './entity-awareness/index.js';
+export * as ExperienceAnalyticsContracts from './experience-analytics/index.js';
 export * as IdentityAccessContracts from './identity-access/index.js';
 export * as MacroContextContracts from './macro-context/index.js';
 export * as ProjectManagementContracts from './project-management/index.js';

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -21,6 +21,11 @@
 			"types": "./dist/entity-awareness/index.d.ts",
 			"default": "./dist/entity-awareness/index.js"
 		},
+		"./experience-analytics": {
+			"development": "./src/experience-analytics/index.ts",
+			"types": "./dist/experience-analytics/index.d.ts",
+			"default": "./dist/experience-analytics/index.js"
+		},
 		"./identity-access": {
 			"development": "./src/identity-access/index.ts",
 			"types": "./dist/identity-access/index.d.ts",

--- a/packages/domain/src/experience-analytics/entities/clarity-project.ts
+++ b/packages/domain/src/experience-analytics/entities/clarity-project.ts
@@ -1,0 +1,95 @@
+import { ConflictError } from '@rankpulse/shared';
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import { ClarityProjectLinked } from '../events/clarity-project-linked.js';
+import { ClarityProjectHandle } from '../value-objects/clarity-handle.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export interface ClarityProjectProps {
+	id: ClarityProjectId;
+	organizationId: OrganizationId;
+	projectId: ProjectId;
+	clarityHandle: ClarityProjectHandle;
+	credentialId: string | null;
+	linkedAt: Date;
+	unlinkedAt: Date | null;
+}
+
+/**
+ * A Microsoft Clarity project linked to a RankPulse project. The aggregate
+ * is the parent of the experience-metrics time-series; snapshots are
+ * value-like rows that don't fan-out events per row.
+ */
+export class ClarityProject extends AggregateRoot {
+	private constructor(private props: ClarityProjectProps) {
+		super();
+	}
+
+	static link(input: {
+		id: ClarityProjectId;
+		organizationId: OrganizationId;
+		projectId: ProjectId;
+		clarityHandle: string;
+		credentialId: string | null;
+		now: Date;
+	}): ClarityProject {
+		const handle = ClarityProjectHandle.create(input.clarityHandle);
+		const cp = new ClarityProject({
+			id: input.id,
+			organizationId: input.organizationId,
+			projectId: input.projectId,
+			clarityHandle: handle,
+			credentialId: input.credentialId,
+			linkedAt: input.now,
+			unlinkedAt: null,
+		});
+		cp.record(
+			new ClarityProjectLinked({
+				clarityProjectId: input.id,
+				projectId: input.projectId,
+				organizationId: input.organizationId,
+				clarityHandle: handle.value,
+				occurredAt: input.now,
+			}),
+		);
+		return cp;
+	}
+
+	static rehydrate(props: ClarityProjectProps): ClarityProject {
+		return new ClarityProject(props);
+	}
+
+	unlink(now: Date): void {
+		if (this.props.unlinkedAt) {
+			throw new ConflictError('ClarityProject is already unlinked');
+		}
+		this.props = { ...this.props, unlinkedAt: now };
+	}
+
+	isActive(): boolean {
+		return this.props.unlinkedAt === null;
+	}
+
+	get id(): ClarityProjectId {
+		return this.props.id;
+	}
+	get organizationId(): OrganizationId {
+		return this.props.organizationId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get clarityHandle(): ClarityProjectHandle {
+		return this.props.clarityHandle;
+	}
+	get credentialId(): string | null {
+		return this.props.credentialId;
+	}
+	get linkedAt(): Date {
+		return this.props.linkedAt;
+	}
+	get unlinkedAt(): Date | null {
+		return this.props.unlinkedAt;
+	}
+}

--- a/packages/domain/src/experience-analytics/entities/experience-snapshot.ts
+++ b/packages/domain/src/experience-analytics/entities/experience-snapshot.ts
@@ -1,0 +1,47 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import type { ExperienceMetrics } from '../value-objects/experience-metrics.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export interface ExperienceSnapshotProps {
+	clarityProjectId: ClarityProjectId;
+	projectId: ProjectId;
+	observedDate: string; // YYYY-MM-DD
+	metrics: ExperienceMetrics;
+	rawPayloadId: string | null;
+}
+
+/**
+ * One immutable Microsoft Clarity daily metrics snapshot at calendar-day
+ * granularity. Value-like factory; the record use case publishes one
+ * summary event per call (mirrors the GSC / GA4 / Bing batch shape).
+ */
+export class ExperienceSnapshot extends AggregateRoot {
+	private constructor(private readonly props: ExperienceSnapshotProps) {
+		super();
+	}
+
+	static record(input: ExperienceSnapshotProps): ExperienceSnapshot {
+		return new ExperienceSnapshot(input);
+	}
+
+	static rehydrate(props: ExperienceSnapshotProps): ExperienceSnapshot {
+		return new ExperienceSnapshot(props);
+	}
+
+	get clarityProjectId(): ClarityProjectId {
+		return this.props.clarityProjectId;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get observedDate(): string {
+		return this.props.observedDate;
+	}
+	get metrics(): ExperienceMetrics {
+		return this.props.metrics;
+	}
+	get rawPayloadId(): string | null {
+		return this.props.rawPayloadId;
+	}
+}

--- a/packages/domain/src/experience-analytics/events/clarity-project-linked.ts
+++ b/packages/domain/src/experience-analytics/events/clarity-project-linked.ts
@@ -1,0 +1,27 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export class ClarityProjectLinked implements DomainEvent {
+	readonly type = 'ClarityProjectLinked';
+	readonly clarityProjectId: ClarityProjectId;
+	readonly projectId: ProjectId;
+	readonly organizationId: OrganizationId;
+	readonly clarityHandle: string;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		clarityProjectId: ClarityProjectId;
+		projectId: ProjectId;
+		organizationId: OrganizationId;
+		clarityHandle: string;
+		occurredAt: Date;
+	}) {
+		this.clarityProjectId = props.clarityProjectId;
+		this.projectId = props.projectId;
+		this.organizationId = props.organizationId;
+		this.clarityHandle = props.clarityHandle;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/experience-analytics/events/experience-snapshot-recorded.ts
+++ b/packages/domain/src/experience-analytics/events/experience-snapshot-recorded.ts
@@ -1,0 +1,29 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { DomainEvent } from '../../shared-kernel/domain-event.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export class ExperienceSnapshotRecorded implements DomainEvent {
+	readonly type = 'ExperienceSnapshotRecorded';
+	readonly clarityProjectId: ClarityProjectId;
+	readonly projectId: ProjectId;
+	readonly observedDate: string;
+	readonly sessionsCount: number;
+	readonly rageClicks: number;
+	readonly occurredAt: Date;
+
+	constructor(props: {
+		clarityProjectId: ClarityProjectId;
+		projectId: ProjectId;
+		observedDate: string;
+		sessionsCount: number;
+		rageClicks: number;
+		occurredAt: Date;
+	}) {
+		this.clarityProjectId = props.clarityProjectId;
+		this.projectId = props.projectId;
+		this.observedDate = props.observedDate;
+		this.sessionsCount = props.sessionsCount;
+		this.rageClicks = props.rageClicks;
+		this.occurredAt = props.occurredAt;
+	}
+}

--- a/packages/domain/src/experience-analytics/index.ts
+++ b/packages/domain/src/experience-analytics/index.ts
@@ -1,0 +1,13 @@
+// Entities / aggregates
+export * from './entities/clarity-project.js';
+export * from './entities/experience-snapshot.js';
+// Events
+export * from './events/clarity-project-linked.js';
+export * from './events/experience-snapshot-recorded.js';
+// Ports
+export * from './ports/clarity-project-repository.js';
+export * from './ports/experience-snapshot-repository.js';
+// Value objects
+export * from './value-objects/clarity-handle.js';
+export * from './value-objects/experience-metrics.js';
+export * from './value-objects/identifiers.js';

--- a/packages/domain/src/experience-analytics/ports/clarity-project-repository.ts
+++ b/packages/domain/src/experience-analytics/ports/clarity-project-repository.ts
@@ -1,0 +1,12 @@
+import type { OrganizationId } from '../../identity-access/value-objects/identifiers.js';
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { ClarityProject } from '../entities/clarity-project.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export interface ClarityProjectRepository {
+	save(clarityProject: ClarityProject): Promise<void>;
+	findById(id: ClarityProjectId): Promise<ClarityProject | null>;
+	findByProjectAndHandle(projectId: ProjectId, clarityHandle: string): Promise<ClarityProject | null>;
+	listForProject(projectId: ProjectId): Promise<readonly ClarityProject[]>;
+	listForOrganization(orgId: OrganizationId): Promise<readonly ClarityProject[]>;
+}

--- a/packages/domain/src/experience-analytics/ports/experience-snapshot-repository.ts
+++ b/packages/domain/src/experience-analytics/ports/experience-snapshot-repository.ts
@@ -1,0 +1,19 @@
+import type { ExperienceSnapshot } from '../entities/experience-snapshot.js';
+import type { ClarityProjectId } from '../value-objects/identifiers.js';
+
+export interface ExperienceSnapshotQuery {
+	from: string; // YYYY-MM-DD inclusive
+	to: string; // YYYY-MM-DD inclusive
+}
+
+export interface ExperienceSnapshotRepository {
+	/**
+	 * Idempotent on (clarityProjectId, observedDate). Returns whether the
+	 * write was a fresh insert or a no-op duplicate.
+	 */
+	save(snapshot: ExperienceSnapshot): Promise<{ inserted: boolean }>;
+	listForClarityProject(
+		clarityProjectId: ClarityProjectId,
+		query: ExperienceSnapshotQuery,
+	): Promise<readonly ExperienceSnapshot[]>;
+}

--- a/packages/domain/src/experience-analytics/value-objects/clarity-handle.ts
+++ b/packages/domain/src/experience-analytics/value-objects/clarity-handle.ts
@@ -1,0 +1,24 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Microsoft Clarity addresses projects by an opaque handle ("project id"
+ * in Microsoft's UI — a 10-character alphanumeric slug shown in the URL).
+ * The token's scope is the project, so this handle is mostly a display
+ * label for the operator; the credential pinning is what actually
+ * partitions the API calls.
+ */
+const HANDLE_REGEX = /^[a-zA-Z0-9]{8,32}$/;
+
+export class ClarityProjectHandle {
+	private constructor(public readonly value: string) {}
+
+	static create(raw: string): ClarityProjectHandle {
+		const trimmed = raw.trim();
+		if (!HANDLE_REGEX.test(trimmed)) {
+			throw new InvalidInputError(
+				'Clarity project handle must be 8-32 alphanumeric characters (the slug shown in the Clarity URL)',
+			);
+		}
+		return new ClarityProjectHandle(trimmed);
+	}
+}

--- a/packages/domain/src/experience-analytics/value-objects/experience-metrics.ts
+++ b/packages/domain/src/experience-analytics/value-objects/experience-metrics.ts
@@ -1,0 +1,56 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Microsoft Clarity daily UX metrics for a project. All counts are
+ * non-negative integers; engagement time is non-negative seconds; scroll
+ * depth is `[0, 1]` (Clarity reports it as a fraction).
+ */
+export class ExperienceMetrics {
+	private constructor(
+		public readonly sessionsCount: number,
+		public readonly botSessionsCount: number,
+		public readonly distinctUserCount: number,
+		public readonly pagesPerSession: number,
+		public readonly rageClicks: number,
+		public readonly deadClicks: number,
+		public readonly avgEngagementSeconds: number,
+		public readonly avgScrollDepth: number,
+	) {}
+
+	static create(input: {
+		sessionsCount: number;
+		botSessionsCount: number;
+		distinctUserCount: number;
+		pagesPerSession: number;
+		rageClicks: number;
+		deadClicks: number;
+		avgEngagementSeconds: number;
+		avgScrollDepth: number;
+	}): ExperienceMetrics {
+		const nonNegInt = (raw: number, label: string): number => {
+			if (!Number.isFinite(raw) || raw < 0) {
+				throw new InvalidInputError(`${label} must be a non-negative number`);
+			}
+			return Math.round(raw);
+		};
+		const nonNegFloat = (raw: number, label: string): number => {
+			if (!Number.isFinite(raw) || raw < 0) {
+				throw new InvalidInputError(`${label} must be a non-negative number`);
+			}
+			return raw;
+		};
+		if (!Number.isFinite(input.avgScrollDepth) || input.avgScrollDepth < 0 || input.avgScrollDepth > 1) {
+			throw new InvalidInputError('avgScrollDepth must be a fraction in [0, 1]');
+		}
+		return new ExperienceMetrics(
+			nonNegInt(input.sessionsCount, 'sessionsCount'),
+			nonNegInt(input.botSessionsCount, 'botSessionsCount'),
+			nonNegInt(input.distinctUserCount, 'distinctUserCount'),
+			nonNegFloat(input.pagesPerSession, 'pagesPerSession'),
+			nonNegInt(input.rageClicks, 'rageClicks'),
+			nonNegInt(input.deadClicks, 'deadClicks'),
+			nonNegFloat(input.avgEngagementSeconds, 'avgEngagementSeconds'),
+			input.avgScrollDepth,
+		);
+	}
+}

--- a/packages/domain/src/experience-analytics/value-objects/identifiers.ts
+++ b/packages/domain/src/experience-analytics/value-objects/identifiers.ts
@@ -1,0 +1,3 @@
+import type { Uuid } from '@rankpulse/shared';
+
+export type ClarityProjectId = Uuid & { readonly __kind: 'ClarityProjectId' };

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export * as BingWebmasterInsights from './bing-webmaster-insights/index.js';
 export * as EntityAwareness from './entity-awareness/index.js';
+export * as ExperienceAnalytics from './experience-analytics/index.js';
 export * as IdentityAccess from './identity-access/index.js';
 export * as MacroContext from './macro-context/index.js';
 export * as ProjectManagement from './project-management/index.js';

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -3,6 +3,8 @@ export { DrizzleBingPropertyRepository } from './repositories/bing-webmaster-ins
 export { DrizzleBingTrafficObservationRepository } from './repositories/bing-webmaster-insights/bing-traffic-observation.repository.js';
 export { DrizzleWikipediaArticleRepository } from './repositories/entity-awareness/wikipedia-article.repository.js';
 export { DrizzleWikipediaPageviewObservationRepository } from './repositories/entity-awareness/wikipedia-pageview-observation.repository.js';
+export { DrizzleClarityProjectRepository } from './repositories/experience-analytics/clarity-project.repository.js';
+export { DrizzleExperienceSnapshotRepository } from './repositories/experience-analytics/experience-snapshot.repository.js';
 export { DrizzleApiTokenRepository } from './repositories/identity-access/api-token.repository.js';
 export { DrizzleMembershipRepository } from './repositories/identity-access/membership.repository.js';
 export { DrizzleOrganizationRepository } from './repositories/identity-access/organization.repository.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0010_oval_sunset_bain.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0010_oval_sunset_bain.sql
@@ -1,0 +1,52 @@
+-- Issue #43 — Microsoft Clarity (experience-analytics) tables. Idempotent
+-- with IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
+
+CREATE TABLE IF NOT EXISTS "clarity_projects" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"clarity_handle" text NOT NULL,
+	"credential_id" uuid,
+	"linked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"unlinked_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "clarity_daily_metrics" (
+	"clarity_project_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"observed_date" text NOT NULL,
+	"sessions_count" bigint NOT NULL,
+	"bot_sessions_count" bigint NOT NULL,
+	"distinct_user_count" bigint NOT NULL,
+	"pages_per_session" double precision NOT NULL,
+	"rage_clicks" bigint NOT NULL,
+	"dead_clicks" bigint NOT NULL,
+	"avg_engagement_seconds" double precision NOT NULL,
+	"avg_scroll_depth" double precision NOT NULL,
+	"raw_payload_id" uuid,
+	CONSTRAINT "clarity_daily_metrics_clarity_project_id_observed_date_pk" PRIMARY KEY("clarity_project_id","observed_date")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "clarity_projects" ADD CONSTRAINT "clarity_projects_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "clarity_projects" ADD CONSTRAINT "clarity_projects_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "clarity_projects" ADD CONSTRAINT "clarity_projects_credential_id_provider_credentials_id_fk" FOREIGN KEY ("credential_id") REFERENCES "public"."provider_credentials"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "clarity_daily_metrics" ADD CONSTRAINT "clarity_daily_metrics_clarity_project_id_clarity_projects_id_fk" FOREIGN KEY ("clarity_project_id") REFERENCES "public"."clarity_projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "clarity_projects_project_handle_unique" ON "clarity_projects" USING btree ("project_id","clarity_handle");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "clarity_projects_project_idx" ON "clarity_projects" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "clarity_daily_metrics_project_idx" ON "clarity_daily_metrics" USING btree ("project_id","observed_date");

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/0010_snapshot.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,3573 @@
+{
+	"id": "4280a15c-f3de-4f14-ba2a-d5cab12c9843",
+	"prevId": "2179c398-b677-4c12-8882-6af39dead0a0",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.api_tokens": {
+			"name": "api_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"hashed_token": {
+					"name": "hashed_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_tokens_hashed_unique": {
+					"name": "api_tokens_hashed_unique",
+					"columns": [
+						{
+							"expression": "hashed_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_tokens_org_idx": {
+					"name": "api_tokens_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_tokens_organization_id_organizations_id_fk": {
+					"name": "api_tokens_organization_id_organizations_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_tokens_created_by_users_id_fk": {
+					"name": "api_tokens_created_by_users_id_fk",
+					"tableFrom": "api_tokens",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "restrict",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_usage_entries": {
+			"name": "api_usage_entries",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"calls": {
+					"name": "calls",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cost_millicents": {
+					"name": "cost_millicents",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"occurred_at": {
+					"name": "occurred_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"api_usage_org_occurred_idx": {
+					"name": "api_usage_org_occurred_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_credential_idx": {
+					"name": "api_usage_credential_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"api_usage_project_idx": {
+					"name": "api_usage_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "occurred_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"api_usage_entries_organization_id_organizations_id_fk": {
+					"name": "api_usage_entries_organization_id_organizations_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_credential_id_provider_credentials_id_fk": {
+					"name": "api_usage_entries_credential_id_provider_credentials_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"api_usage_entries_project_id_projects_id_fk": {
+					"name": "api_usage_entries_project_id_projects_id_fk",
+					"tableFrom": "api_usage_entries",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_properties": {
+			"name": "bing_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_properties_project_site_unique": {
+					"name": "bing_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"bing_properties_project_idx": {
+					"name": "bing_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_properties_organization_id_organizations_id_fk": {
+					"name": "bing_properties_organization_id_organizations_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_project_id_projects_id_fk": {
+					"name": "bing_properties_project_id_projects_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"bing_properties_credential_id_provider_credentials_id_fk": {
+					"name": "bing_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "bing_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.bing_traffic_observations": {
+			"name": "bing_traffic_observations",
+			"schema": "",
+			"columns": {
+				"bing_property_id": {
+					"name": "bing_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_click_position": {
+					"name": "avg_click_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_impression_position": {
+					"name": "avg_impression_position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"bing_traffic_observations_project_idx": {
+					"name": "bing_traffic_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"bing_traffic_observations_bing_property_id_bing_properties_id_fk": {
+					"name": "bing_traffic_observations_bing_property_id_bing_properties_id_fk",
+					"tableFrom": "bing_traffic_observations",
+					"tableTo": "bing_properties",
+					"columnsFrom": ["bing_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"bing_traffic_observations_bing_property_id_observed_date_pk": {
+					"name": "bing_traffic_observations_bing_property_id_observed_date_pk",
+					"columns": ["bing_property_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.clarity_daily_metrics": {
+			"name": "clarity_daily_metrics",
+			"schema": "",
+			"columns": {
+				"clarity_project_id": {
+					"name": "clarity_project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sessions_count": {
+					"name": "sessions_count",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"bot_sessions_count": {
+					"name": "bot_sessions_count",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"distinct_user_count": {
+					"name": "distinct_user_count",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pages_per_session": {
+					"name": "pages_per_session",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rage_clicks": {
+					"name": "rage_clicks",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dead_clicks": {
+					"name": "dead_clicks",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_engagement_seconds": {
+					"name": "avg_engagement_seconds",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_scroll_depth": {
+					"name": "avg_scroll_depth",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"clarity_daily_metrics_project_idx": {
+					"name": "clarity_daily_metrics_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"clarity_daily_metrics_clarity_project_id_clarity_projects_id_fk": {
+					"name": "clarity_daily_metrics_clarity_project_id_clarity_projects_id_fk",
+					"tableFrom": "clarity_daily_metrics",
+					"tableTo": "clarity_projects",
+					"columnsFrom": ["clarity_project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"clarity_daily_metrics_clarity_project_id_observed_date_pk": {
+					"name": "clarity_daily_metrics_clarity_project_id_observed_date_pk",
+					"columns": ["clarity_project_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.clarity_projects": {
+			"name": "clarity_projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"clarity_handle": {
+					"name": "clarity_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"clarity_projects_project_handle_unique": {
+					"name": "clarity_projects_project_handle_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "clarity_handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"clarity_projects_project_idx": {
+					"name": "clarity_projects_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"clarity_projects_organization_id_organizations_id_fk": {
+					"name": "clarity_projects_organization_id_organizations_id_fk",
+					"tableFrom": "clarity_projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"clarity_projects_project_id_projects_id_fk": {
+					"name": "clarity_projects_project_id_projects_id_fk",
+					"tableFrom": "clarity_projects",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"clarity_projects_credential_id_provider_credentials_id_fk": {
+					"name": "clarity_projects_credential_id_provider_credentials_id_fk",
+					"tableFrom": "clarity_projects",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitor_suggestions": {
+			"name": "competitor_suggestions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"keywords_in_top10": {
+					"name": "keywords_in_top10",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"total_top10_hits": {
+					"name": "total_top10_hits",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"first_seen_at": {
+					"name": "first_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'PENDING'"
+				},
+				"promoted_at": {
+					"name": "promoted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dismissed_at": {
+					"name": "dismissed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"competitor_suggestions_project_domain_unique": {
+					"name": "competitor_suggestions_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"competitor_suggestions_project_status_idx": {
+					"name": "competitor_suggestions_project_status_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitor_suggestions_project_id_projects_id_fk": {
+					"name": "competitor_suggestions_project_id_projects_id_fk",
+					"tableFrom": "competitor_suggestions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.competitors": {
+			"name": "competitors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"competitors_project_domain_unique": {
+					"name": "competitors_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"competitors_project_id_projects_id_fk": {
+					"name": "competitors_project_id_projects_id_fk",
+					"tableFrom": "competitors",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_daily_metrics": {
+			"name": "ga4_daily_metrics",
+			"schema": "",
+			"columns": {
+				"ga4_property_id": {
+					"name": "ga4_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions_hash": {
+					"name": "dimensions_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dimensions": {
+					"name": "dimensions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metrics": {
+					"name": "metrics",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_daily_metrics_project_idx": {
+					"name": "ga4_daily_metrics_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk": {
+					"name": "ga4_daily_metrics_ga4_property_id_ga4_properties_id_fk",
+					"tableFrom": "ga4_daily_metrics",
+					"tableTo": "ga4_properties",
+					"columnsFrom": ["ga4_property_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk": {
+					"name": "ga4_daily_metrics_ga4_property_id_observed_date_dimensions_hash_pk",
+					"columns": ["ga4_property_id", "observed_date", "dimensions_hash"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ga4_properties": {
+			"name": "ga4_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_handle": {
+					"name": "property_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ga4_properties_project_handle_unique": {
+					"name": "ga4_properties_project_handle_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "property_handle",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ga4_properties_project_idx": {
+					"name": "ga4_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ga4_properties_organization_id_organizations_id_fk": {
+					"name": "ga4_properties_organization_id_organizations_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_project_id_projects_id_fk": {
+					"name": "ga4_properties_project_id_projects_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"ga4_properties_credential_id_provider_credentials_id_fk": {
+					"name": "ga4_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "ga4_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_observations": {
+			"name": "gsc_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gsc_property_id": {
+					"name": "gsc_property_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"query": {
+					"name": "query",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"page": {
+					"name": "page",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"clicks": {
+					"name": "clicks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impressions": {
+					"name": "impressions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ctr": {
+					"name": "ctr",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_observations_project_idx": {
+					"name": "gsc_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk": {
+					"name": "gsc_observations_observed_at_gsc_property_id_query_page_country_device_pk",
+					"columns": ["observed_at", "gsc_property_id", "query", "page", "country", "device"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.gsc_properties": {
+			"name": "gsc_properties",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"site_url": {
+					"name": "site_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"property_type": {
+					"name": "property_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gsc_properties_project_site_unique": {
+					"name": "gsc_properties_project_site_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "site_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"gsc_properties_project_idx": {
+					"name": "gsc_properties_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"gsc_properties_organization_id_organizations_id_fk": {
+					"name": "gsc_properties_organization_id_organizations_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_project_id_projects_id_fk": {
+					"name": "gsc_properties_project_id_projects_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"gsc_properties_credential_id_provider_credentials_id_fk": {
+					"name": "gsc_properties_credential_id_provider_credentials_id_fk",
+					"tableFrom": "gsc_properties",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keyword_lists": {
+			"name": "keyword_lists",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"keyword_lists_project_idx": {
+					"name": "keyword_lists_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keyword_lists_project_id_projects_id_fk": {
+					"name": "keyword_lists_project_id_projects_id_fk",
+					"tableFrom": "keyword_lists",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.keywords": {
+			"name": "keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"list_id": {
+					"name": "list_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tags": {
+					"name": "tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				}
+			},
+			"indexes": {
+				"keywords_list_phrase_unique": {
+					"name": "keywords_list_phrase_unique",
+					"columns": [
+						{
+							"expression": "list_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"keywords_list_id_keyword_lists_id_fk": {
+					"name": "keywords_list_id_keyword_lists_id_fk",
+					"tableFrom": "keywords",
+					"tableTo": "keyword_lists",
+					"columnsFrom": ["list_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.memberships": {
+			"name": "memberships",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"memberships_org_user_active_unique": {
+					"name": "memberships_org_user_active_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"memberships\".\"revoked_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"memberships_user_idx": {
+					"name": "memberships_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"memberships_organization_id_organizations_id_fk": {
+					"name": "memberships_organization_id_organizations_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"memberships_user_id_users_id_fk": {
+					"name": "memberships_user_id_users_id_fk",
+					"tableFrom": "memberships",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.monitored_domains": {
+			"name": "monitored_domains",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"removed_at": {
+					"name": "removed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"monitored_domains_project_domain_unique": {
+					"name": "monitored_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"monitored_domains_project_idx": {
+					"name": "monitored_domains_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"monitored_domains_organization_id_organizations_id_fk": {
+					"name": "monitored_domains_organization_id_organizations_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"monitored_domains_project_id_projects_id_fk": {
+					"name": "monitored_domains_project_id_projects_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"monitored_domains_credential_id_provider_credentials_id_fk": {
+					"name": "monitored_domains_credential_id_provider_credentials_id_fk",
+					"tableFrom": "monitored_domains",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": [
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.page_speed_snapshots": {
+			"name": "page_speed_snapshots",
+			"schema": "",
+			"columns": {
+				"tracked_page_id": {
+					"name": "tracked_page_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lcp_ms": {
+					"name": "lcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"inp_ms": {
+					"name": "inp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cls": {
+					"name": "cls",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fcp_ms": {
+					"name": "fcp_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ttfb_ms": {
+					"name": "ttfb_ms",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"performance_score": {
+					"name": "performance_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seo_score": {
+					"name": "seo_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"accessibility_score": {
+					"name": "accessibility_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"best_practices_score": {
+					"name": "best_practices_score",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"page_speed_snapshots_project_idx": {
+					"name": "page_speed_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"page_speed_snapshots_tracked_page_id_tracked_pages_id_fk": {
+					"name": "page_speed_snapshots_tracked_page_id_tracked_pages_id_fk",
+					"tableFrom": "page_speed_snapshots",
+					"tableTo": "tracked_pages",
+					"columnsFrom": ["tracked_page_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"page_speed_snapshots_tracked_page_id_observed_at_pk": {
+					"name": "page_speed_snapshots_tracked_page_id_observed_at_pk",
+					"columns": ["tracked_page_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.portfolios": {
+			"name": "portfolios",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"portfolios_org_idx": {
+					"name": "portfolios_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"portfolios_organization_id_organizations_id_fk": {
+					"name": "portfolios_organization_id_organizations_id_fk",
+					"tableFrom": "portfolios",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_domains": {
+			"name": "project_domains",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_domains_project_domain_unique": {
+					"name": "project_domains_project_domain_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_domains_project_id_projects_id_fk": {
+					"name": "project_domains_project_id_projects_id_fk",
+					"tableFrom": "project_domains",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_locations": {
+			"name": "project_locations",
+			"schema": "",
+			"columns": {
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"project_locations_unique": {
+					"name": "project_locations_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"project_locations_project_id_projects_id_fk": {
+					"name": "project_locations_project_id_projects_id_fk",
+					"tableFrom": "project_locations",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"portfolio_id": {
+					"name": "portfolio_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"primary_domain": {
+					"name": "primary_domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"projects_org_idx": {
+					"name": "projects_org_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"projects_org_primary_domain_unique": {
+					"name": "projects_org_primary_domain_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "primary_domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"projects_organization_id_organizations_id_fk": {
+					"name": "projects_organization_id_organizations_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"projects_portfolio_id_portfolios_id_fk": {
+					"name": "projects_portfolio_id_portfolios_id_fk",
+					"tableFrom": "projects",
+					"tableTo": "portfolios",
+					"columnsFrom": ["portfolio_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_credentials": {
+			"name": "provider_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_type": {
+					"name": "scope_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scope_id": {
+					"name": "scope_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ciphertext": {
+					"name": "ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"nonce": {
+					"name": "nonce",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_four": {
+					"name": "last_four",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_credentials_unique": {
+					"name": "provider_credentials_unique",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scope_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "label",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_credentials_org_provider_idx": {
+					"name": "provider_credentials_org_provider_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_credentials_organization_id_organizations_id_fk": {
+					"name": "provider_credentials_organization_id_organizations_id_fk",
+					"tableFrom": "provider_credentials",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_definitions": {
+			"name": "provider_job_definitions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_hash": {
+					"name": "params_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron": {
+					"name": "cron",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_override_id": {
+					"name": "credential_override_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_run_at": {
+					"name": "last_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"provider_job_definitions_unique": {
+					"name": "provider_job_definitions_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "params_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"provider_job_definitions_project_idx": {
+					"name": "provider_job_definitions_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_definitions_project_id_projects_id_fk": {
+					"name": "provider_job_definitions_project_id_projects_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_definitions_credential_override_id_provider_credentials_id_fk": {
+					"name": "provider_job_definitions_credential_override_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_definitions",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_override_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.provider_job_runs": {
+			"name": "provider_job_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"definition_id": {
+					"name": "definition_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_json": {
+					"name": "error_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"provider_job_runs_definition_idx": {
+					"name": "provider_job_runs_definition_idx",
+					"columns": [
+						{
+							"expression": "definition_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"provider_job_runs_definition_id_provider_job_definitions_id_fk": {
+					"name": "provider_job_runs_definition_id_provider_job_definitions_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_job_definitions",
+					"columnsFrom": ["definition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"provider_job_runs_credential_id_provider_credentials_id_fk": {
+					"name": "provider_job_runs_credential_id_provider_credentials_id_fk",
+					"tableFrom": "provider_job_runs",
+					"tableTo": "provider_credentials",
+					"columnsFrom": ["credential_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.radar_rank_snapshots": {
+			"name": "radar_rank_snapshots",
+			"schema": "",
+			"columns": {
+				"monitored_domain_id": {
+					"name": "monitored_domain_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_date": {
+					"name": "observed_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rank": {
+					"name": "rank",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bucket": {
+					"name": "bucket",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"categories": {
+					"name": "categories",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"radar_rank_snapshots_project_idx": {
+					"name": "radar_rank_snapshots_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_date",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"radar_rank_snapshots_monitored_domain_id_monitored_domains_id_fk": {
+					"name": "radar_rank_snapshots_monitored_domain_id_monitored_domains_id_fk",
+					"tableFrom": "radar_rank_snapshots",
+					"tableTo": "monitored_domains",
+					"columnsFrom": ["monitored_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"radar_rank_snapshots_monitored_domain_id_observed_date_pk": {
+					"name": "radar_rank_snapshots_monitored_domain_id_observed_date_pk",
+					"columns": ["monitored_domain_id", "observed_date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ranking_observations": {
+			"name": "ranking_observations",
+			"schema": "",
+			"columns": {
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tracked_keyword_id": {
+					"name": "tracked_keyword_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "smallint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"serp_features": {
+					"name": "serp_features",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"source_provider": {
+					"name": "source_provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"raw_payload_id": {
+					"name": "raw_payload_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"ranking_observations_keyword_idx": {
+					"name": "ranking_observations_keyword_idx",
+					"columns": [
+						{
+							"expression": "tracked_keyword_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"ranking_observations_project_idx": {
+					"name": "ranking_observations_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ranking_observations_observed_at_tracked_keyword_id_pk": {
+					"name": "ranking_observations_observed_at_tracked_keyword_id_pk",
+					"columns": ["observed_at", "tracked_keyword_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.raw_payloads": {
+			"name": "raw_payloads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint_id": {
+					"name": "endpoint_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"request_hash": {
+					"name": "request_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_size": {
+					"name": "payload_size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"raw_payloads_request_hash_unique": {
+					"name": "raw_payloads_request_hash_unique",
+					"columns": [
+						{
+							"expression": "request_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"raw_payloads_provider_endpoint_idx": {
+					"name": "raw_payloads_provider_endpoint_idx",
+					"columns": [
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "endpoint_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fetched_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_keywords": {
+			"name": "tracked_keywords",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phrase": {
+					"name": "phrase",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"language": {
+					"name": "language",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device": {
+					"name": "device",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"search_engine": {
+					"name": "search_engine",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_keywords_unique": {
+					"name": "tracked_keywords_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "phrase",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "country",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "language",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "device",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "search_engine",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_keywords_project_idx": {
+					"name": "tracked_keywords_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_keywords_organization_id_organizations_id_fk": {
+					"name": "tracked_keywords_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_keywords_project_id_projects_id_fk": {
+					"name": "tracked_keywords_project_id_projects_id_fk",
+					"tableFrom": "tracked_keywords",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tracked_pages": {
+			"name": "tracked_pages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"strategy": {
+					"name": "strategy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"tracked_pages_project_url_strategy_unique": {
+					"name": "tracked_pages_project_url_strategy_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "strategy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tracked_pages_project_idx": {
+					"name": "tracked_pages_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tracked_pages_organization_id_organizations_id_fk": {
+					"name": "tracked_pages_organization_id_organizations_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tracked_pages_project_id_projects_id_fk": {
+					"name": "tracked_pages_project_id_projects_id_fk",
+					"tableFrom": "tracked_pages",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locale": {
+					"name": "locale",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'en'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": [
+						{
+							"expression": "lower(\"email\")",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_articles": {
+			"name": "wikipedia_articles",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "uuid",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wikipedia_project": {
+					"name": "wikipedia_project",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"linked_at": {
+					"name": "linked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"unlinked_at": {
+					"name": "unlinked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"wikipedia_articles_project_article_unique": {
+					"name": "wikipedia_articles_project_article_unique",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wikipedia_project",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slug",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"wikipedia_articles_project_idx": {
+					"name": "wikipedia_articles_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_articles_organization_id_organizations_id_fk": {
+					"name": "wikipedia_articles_organization_id_organizations_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "organizations",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"wikipedia_articles_project_id_projects_id_fk": {
+					"name": "wikipedia_articles_project_id_projects_id_fk",
+					"tableFrom": "wikipedia_articles",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.wikipedia_pageviews": {
+			"name": "wikipedia_pageviews",
+			"schema": "",
+			"columns": {
+				"article_id": {
+					"name": "article_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "uuid",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"observed_at": {
+					"name": "observed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"views": {
+					"name": "views",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access": {
+					"name": "access",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent": {
+					"name": "agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"granularity": {
+					"name": "granularity",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"wikipedia_pageviews_project_idx": {
+					"name": "wikipedia_pageviews_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "observed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"wikipedia_pageviews_article_id_wikipedia_articles_id_fk": {
+					"name": "wikipedia_pageviews_article_id_wikipedia_articles_id_fk",
+					"tableFrom": "wikipedia_pageviews",
+					"tableTo": "wikipedia_articles",
+					"columnsFrom": ["article_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"wikipedia_pageviews_article_id_observed_at_pk": {
+					"name": "wikipedia_pageviews_article_id_observed_at_pk",
+					"columns": ["article_id", "observed_at"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
 			"when": 1778052907781,
 			"tag": "0009_harsh_mattie_franklin",
 			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1778054148079,
+			"tag": "0010_oval_sunset_bain",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/experience-analytics/clarity-project.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/experience-analytics/clarity-project.repository.ts
@@ -1,0 +1,104 @@
+import { ExperienceAnalytics, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { ConflictError } from '@rankpulse/shared';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { clarityProjects } from '../../schema/index.js';
+
+const UNIQUE_TUPLE_CONSTRAINT = 'clarity_projects_project_handle_unique';
+
+const isUniqueViolation = (err: unknown): boolean => {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: string; constraint_name?: string; constraint?: string };
+	if (e.code !== '23505') return false;
+	const constraint = e.constraint_name ?? e.constraint;
+	return constraint === UNIQUE_TUPLE_CONSTRAINT;
+};
+
+export class DrizzleClarityProjectRepository implements ExperienceAnalytics.ClarityProjectRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(cp: ExperienceAnalytics.ClarityProject): Promise<void> {
+		try {
+			await this.db
+				.insert(clarityProjects)
+				.values({
+					id: cp.id,
+					organizationId: cp.organizationId,
+					projectId: cp.projectId,
+					clarityHandle: cp.clarityHandle.value,
+					credentialId: cp.credentialId,
+					linkedAt: cp.linkedAt,
+					unlinkedAt: cp.unlinkedAt,
+				})
+				.onConflictDoUpdate({
+					target: clarityProjects.id,
+					set: {
+						clarityHandle: cp.clarityHandle.value,
+						credentialId: cp.credentialId,
+						unlinkedAt: cp.unlinkedAt,
+					},
+				});
+		} catch (err) {
+			if (isUniqueViolation(err)) {
+				throw new ConflictError(
+					`Clarity project "${cp.clarityHandle.value}" is already linked to project ${cp.projectId}`,
+				);
+			}
+			throw err;
+		}
+	}
+
+	async findById(
+		id: ExperienceAnalytics.ClarityProjectId,
+	): Promise<ExperienceAnalytics.ClarityProject | null> {
+		const [row] = await this.db.select().from(clarityProjects).where(eq(clarityProjects.id, id)).limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async findByProjectAndHandle(
+		projectId: ProjectManagement.ProjectId,
+		clarityHandle: string,
+	): Promise<ExperienceAnalytics.ClarityProject | null> {
+		const handle = ExperienceAnalytics.ClarityProjectHandle.create(clarityHandle);
+		const [row] = await this.db
+			.select()
+			.from(clarityProjects)
+			.where(and(eq(clarityProjects.projectId, projectId), eq(clarityProjects.clarityHandle, handle.value)))
+			.limit(1);
+		return row ? this.toAggregate(row) : null;
+	}
+
+	async listForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		const rows = await this.db
+			.select()
+			.from(clarityProjects)
+			.where(eq(clarityProjects.projectId, projectId))
+			.orderBy(desc(clarityProjects.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	async listForOrganization(
+		orgId: IdentityAccess.OrganizationId,
+	): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		const rows = await this.db
+			.select()
+			.from(clarityProjects)
+			.where(eq(clarityProjects.organizationId, orgId))
+			.orderBy(desc(clarityProjects.linkedAt));
+		return rows.map((r) => this.toAggregate(r));
+	}
+
+	private toAggregate(row: typeof clarityProjects.$inferSelect): ExperienceAnalytics.ClarityProject {
+		return ExperienceAnalytics.ClarityProject.rehydrate({
+			id: row.id as ExperienceAnalytics.ClarityProjectId,
+			organizationId: row.organizationId as IdentityAccess.OrganizationId,
+			projectId: row.projectId as ProjectManagement.ProjectId,
+			clarityHandle: ExperienceAnalytics.ClarityProjectHandle.create(row.clarityHandle),
+			credentialId: row.credentialId,
+			linkedAt: row.linkedAt,
+			unlinkedAt: row.unlinkedAt,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/experience-analytics/experience-snapshot.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/experience-analytics/experience-snapshot.repository.ts
@@ -1,0 +1,66 @@
+import { ExperienceAnalytics, type ProjectManagement } from '@rankpulse/domain';
+import { and, between, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { clarityDailyMetrics } from '../../schema/index.js';
+
+export class DrizzleExperienceSnapshotRepository implements ExperienceAnalytics.ExperienceSnapshotRepository {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async save(snapshot: ExperienceAnalytics.ExperienceSnapshot): Promise<{ inserted: boolean }> {
+		const result = await this.db
+			.insert(clarityDailyMetrics)
+			.values({
+				clarityProjectId: snapshot.clarityProjectId,
+				projectId: snapshot.projectId,
+				observedDate: snapshot.observedDate,
+				sessionsCount: snapshot.metrics.sessionsCount,
+				botSessionsCount: snapshot.metrics.botSessionsCount,
+				distinctUserCount: snapshot.metrics.distinctUserCount,
+				pagesPerSession: snapshot.metrics.pagesPerSession,
+				rageClicks: snapshot.metrics.rageClicks,
+				deadClicks: snapshot.metrics.deadClicks,
+				avgEngagementSeconds: snapshot.metrics.avgEngagementSeconds,
+				avgScrollDepth: snapshot.metrics.avgScrollDepth,
+				rawPayloadId: snapshot.rawPayloadId,
+			})
+			.onConflictDoNothing({
+				target: [clarityDailyMetrics.clarityProjectId, clarityDailyMetrics.observedDate],
+			})
+			.returning({ clarityProjectId: clarityDailyMetrics.clarityProjectId });
+		return { inserted: result.length > 0 };
+	}
+
+	async listForClarityProject(
+		clarityProjectId: ExperienceAnalytics.ClarityProjectId,
+		query: ExperienceAnalytics.ExperienceSnapshotQuery,
+	): Promise<readonly ExperienceAnalytics.ExperienceSnapshot[]> {
+		const rows = await this.db
+			.select()
+			.from(clarityDailyMetrics)
+			.where(
+				and(
+					eq(clarityDailyMetrics.clarityProjectId, clarityProjectId),
+					between(clarityDailyMetrics.observedDate, query.from, query.to),
+				),
+			)
+			.orderBy(clarityDailyMetrics.observedDate);
+		return rows.map((r) =>
+			ExperienceAnalytics.ExperienceSnapshot.rehydrate({
+				clarityProjectId: r.clarityProjectId as ExperienceAnalytics.ClarityProjectId,
+				projectId: r.projectId as ProjectManagement.ProjectId,
+				observedDate: r.observedDate,
+				metrics: ExperienceAnalytics.ExperienceMetrics.create({
+					sessionsCount: r.sessionsCount,
+					botSessionsCount: r.botSessionsCount,
+					distinctUserCount: r.distinctUserCount,
+					pagesPerSession: r.pagesPerSession,
+					rageClicks: r.rageClicks,
+					deadClicks: r.deadClicks,
+					avgEngagementSeconds: r.avgEngagementSeconds,
+					avgScrollDepth: r.avgScrollDepth,
+				}),
+				rawPayloadId: r.rawPayloadId,
+			}),
+		);
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/index.ts
@@ -817,3 +817,68 @@ export const radarRankSnapshots = pgTable(
 
 export type MonitoredDomainRow = typeof monitoredDomains.$inferSelect;
 export type RadarRankSnapshotRow = typeof radarRankSnapshots.$inferSelect;
+
+// ---- experience-analytics (Microsoft Clarity) ----
+
+/**
+ * Issue #43 — Microsoft Clarity projects linked to a RankPulse project.
+ * Operator-supplied handle is the slug shown in the Clarity URL; the
+ * credential pinning is what actually scopes the API calls.
+ */
+export const clarityProjects = pgTable(
+	'clarity_projects',
+	{
+		id: uuid('id').primaryKey(),
+		organizationId: uuid('organization_id')
+			.notNull()
+			.references(() => organizations.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		clarityHandle: text('clarity_handle').notNull(),
+		credentialId: uuid('credential_id').references(() => providerCredentials.id, { onDelete: 'set null' }),
+		linkedAt: timestamp('linked_at', { withTimezone: true }).notNull().defaultNow(),
+		unlinkedAt: timestamp('unlinked_at', { withTimezone: true }),
+	},
+	(t) => ({
+		uniqueByProjectHandle: uniqueIndex('clarity_projects_project_handle_unique').on(
+			t.projectId,
+			t.clarityHandle,
+		),
+		projectIdx: index('clarity_projects_project_idx').on(t.projectId),
+	}),
+);
+
+/**
+ * Time-series of Clarity daily UX metrics. Natural PK
+ * (clarity_project_id, observed_date) so daily re-fetches collapse cleanly.
+ * Counts are bigint to be safe (high-traffic projects can run into the
+ * millions/day); avg_scroll_depth is double precision because it's a
+ * fraction in [0,1].
+ */
+export const clarityDailyMetrics = pgTable(
+	'clarity_daily_metrics',
+	{
+		clarityProjectId: uuid('clarity_project_id')
+			.notNull()
+			.references(() => clarityProjects.id, { onDelete: 'cascade' }),
+		projectId: uuid('project_id').notNull(),
+		observedDate: text('observed_date').notNull(), // YYYY-MM-DD
+		sessionsCount: bigint('sessions_count', { mode: 'number' }).notNull(),
+		botSessionsCount: bigint('bot_sessions_count', { mode: 'number' }).notNull(),
+		distinctUserCount: bigint('distinct_user_count', { mode: 'number' }).notNull(),
+		pagesPerSession: doublePrecision('pages_per_session').notNull(),
+		rageClicks: bigint('rage_clicks', { mode: 'number' }).notNull(),
+		deadClicks: bigint('dead_clicks', { mode: 'number' }).notNull(),
+		avgEngagementSeconds: doublePrecision('avg_engagement_seconds').notNull(),
+		avgScrollDepth: doublePrecision('avg_scroll_depth').notNull(),
+		rawPayloadId: uuid('raw_payload_id'),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.clarityProjectId, t.observedDate] }),
+		projectIdx: index('clarity_daily_metrics_project_idx').on(t.projectId, t.observedDate),
+	}),
+);
+
+export type ClarityProjectRow = typeof clarityProjects.$inferSelect;
+export type ClarityDailyMetricRow = typeof clarityDailyMetrics.$inferSelect;

--- a/packages/providers/microsoft-clarity/package.json
+++ b/packages/providers/microsoft-clarity/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@rankpulse/provider-microsoft-clarity",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"development": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"test:unit": "vitest run --passWithNoTests",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist .turbo *.tsbuildinfo"
+	},
+	"dependencies": {
+		"@rankpulse/domain": "workspace:*",
+		"@rankpulse/provider-core": "workspace:*",
+		"@rankpulse/shared": "workspace:*",
+		"zod": "4.4.3"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"vitest": "4.1.5"
+	}
+}

--- a/packages/providers/microsoft-clarity/src/acl/data-export-to-snapshot.acl.spec.ts
+++ b/packages/providers/microsoft-clarity/src/acl/data-export-to-snapshot.acl.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { DataExportResponse } from '../endpoints/data-export.js';
+import { extractSnapshot } from './data-export-to-snapshot.acl.js';
+
+describe('extractSnapshot (Clarity data-export)', () => {
+	it('reduces the metricName-keyed response into a single typed snapshot', () => {
+		const response: DataExportResponse = [
+			{ metricName: 'Traffic', information: [{ Traffic: 12_500 }] },
+			{ metricName: 'BotSessions', information: [{ BotSessions: 1_200 }] },
+			{ metricName: 'DistinctUsers', information: [{ DistinctUsers: 8_400 }] },
+			{ metricName: 'PagesPerSession', information: [{ PagesPerSession: 3.4 }] },
+			{ metricName: 'RageClicks', information: [{ RageClicks: 47 }] },
+			{ metricName: 'DeadClicks', information: [{ DeadClicks: 19 }] },
+			{ metricName: 'EngagementTime', information: [{ EngagementTime: 142.7 }] },
+			{ metricName: 'ScrollDepth', information: [{ ScrollDepth: 0.62 }] },
+		];
+		const snap = extractSnapshot(response, '2026-05-01');
+		expect(snap).toEqual({
+			observedDate: '2026-05-01',
+			sessionsCount: 12_500,
+			botSessionsCount: 1_200,
+			distinctUserCount: 8_400,
+			pagesPerSession: 3.4,
+			rageClicks: 47,
+			deadClicks: 19,
+			avgEngagementSeconds: 142.7,
+			avgScrollDepth: 0.62,
+		});
+	});
+
+	it('returns 0 for missing metric entries rather than dropping the snapshot', () => {
+		const partial: DataExportResponse = [
+			{ metricName: 'Traffic', information: [{ Traffic: 100 }] },
+			// All other metrics absent — Clarity sometimes omits them on
+			// low-traffic days.
+		];
+		const snap = extractSnapshot(partial, '2026-05-02');
+		expect(snap.sessionsCount).toBe(100);
+		expect(snap.rageClicks).toBe(0);
+		expect(snap.avgScrollDepth).toBe(0);
+	});
+
+	it('coerces string-typed numeric values (Microsoft sometimes emits strings)', () => {
+		const stringy: DataExportResponse = [
+			{ metricName: 'Traffic', information: [{ Traffic: '2500' }] },
+			{ metricName: 'RageClicks', information: [{ RageClicks: 'not-a-number' }] },
+		];
+		const snap = extractSnapshot(stringy, '2026-05-03');
+		expect(snap.sessionsCount).toBe(2500);
+		expect(snap.rageClicks).toBe(0);
+	});
+
+	it('falls back to known alternate keys (value / Total) when the metric-named key is absent', () => {
+		const altShape: DataExportResponse = [
+			{ metricName: 'Traffic', information: [{ value: 9000 }] },
+			{ metricName: 'RageClicks', information: [{ Total: 13 }] },
+		];
+		const snap = extractSnapshot(altShape, '2026-05-04');
+		expect(snap.sessionsCount).toBe(9000);
+		expect(snap.rageClicks).toBe(13);
+	});
+
+	it('returns all-zero counts for an empty response (auth or fresh-project edge case)', () => {
+		const snap = extractSnapshot([], '2026-05-05');
+		expect(snap.observedDate).toBe('2026-05-05');
+		expect(snap.sessionsCount).toBe(0);
+		expect(snap.distinctUserCount).toBe(0);
+	});
+});

--- a/packages/providers/microsoft-clarity/src/acl/data-export-to-snapshot.acl.ts
+++ b/packages/providers/microsoft-clarity/src/acl/data-export-to-snapshot.acl.ts
@@ -1,0 +1,64 @@
+import type { DataExportResponse } from '../endpoints/data-export.js';
+
+export interface ClarityMetricsSnapshot {
+	observedDate: string; // YYYY-MM-DD — supplied by the caller (Clarity's response is span-of-days)
+	sessionsCount: number;
+	botSessionsCount: number;
+	distinctUserCount: number;
+	pagesPerSession: number;
+	rageClicks: number;
+	deadClicks: number;
+	avgEngagementSeconds: number;
+	avgScrollDepth: number;
+}
+
+const toFinite = (raw: unknown): number => {
+	if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+	if (typeof raw === 'string') {
+		const n = Number(raw);
+		return Number.isFinite(n) ? n : 0;
+	}
+	return 0;
+};
+
+const findMetric = (response: DataExportResponse, metricName: string): number => {
+	const entry = response.find((e) => e.metricName === metricName);
+	if (!entry || !entry.information || entry.information.length === 0) return 0;
+	const first = entry.information[0];
+	if (!first) return 0;
+	// Information items use the metric name as a key. We try several
+	// known shapes (Microsoft's response varies by metric):
+	const candidates = [first[metricName], first.value, first.Total, first.totalSessionsCount];
+	for (const c of candidates) {
+		if (c !== undefined) return toFinite(c);
+	}
+	// Fallback: first numeric-typed entry in the information row.
+	for (const v of Object.values(first)) {
+		if (typeof v === 'number' && Number.isFinite(v)) return v;
+	}
+	return 0;
+};
+
+/**
+ * Pure ACL: Clarity Data Export response → a single typed snapshot row.
+ * The response groups metrics under `metricName` keys; we reduce to one
+ * row keyed on `observedDate` (the cron's wall-clock date — Clarity
+ * returns aggregated metrics over the requested window, not per-day,
+ * so the caller stamps the date).
+ */
+export const extractSnapshot = (
+	response: DataExportResponse,
+	observedDate: string,
+): ClarityMetricsSnapshot => {
+	return {
+		observedDate,
+		sessionsCount: findMetric(response, 'Traffic'),
+		botSessionsCount: findMetric(response, 'BotSessions'),
+		distinctUserCount: findMetric(response, 'DistinctUsers'),
+		pagesPerSession: findMetric(response, 'PagesPerSession'),
+		rageClicks: findMetric(response, 'RageClicks'),
+		deadClicks: findMetric(response, 'DeadClicks'),
+		avgEngagementSeconds: findMetric(response, 'EngagementTime'),
+		avgScrollDepth: findMetric(response, 'ScrollDepth'),
+	};
+};

--- a/packages/providers/microsoft-clarity/src/credential.ts
+++ b/packages/providers/microsoft-clarity/src/credential.ts
@@ -1,0 +1,20 @@
+import { InvalidInputError } from '@rankpulse/shared';
+
+/**
+ * Microsoft Clarity auth: an API token generated under Clarity Settings
+ * → Data Export → Generate Token. The token is JWT-shaped (eyJ…) and
+ * scoped to a single Clarity project.
+ *
+ * We validate length+charset shape and otherwise pass through opaque.
+ */
+const TOKEN_REGEX = /^[A-Za-z0-9_.-]{20,}$/;
+
+export const validateClarityToken = (plaintext: string): string => {
+	const trimmed = plaintext.trim();
+	if (!TOKEN_REGEX.test(trimmed)) {
+		throw new InvalidInputError(
+			'Microsoft Clarity API token must be 20+ characters (alphanumerics, ".", "_", "-"). Generate one in Clarity → Settings → Data Export.',
+		);
+	}
+	return trimmed;
+};

--- a/packages/providers/microsoft-clarity/src/endpoints/data-export.ts
+++ b/packages/providers/microsoft-clarity/src/endpoints/data-export.ts
@@ -1,0 +1,72 @@
+import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
+import { z } from 'zod';
+import type { ClarityHttp } from '../http.js';
+
+/**
+ * `GET /project-live-insights` returns aggregated UX metrics for the last
+ * `numOfDays` days (1-3 only — Microsoft's API caps it). The response is
+ * a flat array of objects, each with one (dimension, metricName, value)
+ * combination — we re-shape into per-day metric maps in the ACL.
+ *
+ * Cron is daily at 06:00 UTC with `numOfDays=1` because the free tier
+ * allows only 10 req/day per project; running the descriptor with the
+ * default keeps daily backfills idempotent against the previous day's
+ * metric values.
+ */
+export const DataExportParams = z.object({
+	numOfDays: z.number().int().min(1).max(3).default(1),
+	// dimension1/2/3 supports: Browser, Device, OS, Country, Page, OperatingSystem, etc.
+	// Keeping the API surface small for v1 — projects rarely change dimensions
+	// in flight, and adding dims is a backwards-compatible change later.
+	dimensions: z
+		.array(z.enum(['Browser', 'Device', 'OS', 'Country', 'Page']))
+		.max(3)
+		.default([]),
+});
+export type DataExportParams = z.infer<typeof DataExportParams>;
+
+export const dataExportDescriptor: EndpointDescriptor = {
+	id: 'clarity-data-export',
+	category: 'onpage',
+	displayName: 'Microsoft Clarity Data Export',
+	description:
+		'Aggregated UX behavioral metrics (sessions, distinct users, rage clicks, dead clicks, scroll depth, engagement time) from a Clarity project. Free; 10 req/day/project.',
+	paramsSchema: DataExportParams,
+	cost: { unit: 'usd_cents', amount: 0 },
+	defaultCron: '0 6 * * *',
+	rateLimit: { max: 10, durationMs: 24 * 60 * 60 * 1000 },
+};
+
+/**
+ * Clarity's response is verbose. Each entry has an `information` array
+ * with one or more metric/value pairs. The shape is loose and Microsoft
+ * may add fields, so we strictly type only what we read.
+ */
+export interface DataExportInformationItem {
+	[k: string]: string | number | undefined;
+}
+export interface DataExportEntry {
+	metricName?: string;
+	information?: DataExportInformationItem[];
+}
+export type DataExportResponse = DataExportEntry[];
+
+export const fetchDataExport = async (
+	http: ClarityHttp,
+	params: DataExportParams,
+	ctx: FetchContext,
+): Promise<DataExportResponse> => {
+	const query: Record<string, string | string[]> = {
+		numOfDays: String(params.numOfDays),
+	};
+	params.dimensions.forEach((dim, idx) => {
+		query[`dimension${idx + 1}`] = dim;
+	});
+	const raw = (await http.get(
+		'/project-live-insights',
+		query,
+		ctx.credential.plaintextSecret,
+		ctx.signal,
+	)) as DataExportResponse;
+	return raw;
+};

--- a/packages/providers/microsoft-clarity/src/http.ts
+++ b/packages/providers/microsoft-clarity/src/http.ts
@@ -1,0 +1,88 @@
+/**
+ * Microsoft Clarity Data Export API client. Auth = Bearer token. The
+ * free tier allows 10 req/day per project — generous for a daily cron
+ * (we use 1) but tight enough that we declare the rate limit explicitly
+ * in the descriptor so backfills don't burn the budget in seconds.
+ */
+import { validateClarityToken } from './credential.js';
+
+export interface ClarityHttpOptions {
+	baseUrl?: string;
+	fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_BASE_URL = 'https://www.clarity.ms/export-data/api/v1';
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+export class ClarityApiError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly body: unknown,
+		message: string,
+	) {
+		super(message);
+		this.name = 'ClarityApiError';
+	}
+}
+
+export class ClarityHttp {
+	private readonly baseUrl: string;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(options: ClarityHttpOptions = {}) {
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	}
+
+	async get(
+		path: string,
+		query: Record<string, string | string[]>,
+		plaintextCredential: string,
+		signal?: AbortSignal,
+	): Promise<unknown> {
+		const token = validateClarityToken(plaintextCredential);
+		const params = new URLSearchParams();
+		for (const [k, v] of Object.entries(query)) {
+			if (Array.isArray(v)) for (const item of v) params.append(k, item);
+			else params.append(k, v);
+		}
+		const url = `${this.baseUrl}${path}${params.size > 0 ? `?${params.toString()}` : ''}`;
+		const response = await this.fetchImpl(url, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: 'application/json',
+			},
+			signal,
+		});
+		const contentLength = response.headers.get('content-length');
+		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
+			throw new ClarityApiError(
+				response.status,
+				null,
+				`Clarity ${path} response too large: ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const text = await response.text();
+		if (text.length > MAX_RESPONSE_BYTES) {
+			throw new ClarityApiError(
+				response.status,
+				null,
+				`Clarity ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
+			);
+		}
+		const parsed = text.length > 0 ? safeParse(text) : null;
+		if (!response.ok) {
+			throw new ClarityApiError(response.status, parsed, `Clarity ${path} returned HTTP ${response.status}`);
+		}
+		return parsed;
+	}
+}
+
+const safeParse = (text: string): unknown => {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+};

--- a/packages/providers/microsoft-clarity/src/index.ts
+++ b/packages/providers/microsoft-clarity/src/index.ts
@@ -1,0 +1,5 @@
+export * from './acl/data-export-to-snapshot.acl.js';
+export * from './credential.js';
+export * from './endpoints/data-export.js';
+export * from './http.js';
+export * from './provider.js';

--- a/packages/providers/microsoft-clarity/src/provider.spec.ts
+++ b/packages/providers/microsoft-clarity/src/provider.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { ClarityProvider } from './provider.js';
+
+const validToken = 'eyJhbGciOiJIUzI1NiJ9.fake.signature_value_padding_here';
+
+describe('ClarityProvider', () => {
+	it('exposes clarity-data-export via discover()', () => {
+		const ids = new ClarityProvider().discover().map((e) => e.id);
+		expect(ids).toEqual(['clarity-data-export']);
+	});
+
+	it('validateCredentialPlaintext accepts a JWT-shaped token', () => {
+		expect(() => new ClarityProvider().validateCredentialPlaintext(validToken)).not.toThrow();
+	});
+
+	it('validateCredentialPlaintext rejects too-short tokens', () => {
+		expect(() => new ClarityProvider().validateCredentialPlaintext('short')).toThrow();
+	});
+
+	it('paramsSchema rejects numOfDays outside the 1-3 Microsoft cap', () => {
+		const ep = new ClarityProvider().discover().find((e) => e.id === 'clarity-data-export');
+		expect(ep?.paramsSchema.safeParse({ numOfDays: 0 }).success).toBe(false);
+		expect(ep?.paramsSchema.safeParse({ numOfDays: 4 }).success).toBe(false);
+		expect(ep?.paramsSchema.safeParse({ numOfDays: 1 }).success).toBe(true);
+	});
+
+	it('paramsSchema rejects more than 3 dimensions', () => {
+		const ep = new ClarityProvider().discover().find((e) => e.id === 'clarity-data-export');
+		expect(
+			ep?.paramsSchema.safeParse({ numOfDays: 1, dimensions: ['Browser', 'Device', 'OS', 'Country'] })
+				.success,
+		).toBe(false);
+	});
+
+	it('fetch rejects an unknown endpoint id', async () => {
+		const provider = new ClarityProvider();
+		await expect(
+			provider.fetch('not-real', {}, {
+				credential: { plaintextSecret: validToken },
+				signal: new AbortController().signal,
+			} as never),
+		).rejects.toThrow();
+	});
+});

--- a/packages/providers/microsoft-clarity/src/provider.ts
+++ b/packages/providers/microsoft-clarity/src/provider.ts
@@ -1,0 +1,42 @@
+import { ProviderConnectivity } from '@rankpulse/domain';
+import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import { validateClarityToken } from './credential.js';
+import { type DataExportParams, dataExportDescriptor, fetchDataExport } from './endpoints/data-export.js';
+import { ClarityHttp } from './http.js';
+
+const ENDPOINTS: readonly EndpointDescriptor[] = [dataExportDescriptor];
+
+export class ClarityProvider implements Provider {
+	readonly id = ProviderConnectivity.ProviderId.create('microsoft-clarity');
+	readonly displayName = 'Microsoft Clarity';
+	readonly authStrategy = 'apiKey' as const;
+
+	private readonly http: ClarityHttp;
+
+	constructor(options?: { fetchImpl?: typeof fetch }) {
+		this.http = new ClarityHttp(options);
+	}
+
+	discover(): readonly EndpointDescriptor[] {
+		return ENDPOINTS;
+	}
+
+	validateCredentialPlaintext(plaintextSecret: string): void {
+		validateClarityToken(plaintextSecret);
+	}
+
+	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
+		switch (endpointId) {
+			case dataExportDescriptor.id: {
+				const parsed = dataExportDescriptor.paramsSchema.safeParse(params);
+				if (!parsed.success) {
+					throw new InvalidInputError(`Invalid params for ${endpointId}: ${parsed.error.message}`);
+				}
+				return await fetchDataExport(this.http, parsed.data as DataExportParams, ctx);
+			}
+			default:
+				throw new InvalidInputError(`microsoft-clarity has no endpoint "${endpointId}"`);
+		}
+	}
+}

--- a/packages/providers/microsoft-clarity/tsconfig.build.json
+++ b/packages/providers/microsoft-clarity/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": false,
+		"sourceMap": true
+	},
+	"exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/providers/microsoft-clarity/tsconfig.json
+++ b/packages/providers/microsoft-clarity/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/providers/microsoft-clarity/vitest.config.ts
+++ b/packages/providers/microsoft-clarity/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	resolve: { conditions: ['development', 'module', 'import', 'default'] },
+	test: {
+		environment: 'node',
+		include: ['src/**/*.spec.ts'],
+	},
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,7 @@
 import { HttpClient, type HttpClientOptions } from './http.js';
 import { AuthResource } from './resources/auth.js';
 import { BingResource } from './resources/bing.js';
+import { ClarityResource } from './resources/clarity.js';
 import { Ga4Resource } from './resources/ga4.js';
 import { GscResource } from './resources/gsc.js';
 import { PageSpeedResource } from './resources/page-speed.js';
@@ -27,6 +28,7 @@ export class RankPulseClient {
 	readonly ga4: Ga4Resource;
 	readonly bing: BingResource;
 	readonly radar: RadarResource;
+	readonly clarity: ClarityResource;
 
 	constructor(options: RankPulseClientOptions) {
 		const prefix = options.apiPrefix ?? DEFAULT_PREFIX;
@@ -42,5 +44,6 @@ export class RankPulseClient {
 		this.ga4 = new Ga4Resource(http);
 		this.bing = new BingResource(http);
 		this.radar = new RadarResource(http);
+		this.clarity = new ClarityResource(http);
 	}
 }

--- a/packages/sdk/src/resources/clarity.ts
+++ b/packages/sdk/src/resources/clarity.ts
@@ -1,0 +1,30 @@
+import type { ExperienceAnalyticsContracts } from '@rankpulse/contracts';
+import type { HttpClient } from '../http.js';
+
+export class ClarityResource {
+	constructor(private readonly http: HttpClient) {}
+
+	listForProject(projectId: string): Promise<ExperienceAnalyticsContracts.ClarityProjectDto[]> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/clarity/projects`);
+	}
+
+	link(
+		projectId: string,
+		body: ExperienceAnalyticsContracts.LinkClarityProjectRequest,
+	): Promise<{ clarityProjectId: string }> {
+		return this.http.post(`/projects/${encodeURIComponent(projectId)}/clarity/projects`, body);
+	}
+
+	unlink(clarityProjectId: string): Promise<{ ok: true }> {
+		return this.http.delete(`/clarity/projects/${encodeURIComponent(clarityProjectId)}`);
+	}
+
+	history(
+		clarityProjectId: string,
+		query: ExperienceAnalyticsContracts.ExperienceHistoryQuery,
+	): Promise<ExperienceAnalyticsContracts.ExperienceHistoryRowDto[]> {
+		return this.http.get(`/clarity/projects/${encodeURIComponent(clarityProjectId)}/history`, {
+			query: { from: query.from, to: query.to },
+		});
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
+      '@rankpulse/provider-microsoft-clarity':
+        specifier: workspace:*
+        version: link:../../packages/providers/microsoft-clarity
       '@rankpulse/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -223,6 +226,9 @@ importers:
       '@rankpulse/provider-gsc':
         specifier: workspace:*
         version: link:../../packages/providers/google-search-console
+      '@rankpulse/provider-microsoft-clarity':
+        specifier: workspace:*
+        version: link:../../packages/providers/microsoft-clarity
       '@rankpulse/provider-pagespeed':
         specifier: workspace:*
         version: link:../../packages/providers/pagespeed
@@ -473,6 +479,28 @@ importers:
       google-auth-library:
         specifier: 10.6.2
         version: 10.6.2
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/providers/microsoft-clarity:
+    dependencies:
+      '@rankpulse/domain':
+        specifier: workspace:*
+        version: link:../../domain
+      '@rankpulse/provider-core':
+        specifier: workspace:*
+        version: link:../core
+      '@rankpulse/shared':
+        specifier: workspace:*
+        version: link:../../shared
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
Closes #43.

## Summary
- New provider `@rankpulse/provider-microsoft-clarity`: Bearer-token client (`Authorization: Bearer <Clarity token>`), 8 MB body cap. Single endpoint `clarity-data-export` (GET `/project-live-insights`, daily cron `0 6 * * *`, rate limit 10 req/day per project to align with the free tier). Pure ACL reduces Microsoft's verbose `metricName`-keyed array into a single typed snapshot, with fallbacks to `value` / `Total` keys when the metric-named key is absent and string-coercion for numeric strings Microsoft sometimes emits.
- New `experience-analytics` bounded context: `ClarityProject` aggregate with `ClarityProjectHandle` VO (8-32 alphanumeric slug), `ExperienceMetrics` value-like enforcing scroll-depth in `[0, 1]` and non-negative counts, `ExperienceSnapshot` value-like, `ClarityProjectLinked` and `ExperienceSnapshotRecorded` events.
- Drizzle migration 0010 — `clarity_projects` (uniqueness on `(project_id, clarity_handle)`) + `clarity_daily_metrics` (natural PK `(clarity_project_id, observed_date)`, bigint counts for high-traffic safety); idempotent IF NOT EXISTS + DO $$ EXCEPTION duplicate_object guards.
- Application — `LinkClarityProject` (canonicalises before lookup), `UnlinkClarityProject` (idempotent), `RecordExperienceSnapshot` (returns inserted boolean, only emits event on first insert), `QueryExperienceHistory`. 5 unit tests covering happy path, idempotency, NotFound, scroll-depth boundary rejection, and count-invariant rejection.
- Worker — provider registered, processor dispatches `clarity-data-export` to ACL + record use case (the cron's wall-clock date stamps the observation), classifies `402`/`429` as quota-exhausted (auto-pause).
- API — `GET/POST/DELETE /clarity/...` endpoints in `ExperienceAnalyticsModule` with the same IDOR-safe 404-collapse pattern.
- SDK — `clarity` resource (`listForProject`, `link`, `unlink`, `history`).
- UI — atomic-design `LinkClarityDrawer` + new Clarity card on the project detail page (MousePointerClick icon, mobile-first, copy on the API token generation step).

## Pipeline status (local)
- `pnpm lint` — clean (biome `check .`).
- `pnpm typecheck` — 20/20 packages OK.
- `pnpm test` — all 20 workspaces green; **11** new provider tests + **5** new application tests added.
- `pnpm build` — full monorepo build green (17/17).

## Test plan
- [ ] CI green (format/lint/typecheck/tests/coverage).
- [ ] Migration `0010_oval_sunset_bain.sql` applies cleanly on the existing prod database.
- [ ] After deploy, register a Clarity API-token credential, link a Clarity project, schedule the cron (with a `clarityProjectId` in systemParams), trigger run-now and confirm a row lands in `clarity_daily_metrics`.
- [ ] Re-run the same job and verify it does not duplicate (PK conflict swallowed, no duplicate event).