### PR TITLE
fix(ai-search-insights): 4 production bugs blocking AI Brand Radar

### DIFF
--- a/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
+++ b/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
@@ -212,7 +212,7 @@ export class AiSearchInsightsController {
 		return { items: items.map((i) => ({ ...i, providers: [...i.providers] })) };
 	}
 
-	@Get('projects/:projectId/ai-search/competitive-matrix')
+	@Get('projects/:projectId/ai-search/matrix')
 	async competitiveMatrix(
 		@Principal() principal: AuthPrincipal,
 		@Param('projectId') projectId: string,

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -798,7 +798,7 @@ export function buildOpenApiDocument(): unknown {
 
 	registry.registerPath({
 		method: 'get',
-		path: '/api/v1/projects/{projectId}/ai-search/competitive-matrix',
+		path: '/api/v1/projects/{projectId}/ai-search/matrix',
 		summary: 'AI Brand Radar — competitive matrix (provider × locale × brand)',
 		description:
 			'Flat list of cells the UI pivots into a heatmap. Brands with zero mentions are not present in the response — the UI fills them as 0% cells so the heatmap stays dense.',

--- a/packages/application/src/ai-search-insights/use-cases/query-ai-search-citations.use-case.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-ai-search-citations.use-case.ts
@@ -38,14 +38,16 @@ export class QueryAiSearchCitationsUseCase {
 			onlyOwnDomains: query.onlyOwnDomains,
 			aiProvider: query.aiProvider,
 		});
+		const safeIso = (d: Date): string =>
+			Number.isFinite(d.getTime()) ? d.toISOString() : new Date(0).toISOString();
 		return rows.map((r) => ({
 			url: r.url,
-			domain: r.domain,
+			domain: r.domain ?? '',
 			isOwnDomain: r.isOwnDomain,
 			totalCitations: r.totalCitations,
 			providers: r.providers,
-			firstSeenAt: r.firstSeenAt.toISOString(),
-			lastSeenAt: r.lastSeenAt.toISOString(),
+			firstSeenAt: safeIso(r.firstSeenAt),
+			lastSeenAt: safeIso(r.lastSeenAt),
 		}));
 	}
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -82,7 +82,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			citation_count: number;
 		}>`
 			WITH base AS (
-				SELECT id, ai_provider, country, language, mentions, citations
+				SELECT id, ai_provider, country, language,
+					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions,
+					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
 				FROM llm_answers
 				WHERE project_id = ${projectId}
 				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
@@ -104,7 +106,8 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					(SELECT COUNT(*) FROM jsonb_array_elements(b.citations) c
 					 WHERE COALESCE((c->>'isOwnDomain')::bool, false)
 					   AND c->>'url' = (m->>'citedUrl'))::int AS citation_count
-				FROM base b, jsonb_array_elements(b.mentions) m
+				FROM base b
+				CROSS JOIN LATERAL jsonb_array_elements(b.mentions) m
 				WHERE m ? 'brand'
 			)
 			SELECT
@@ -179,14 +182,17 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					c->>'url' AS url,
 					c->>'domain' AS domain,
 					COALESCE((c->>'isOwnDomain')::bool, false) AS is_own_domain
-				FROM llm_answers a, jsonb_array_elements(a.citations) c
+				FROM llm_answers a
+				CROSS JOIN LATERAL jsonb_array_elements(
+					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
+				) c
 				WHERE a.project_id = ${projectId}
 				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
 				  AND (${aiProvider}::text IS NULL OR a.ai_provider = ${aiProvider}::text)
 			)
 			SELECT
 				url,
-				domain,
+				COALESCE(domain, '') AS domain,
 				bool_or(is_own_domain) AS is_own_domain,
 				COUNT(*)::int AS total_citations,
 				array_agg(DISTINCT ai_provider) AS providers,
@@ -376,7 +382,10 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					c->>'domain' AS domain,
 					to_char(a.captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
 					BOOL_OR(COALESCE((c->>'isOwnDomain')::bool, false)) AS cited
-				FROM llm_answers a, jsonb_array_elements(a.citations) c
+				FROM llm_answers a
+				CROSS JOIN LATERAL jsonb_array_elements(
+					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
+				) c
 				WHERE a.project_id = ${projectId}
 				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
 				  AND COALESCE((c->>'isOwnDomain')::bool, false) = true
@@ -464,7 +473,10 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					m->>'brand' AS brand,
 					COALESCE((m->>'isOwnBrand')::bool, false) AS is_own_brand,
 					(m->>'position')::int AS position
-				FROM llm_answers a, jsonb_array_elements(a.mentions) m
+				FROM llm_answers a
+				CROSS JOIN LATERAL jsonb_array_elements(
+					CASE WHEN jsonb_typeof(a.mentions) = 'array' THEN a.mentions ELSE '[]'::jsonb END
+				) m
 				WHERE a.project_id = ${projectId}
 				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
 			),

--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -28,6 +28,14 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			own_avg_position: number | null;
 			competitor_mention_count: number;
 		}>`
+			WITH base AS (
+				SELECT
+					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions,
+					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
+				FROM llm_answers
+				WHERE project_id = ${projectId}
+				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+			)
 			SELECT
 				COUNT(*)::int AS total_answers,
 				COUNT(*) FILTER (
@@ -45,9 +53,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					(SELECT COUNT(*) FROM jsonb_array_elements(mentions) m
 					 WHERE NOT COALESCE((m->>'isOwnBrand')::bool, false))
 				), 0)::int AS competitor_mention_count
-			FROM llm_answers
-			WHERE project_id = ${projectId}
-			  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+			FROM base
 		`);
 		const row = (rows as unknown as { rows?: unknown[] }).rows?.[0] ?? rows[0];
 		const r = row as {
@@ -236,15 +242,21 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			total_answers: number;
 			answers_with_own_mention: number;
 		}>`
+			WITH base AS (
+				SELECT
+					captured_at,
+					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
+				FROM llm_answers
+				WHERE brand_prompt_id = ${brandPromptId}
+				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+			)
 			SELECT
 				to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
 				COUNT(*)::int AS total_answers,
 				COUNT(*) FILTER (
 					WHERE jsonb_path_exists(mentions, '$[*] ? (@.isOwnBrand == true)')
 				)::int AS answers_with_own_mention
-			FROM llm_answers
-			WHERE brand_prompt_id = ${brandPromptId}
-			  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+			FROM base
 			GROUP BY day
 			ORDER BY day
 		`);
@@ -298,6 +310,14 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			last_week_total: number;
 			last_week_own_mentions: number;
 		}>`
+			WITH base AS (
+				SELECT ai_provider, country, language, captured_at,
+					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
+				FROM llm_answers
+				WHERE project_id = ${projectId}
+				  AND captured_at >= ${lastWeekStart}
+				  AND captured_at <= ${asOf}
+			)
 			SELECT
 				ai_provider,
 				country,
@@ -315,10 +335,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					  AND captured_at < ${thisWeekStart}
 					  AND jsonb_path_exists(mentions, '$[*] ? (@.isOwnBrand == true)')
 				)::int AS last_week_own_mentions
-			FROM llm_answers
-			WHERE project_id = ${projectId}
-			  AND captured_at >= ${lastWeekStart}
-			  AND captured_at <= ${asOf}
+			FROM base
 			GROUP BY ai_provider, country, language
 		`);
 		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{

--- a/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
+++ b/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
@@ -84,27 +84,76 @@ export interface AnthropicMessagesPayload {
 	usage?: AnthropicUsage;
 }
 
-const buildBody = (params: MessagesWithWebSearchParams): unknown => ({
-	model: params.model,
-	max_tokens: 4000,
-	temperature: 0,
-	tools: [
-		{
-			type: 'web_search_20250305',
-			name: 'web_search',
-			max_uses: WEB_SEARCH_MAX_USES,
-			user_location: {
-				type: 'approximate',
-				country: params.locationCountry,
+/**
+ * Anthropic's `user_location` accepts `city`, `region`, `country`, and
+ * `timezone`. Empirically, country-only configurations have been flaky for
+ * some country codes (the request 400s with no clear error from Anthropic),
+ * so we attach the country's IANA timezone whenever we know it. Falls back
+ * to country-only for codes we haven't mapped yet — strictly additive.
+ */
+const COUNTRY_TIMEZONE: Record<string, string> = {
+	US: 'America/New_York',
+	CA: 'America/Toronto',
+	MX: 'America/Mexico_City',
+	GB: 'Europe/London',
+	IE: 'Europe/Dublin',
+	FR: 'Europe/Paris',
+	DE: 'Europe/Berlin',
+	ES: 'Europe/Madrid',
+	PT: 'Europe/Lisbon',
+	IT: 'Europe/Rome',
+	NL: 'Europe/Amsterdam',
+	BE: 'Europe/Brussels',
+	CH: 'Europe/Zurich',
+	AT: 'Europe/Vienna',
+	SE: 'Europe/Stockholm',
+	NO: 'Europe/Oslo',
+	DK: 'Europe/Copenhagen',
+	FI: 'Europe/Helsinki',
+	PL: 'Europe/Warsaw',
+	BR: 'America/Sao_Paulo',
+	AR: 'America/Argentina/Buenos_Aires',
+	CL: 'America/Santiago',
+	CO: 'America/Bogota',
+	JP: 'Asia/Tokyo',
+	AU: 'Australia/Sydney',
+	NZ: 'Pacific/Auckland',
+	IN: 'Asia/Kolkata',
+};
+
+const buildBody = (params: MessagesWithWebSearchParams): unknown => {
+	const timezone = COUNTRY_TIMEZONE[params.locationCountry];
+	const userLocation: Record<string, string> = {
+		type: 'approximate',
+		country: params.locationCountry,
+	};
+	if (timezone) {
+		userLocation.timezone = timezone;
+	}
+	return {
+		model: params.model,
+		max_tokens: 4000,
+		temperature: 0,
+		tools: [
+			{
+				type: 'web_search_20250305',
+				name: 'web_search',
+				max_uses: WEB_SEARCH_MAX_USES,
+				user_location: userLocation,
 			},
+		],
+		// Force web_search instead of `{ type: 'auto' }`. With `auto`, Claude
+		// can decide to answer from training data and skip the tool entirely
+		// — that silently zeroes the citation rate metric AND, for some
+		// locale × prompt combinations, surfaces as 400s on the messages
+		// endpoint when no tool is chosen.
+		tool_choice: { type: 'tool', name: 'web_search' },
+		messages: [{ role: 'user', content: params.prompt }],
+		metadata: {
+			user_id: params.brandPromptId,
 		},
-	],
-	tool_choice: { type: 'auto' },
-	messages: [{ role: 'user', content: params.prompt }],
-	metadata: {
-		user_id: params.brandPromptId,
-	},
-});
+	};
+};
 
 export const fetchMessagesWithWebSearch = async (
 	http: AnthropicHttp,

--- a/packages/providers/openai/src/endpoints/responses-with-web-search.ts
+++ b/packages/providers/openai/src/endpoints/responses-with-web-search.ts
@@ -102,15 +102,16 @@ const buildBody = (params: ResponsesWithWebSearchParams): unknown => ({
 	model: params.model,
 	input: params.prompt,
 	tools: [{ type: 'web_search' }],
-	// `'required'` forces the model to call A tool — since `web_search` is
-	// the only one declared, this guarantees grounding. `'auto'` lets the
-	// model skip web_search when it thinks it has enough training-data
-	// knowledge, which silently breaks the citation rate metric.
-	tool_choice: 'required',
-	temperature: 0,
-	// 4000 tokens covers nearly every realistic LLM-search answer; longer
-	// answers either truncate (acceptable for our use case) or fail with
-	// 400 if the prompt+tools blow the model's context.
+	// For built-in tools (e.g. web_search) the Responses API requires the
+	// hosted-tool object form to force a specific tool — the bare string
+	// `'required'` returns 400 ("hosted tool 'web_search' must be referenced
+	// by object type"). With only one tool declared, this also guarantees
+	// the model can't skip grounding.
+	tool_choice: { type: 'web_search' },
+	// gpt-5-mini is a reasoning model and only supports the default
+	// temperature (1). Passing `temperature: 0` explicitly returns 400
+	// ("Unsupported value: temperature does not support 0"). Omitting the
+	// field altogether lets the API default kick in across model tiers.
 	max_output_tokens: 4000,
 	// Provide the locale as user metadata. The Responses API doesn't
 	// formally accept a locale param, but `metadata.location_*` is propagated

--- a/packages/sdk/src/resources/ai-search.ts
+++ b/packages/sdk/src/resources/ai-search.ts
@@ -94,7 +94,7 @@ export class AiSearchResource {
 		projectId: string,
 		query?: AiSearchInsightsContracts.CompetitiveMatrixQuery,
 	): Promise<AiSearchInsightsContracts.CompetitiveMatrixResponse> {
-		return this.http.get(`/projects/${encodeURIComponent(projectId)}/ai-search/competitive-matrix`, {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/ai-search/matrix`, {
 			query: query ?? {},
 		});
 	}


### PR DESCRIPTION
## Summary

PR 1 of the AI Brand Radar P0 fix bundle. Each of the four bugs zeroed a different slice of the feature — two killed every worker capture (so the dashboards had no data to read), and two killed the read endpoints (so the data that did land never reached the SPA).

### Bugs fixed

**OpenAI worker 0/18** — `packages/providers/openai/src/endpoints/responses-with-web-search.ts`
- `gpt-5-mini` is a reasoning model and rejects `temperature: 0` with `Unsupported value: temperature does not support 0 with this model`. Dropped the explicit override; the API default (1) is the only accepted value for this tier.
- The Responses API rejects the bare string `tool_choice: 'required'` for hosted tools (`hosted tool 'web_search' must be referenced by object type`). Switched to `{ type: 'web_search' }` to force the built-in tool the API-correct way.

**Anthropic PT EN 0/10** — `packages/providers/anthropic/src/endpoints/messages-with-web-search.ts`
- Country-only `user_location` was flaky on `/v1/messages` for several country codes (PT among them). Added a country → IANA-timezone map and attach `timezone` whenever we know it. Strictly additive — countries we haven't mapped fall back to country-only behaviour.
- Replaced `tool_choice: { type: 'auto' }` with `{ type: 'tool', name: 'web_search' }` so Claude can't decide to skip the tool. With `auto`, some locale × prompt combinations surfaced as 400s when the model declined to call any tool, and even when they succeeded, the citation-rate metric silently zeroed.

**`/ai-search/citations` 500** — `packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts`, `packages/application/src/ai-search-insights/use-cases/query-ai-search-citations.use-case.ts`
- Wrapped every `jsonb_array_elements(a.citations|a.mentions)` call in a `CASE WHEN jsonb_typeof = 'array' THEN ... ELSE '[]'::jsonb END` guard. The column is `notNull DEFAULT '[]'`, but a single legacy / malformed row was enough to crash the whole aggregation with `cannot extract elements from a non-array`.
- Coerced missing `domain` to `''` in the citations SELECT (the contract requires `z.string()` non-nullable) and used a `safeIso` helper in the use case so an Invalid Date can't bubble up to the JSON serializer as a 500.

**`/ai-search/matrix` 404** — `apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts`, `packages/sdk/src/resources/ai-search.ts`, `apps/api/src/openapi/spec.ts`
- The SPA route has lived at `/projects/:id/ai-search/matrix` since #87, but the controller / SDK / OpenAPI spec stayed on `competitive-matrix`. Direct API consumers (and anyone copying the URL out of the browser address bar) hit 404. Renamed the API route to `/ai-search/matrix` so the API path matches the SPA route convention.

## Test plan

- [x] `pnpm typecheck` — 26 tasks, all pass
- [x] `pnpm test` — 26 tasks, 209 application tests + provider tests pass
- [x] `pnpm lint` — only 2 pre-existing warnings (unrelated to this PR)
- [x] `pnpm build` — 23 tasks, all pass
- [ ] Verify in staging: schedule a BrandPrompt, watch a worker tick land an OpenAI capture
- [ ] Verify in staging: schedule a PT-EN BrandPrompt with an Anthropic credential, watch a worker tick land an Anthropic capture
- [ ] Verify in staging: hit `GET /api/v1/projects/:id/ai-search/citations` after captures land — 200 with items, no 500
- [ ] Verify in staging: hit `GET /api/v1/projects/:id/ai-search/matrix` — 200, not 404
- [ ] Verify in staging: SPA route `/projects/:id/ai-search/matrix` renders the heatmap with cells, no console errors

https://claude.ai/code/session_01LSPHYSuaSw1AvJByF9GZ23

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSPHYSuaSw1AvJByF9GZ23)_