### PR TITLE
fix(resolvers): construct value objects (PageUrl/WikipediaProject/ArticleSlug) instead of unsafe cast

### DIFF
--- a/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.ts
+++ b/packages/application/src/entity-awareness/system-param-resolvers/wikipedia-article.system-param-resolver.ts
@@ -1,4 +1,5 @@
-import type { EntityAwareness, ProjectManagement } from '@rankpulse/domain';
+import type { ProjectManagement } from '@rankpulse/domain';
+import { EntityAwareness } from '@rankpulse/domain';
 import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
 import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
 
@@ -39,8 +40,8 @@ export class WikipediaArticleSystemParamResolver implements SystemParamResolver 
 
 		const found = await this.articles.findByProjectAndSlug(
 			input.projectId as ProjectManagement.ProjectId,
-			wpProject as unknown as EntityAwareness.WikipediaProject,
-			article as unknown as EntityAwareness.ArticleSlug,
+			EntityAwareness.WikipediaProject.create(wpProject),
+			EntityAwareness.ArticleSlug.create(article),
 		);
 		if (!found?.isActive()) {
 			throw new NotFoundError(

--- a/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.ts
+++ b/packages/application/src/web-performance/system-param-resolvers/tracked-page.system-param-resolver.ts
@@ -1,4 +1,5 @@
-import type { ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import type { ProjectManagement } from '@rankpulse/domain';
+import { WebPerformance } from '@rankpulse/domain';
 import { InvalidInputError, NotFoundError } from '@rankpulse/shared';
 import type { SystemParamResolver } from '../../provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.js';
 
@@ -34,13 +35,15 @@ export class TrackedPageSystemParamResolver implements SystemParamResolver {
 			);
 		}
 
-		// The repo `findByTuple` accepts the raw primitives; value-objects
-		// are constructed inside the infrastructure adapter to keep this
-		// resolver minimal-surface.
+		// Construct value objects — the repo dereferences `.value` on PageUrl
+		// during the SQL where-clause, so passing a raw string yields
+		// UNDEFINED_VALUE in postgres-js. PageUrl.create() validates the
+		// scheme/length too, so a bad params.url short-circuits here with
+		// InvalidInputError instead of leaking an SQL error to the caller.
 		const page = await this.pages.findByTuple(
 			input.projectId as ProjectManagement.ProjectId,
-			url as unknown as WebPerformance.PageUrl,
-			strategy as unknown as WebPerformance.PageSpeedStrategy,
+			WebPerformance.PageUrl.create(url),
+			strategy as WebPerformance.PageSpeedStrategy,
 		);
 		if (!page) {
 			throw new NotFoundError(


### PR DESCRIPTION
PR #55's resolvers used `as unknown as PageUrl` / `as unknown as ArticleSlug` casts. The Drizzle repos dereference `.value` on those parameters in the SQL where clause, so passing raw strings yields `undefined` and postgres-js throws `UNDEFINED_VALUE` → 500.

Reproduced live trying to schedule PSI for the 22 PT tracked pages: every POST returned 500.

Fix: construct value objects via their factories (`PageUrl.create`, `WikipediaProject.create`, `ArticleSlug.create`). The factories also validate scheme/length so a bad input short-circuits with `InvalidInputError` before hitting the DB.

Lint clean, typecheck OK, 154/154 tests pass.