### PR TITLE
feat(pagespeed): polymorphic auth — accept Service Account JSON OR API key

### DIFF
--- a/packages/providers/pagespeed/package.json
+++ b/packages/providers/pagespeed/package.json
@@ -23,7 +23,8 @@
 		"@rankpulse/domain": "workspace:*",
 		"@rankpulse/provider-core": "workspace:*",
 		"@rankpulse/shared": "workspace:*",
-		"zod": "4.4.3"
+		"zod": "4.4.3",
+		"google-auth-library": "^9.15.0"
 	},
 	"devDependencies": {
 		"typescript": "6.0.3",

--- a/packages/providers/pagespeed/src/endpoints/runpagespeed.ts
+++ b/packages/providers/pagespeed/src/endpoints/runpagespeed.ts
@@ -69,7 +69,7 @@ export interface RunPagespeedResponse {
 export const fetchRunPagespeed = async (
 	http: PageSpeedHttp,
 	params: RunPagespeedParams,
-	apiKey: string,
+	auth: import('../http.js').PageSpeedAuth,
 	ctx: FetchContext,
 ): Promise<RunPagespeedResponse> => {
 	const query: Record<string, string | string[]> = {
@@ -77,9 +77,8 @@ export const fetchRunPagespeed = async (
 		strategy: params.strategy,
 		locale: params.locale,
 		category: params.category,
-		key: apiKey,
 	};
-	const raw = (await http.get(PATH, query, ctx.signal)) as RunPagespeedResponse;
+	const raw = (await http.get(PATH, query, auth, ctx.signal)) as RunPagespeedResponse;
 	if (!raw || typeof raw !== 'object') {
 		ctx.logger.warn('PSI returned empty or non-object response', { raw });
 		return {};

--- a/packages/providers/pagespeed/src/http.ts
+++ b/packages/providers/pagespeed/src/http.ts
@@ -1,15 +1,21 @@
 /**
- * Google PageSpeed Insights v5 client. Auth: API key as query param.
- * Free tier: 1 req/sec, 25k/day per key. Without a key Google still
- * accepts the request but applies a much harsher per-IP throttle that
- * would fail in shared egress (CI runners, bursty cron). The descriptor
- * declares the rate limit so the scheduling layer doesn't over-fan-out.
+ * Google PageSpeed Insights v5 client. Supports two auth modes — API key
+ * as a query param, or OAuth2 Bearer token from a service account.
+ *
+ * Free tier with API key: 1 req/sec, 25k/day per key.
+ * SA OAuth: same daily quota, scoped per-project on Google Cloud.
+ *
+ * Both flows hit the same v5 endpoint; only the auth surface differs.
+ * Pick the right one by inspecting the credential's plaintextSecret —
+ * see `provider.ts` for the polymorphic dispatch.
  */
 
 export interface PageSpeedHttpOptions {
 	baseUrl?: string;
 	fetchImpl?: typeof fetch;
 }
+
+export type PageSpeedAuth = { kind: 'apiKey'; apiKey: string } | { kind: 'bearer'; token: string };
 
 const DEFAULT_BASE_URL = 'https://www.googleapis.com';
 
@@ -24,18 +30,25 @@ export class PageSpeedHttp {
 		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
 	}
 
-	async get(path: string, query: Record<string, string | string[]>, signal?: AbortSignal): Promise<unknown> {
+	async get(
+		path: string,
+		query: Record<string, string | string[]>,
+		auth: PageSpeedAuth,
+		signal?: AbortSignal,
+	): Promise<unknown> {
 		const params = new URLSearchParams();
 		for (const [k, v] of Object.entries(query)) {
 			if (Array.isArray(v)) for (const item of v) params.append(k, item);
 			else params.append(k, v);
 		}
+		// API key goes as ?key=... ; Bearer goes in the Authorization header.
+		// PSI accepts either but never both — Google logs warnings if both
+		// reach the same request.
+		if (auth.kind === 'apiKey') params.append('key', auth.apiKey);
+		const headers: Record<string, string> = { Accept: 'application/json' };
+		if (auth.kind === 'bearer') headers.Authorization = `Bearer ${auth.token}`;
 		const url = `${this.baseUrl}${path}?${params.toString()}`;
-		const response = await this.fetchImpl(url, {
-			method: 'GET',
-			headers: { Accept: 'application/json' },
-			signal,
-		});
+		const response = await this.fetchImpl(url, { method: 'GET', headers, signal });
 		const contentLength = response.headers.get('content-length');
 		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
 			throw new PageSpeedApiError(

--- a/packages/providers/pagespeed/src/provider.spec.ts
+++ b/packages/providers/pagespeed/src/provider.spec.ts
@@ -70,3 +70,30 @@ describe('PageSpeedProvider', () => {
 		expect(result.id).toBe('https://example.com/');
 	});
 });
+
+describe('PageSpeedProvider — multi-auth credential validation', () => {
+	const provider = new PageSpeedProvider();
+	const SA_VALID_JSON = JSON.stringify({
+		type: 'service_account',
+		client_email: 'foo@bar.iam.gserviceaccount.com',
+		private_key: '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n',
+	});
+
+	it('accepts a valid service account JSON as credential', () => {
+		expect(() => provider.validateCredentialPlaintext(SA_VALID_JSON)).not.toThrow();
+	});
+
+	it('rejects a JSON-shaped credential missing client_email', () => {
+		const bad = JSON.stringify({ private_key: 'pk' });
+		expect(() => provider.validateCredentialPlaintext(bad)).toThrow(InvalidInputError);
+	});
+
+	it('rejects a JSON-shaped credential missing private_key', () => {
+		const bad = JSON.stringify({ client_email: 'x@y' });
+		expect(() => provider.validateCredentialPlaintext(bad)).toThrow(InvalidInputError);
+	});
+
+	it('rejects a string that is neither a valid SA JSON nor a valid API key', () => {
+		expect(() => provider.validateCredentialPlaintext('{not-json}')).toThrow(InvalidInputError);
+	});
+});

--- a/packages/providers/pagespeed/src/provider.ts
+++ b/packages/providers/pagespeed/src/provider.ts
@@ -1,29 +1,53 @@
 import { ProviderConnectivity } from '@rankpulse/domain';
 import type { EndpointDescriptor, FetchContext, Provider } from '@rankpulse/provider-core';
 import { InvalidInputError } from '@rankpulse/shared';
+import { JWT } from 'google-auth-library';
 import {
 	fetchRunPagespeed,
 	type RunPagespeedParams,
 	runPagespeedDescriptor,
 } from './endpoints/runpagespeed.js';
-import { PageSpeedHttp, type PageSpeedHttpOptions } from './http.js';
+import { type PageSpeedAuth, PageSpeedHttp, type PageSpeedHttpOptions } from './http.js';
 
 const ENDPOINTS: readonly EndpointDescriptor[] = [runPagespeedDescriptor];
 
 const API_KEY_REGEX = /^[A-Za-z0-9_-]{20,}$/;
 
+/** OAuth2 scope PSI accepts. The same `cloud-platform` scope works for
+ * any Google API the SA has been authorized on; we keep it tight to PSI
+ * intent so the SA's other privileges don't bleed in. */
+const PSI_OAUTH_SCOPES = ['https://www.googleapis.com/auth/cloud-platform.read-only'];
+
 /**
  * Google PageSpeed Insights provider — v1.1 free expansion (issue #18).
  *
- * Auth: a single API key from Google Cloud Console (PSI v5). The
- * plaintext credential is just the key string; we validate the
- * minimum shape (alphanumeric + `_` / `-`, length >= 20) so a typo at
- * registration time fails fast instead of becoming a runtime 403 in
- * the worker.
+ * Polymorphic auth — the credential's `plaintextSecret` is auto-detected
+ * at fetch time and the right transport is used:
+ *
+ *  - **Service Account JSON**: parsed; an OAuth2 access token is minted
+ *    via `google-auth-library` and passed as `Authorization: Bearer <tok>`.
+ *    Same SA can be reused for GSC / GA4 (a single secret in the vault
+ *    covers all three Google APIs RankPulse consumes).
+ *  - **API key string**: passed as `?key=<key>` query param. Useful for
+ *    portfolios/projects that don't have a Google Cloud project (or
+ *    don't want to grant the SA viewership of their resources).
+ *
+ * The credential cascade (org → portfolio → project → domain — see
+ * `ResolveProviderCredentialUseCase`) is unchanged; an operator can have
+ * a default SA at the org scope and override per-project to use an API
+ * key (or vice-versa) by registering a domain/project-scoped credential.
+ *
+ * Validation at registration time accepts both formats so a typo on either
+ * still fails fast instead of becoming a runtime 403 in the worker.
  */
 export class PageSpeedProvider implements Provider {
 	readonly id = ProviderConnectivity.ProviderId.create('pagespeed');
 	readonly displayName = 'Google PageSpeed Insights';
+	// Kept singular for back-compat with the public `Provider` contract.
+	// Both `apiKey` and `serviceAccount` are accepted at runtime; the
+	// validateCredentialPlaintext + fetch paths do the actual dispatch.
+	// When `Provider.authStrategies: AuthStrategy[]` lands (BACKLOG
+	// followup), this becomes `['serviceAccount', 'apiKey']`.
 	readonly authStrategy = 'apiKey' as const;
 
 	private readonly http: PageSpeedHttp;
@@ -37,25 +61,76 @@ export class PageSpeedProvider implements Provider {
 	}
 
 	validateCredentialPlaintext(plaintextSecret: string): void {
-		if (!API_KEY_REGEX.test(plaintextSecret)) {
+		// Try both shapes; reject only if neither matches.
+		const trimmed = plaintextSecret.trim();
+		if (trimmed.startsWith('{')) {
+			// Looks like JSON — must be a valid Service Account.
+			try {
+				const parsed = JSON.parse(trimmed) as { client_email?: unknown; private_key?: unknown };
+				if (typeof parsed.client_email !== 'string' || typeof parsed.private_key !== 'string') {
+					throw new Error();
+				}
+			} catch {
+				throw new InvalidInputError(
+					'PageSpeed credential JSON must be a Google Service Account with client_email + private_key',
+				);
+			}
+			return;
+		}
+		// Else expect a bare API key.
+		if (!API_KEY_REGEX.test(trimmed)) {
 			throw new InvalidInputError(
-				'PageSpeed Insights API key must be at least 20 characters of [A-Za-z0-9_-]',
+				'PageSpeed credential must be either a Service Account JSON or an API key (>=20 chars of [A-Za-z0-9_-])',
 			);
 		}
 	}
 
 	async fetch(endpointId: string, params: unknown, ctx: FetchContext): Promise<unknown> {
 		switch (endpointId) {
-			case runPagespeedDescriptor.id:
+			case runPagespeedDescriptor.id: {
+				const auth = await this.resolveAuth(ctx.credential.plaintextSecret);
 				return await fetchRunPagespeed(
 					this.http,
 					this.parseParams(runPagespeedDescriptor, params) as RunPagespeedParams,
-					ctx.credential.plaintextSecret,
+					auth,
 					ctx,
 				);
+			}
 			default:
 				throw new InvalidInputError(`PageSpeed has no endpoint "${endpointId}"`);
 		}
+	}
+
+	/**
+	 * Decide auth path from the credential shape:
+	 * - JSON object that parses as a SA → mint a Bearer token (cached
+	 *   internally by google-auth-library until expiry).
+	 * - Otherwise → treat as a bare API key.
+	 */
+	private async resolveAuth(plaintextSecret: string): Promise<PageSpeedAuth> {
+		const trimmed = plaintextSecret.trim();
+		if (trimmed.startsWith('{')) {
+			let key: { client_email?: string; private_key?: string };
+			try {
+				key = JSON.parse(trimmed);
+			} catch {
+				throw new InvalidInputError('PSI credential parses as JSON but is not valid');
+			}
+			if (!key.client_email || !key.private_key) {
+				throw new InvalidInputError('PSI service account JSON must contain client_email and private_key');
+			}
+			const jwt = new JWT({
+				email: key.client_email,
+				key: key.private_key,
+				scopes: PSI_OAUTH_SCOPES,
+			});
+			const { token } = await jwt.getAccessToken();
+			if (!token) {
+				throw new InvalidInputError('Failed to mint OAuth2 access token from PSI service account');
+			}
+			return { kind: 'bearer', token };
+		}
+		return { kind: 'apiKey', apiKey: trimmed };
 	}
 
 	private parseParams(descriptor: EndpointDescriptor, raw: unknown): unknown {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,6 +523,9 @@ importers:
       '@rankpulse/shared':
         specifier: workspace:*
         version: link:../../shared
+      google-auth-library:
+        specifier: ^9.15.0
+        version: 9.15.1
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -2356,9 +2359,17 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -2379,6 +2390,14 @@ packages:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -2389,6 +2408,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -2454,6 +2477,10 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isbot@5.1.39:
     resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
@@ -2650,6 +2677,15 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -3004,6 +3040,9 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3063,6 +3102,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3162,6 +3206,12 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4523,12 +4573,32 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -4572,11 +4642,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   has-symbols@1.1.0: {}
 
@@ -4644,6 +4736,8 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-promise@4.0.0: {}
+
+  is-stream@2.0.1: {}
 
   isbot@5.1.39: {}
 
@@ -4795,6 +4889,10 @@ snapshots:
   node-addon-api@8.7.0: {}
 
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -5176,6 +5274,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tr46@0.0.3: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -5233,6 +5333,8 @@ snapshots:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -5340,6 +5442,13 @@ snapshots:
   void-elements@3.1.0: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## What

PageSpeed Insights now resolves auth at fetch time from the **credential shape**, accepting both:

| Credential form | Auth used | When |
|---|---|---|
| Google Service Account JSON (`{client_email, private_key, ...}`) | OAuth2 Bearer (mintea token vía `google-auth-library`, igual que GA4) | Operator already has the SA in the vault from GSC/GA4 setup |
| API key string (>=20 chars `[A-Za-z0-9_-]`) | `?key=<key>` query param | Portfolio/project without a Google Cloud project, or that want to keep the org SA away from a specific property |

The `CredentialScope` cascade (`org → portfolio → project → domain` resolved by `ResolveProviderCredentialUseCase`) is **unchanged**. An operator can have a default SA at org scope and override per project/domain with an API key (or the inverse) without any code change — the provider auto-detects.

## Why

User asked: "deberíamos poder configurarlo a nivel de proyecto, portfolio, etc". The CredentialScope already supports that — every provider just needs to accept the multiple auth surfaces. PSI was the first that needed it; this PR is the template.

## How

- `http.ts` exposes a discriminated `PageSpeedAuth` union (`{kind:"apiKey",apiKey} | {kind:"bearer",token}`). The fetcher takes the union directly — HTTP layer stays auth-agnostic.
- `provider.ts` dispatches on the credential shape (`startsWith("{")` ⇒ parse SA + JWT.getAccessToken) at fetch time.
- `validateCredentialPlaintext` accepts both shapes — typo on either fails fast at registration.

## Tests

4 new unit tests on the multi-auth validation path. 19/19 PSI tests pass. Full workspace lint clean. Typecheck green on all packages.

## Followup

`Provider.authStrategy` is still singular in the public contract. Promoting it to `authStrategies: AuthStrategy[]` is part of the architectural cleanup tracked in #56. This PR keeps the existing contract working — internally PSI accepts both forms, externally still declares `apiKey` for back-compat.