### PR TITLE
fix(api): register PageSpeed + Wikipedia providers in API composition root

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,7 +41,9 @@
 		"jose": "6.2.3",
 		"reflect-metadata": "0.2.2",
 		"rxjs": "7.8.2",
-		"zod": "4.4.3"
+		"zod": "4.4.3",
+		"@rankpulse/provider-pagespeed": "workspace:*",
+		"@rankpulse/provider-wikipedia": "workspace:*"
 	},
 	"devDependencies": {
 		"@swc-node/register": "1.11.1",

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -36,6 +36,8 @@ import { GscProvider } from '@rankpulse/provider-gsc';
 import { MetaProvider } from '@rankpulse/provider-meta';
 import { ClarityProvider } from '@rankpulse/provider-microsoft-clarity';
 import { OpenAiProvider } from '@rankpulse/provider-openai';
+import { PageSpeedProvider } from '@rankpulse/provider-pagespeed';
+import { WikipediaProvider } from '@rankpulse/provider-wikipedia';
 import { InvalidInputError, SystemClock, SystemIdGenerator } from '@rankpulse/shared';
 import { JwtService } from '../common/auth/jwt.service.js';
 import type { AppEnv } from '../config/env.js';
@@ -140,6 +142,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 	providerRegistry.register(new DataForSeoProvider());
 	providerRegistry.register(new GscProvider());
 	providerRegistry.register(new Ga4Provider());
+	providerRegistry.register(new PageSpeedProvider());
+	providerRegistry.register(new WikipediaProvider());
 	providerRegistry.register(new BingProvider());
 	providerRegistry.register(new CloudflareRadarProvider());
 	providerRegistry.register(new MetaProvider());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@rankpulse/provider-openai':
         specifier: workspace:*
         version: link:../../packages/providers/openai
+      '@rankpulse/provider-pagespeed':
+        specifier: workspace:*
+        version: link:../../packages/providers/pagespeed
+      '@rankpulse/provider-wikipedia':
+        specifier: workspace:*
+        version: link:../../packages/providers/wikipedia
       '@rankpulse/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
The API's composition root was missing two provider registrations: `PageSpeedProvider` and `WikipediaProvider`. Worker had both (via apps/worker/src/providers/registry.ts) but API didn't, so:

```
POST /providers/pagespeed/credentials → 404 "Provider \"pagespeed\" is not registered"
POST /providers/pagespeed/endpoints/.../schedule → 404 (same)
POST /providers/wikipedia/credentials → 404 (same, also broken)
```

Symptom: 22 PSI tracked-pages register fine via POST /projects/:id/page-speed/pages (that lives in the web-performance bounded context, not in provider-connectivity), but the follow-up step to schedule daily fetch jobs returns 404 because the provider itself isn't in the API's registry.

## Fix
- 2 imports + 2 `registry.register()` lines.
- Add `@rankpulse/provider-pagespeed` and `@rankpulse/provider-wikipedia` to apps/api/package.json deps.
- Lockfile updated.

Same registration order as the worker's registry.ts.

## Followup
Issue #56 already tracks the architectural cleanup. Worth adding: registry construction is duplicated across API and worker — consolidating into a shared `buildProviderRegistry()` function would prevent this category of drift altogether.