### PR TITLE
fix(ai-search-insights): enable columnstore before compression policy on llm_answers

### DIFF
--- a/packages/infrastructure/src/persistence/drizzle/migrations/0013_ai_search_insights.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0013_ai_search_insights.sql
@@ -57,6 +57,22 @@ BEGIN
 			if_not_exists => TRUE,
 			migrate_data => TRUE
 		);
+		-- `add_compression_policy` requires columnstore (TimescaleDB
+		-- compression) to be enabled on the hypertable first; without
+		-- this ALTER it raises:
+		--   "columnstore not enabled on hypertable \"llm_answers\""
+		-- Skipped when columnstore is already enabled so the block is
+		-- safe to re-run.
+		IF NOT COALESCE(
+			(SELECT compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 'llm_answers'),
+			false
+		) THEN
+			ALTER TABLE llm_answers SET (
+				timescaledb.compress = true,
+				timescaledb.compress_segmentby = 'project_id, ai_provider',
+				timescaledb.compress_orderby = 'captured_at DESC, id'
+			);
+		END IF;
 		-- Compress chunks older than 7 days. Mentions/citations/raw_text are
 		-- the bulk of the row; columnstore compression collapses them ~10x
 		-- in production-grade datasets.

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0014_llm_answers_compression_repair.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0014_llm_answers_compression_repair.sql
@@ -1,0 +1,38 @@
+-- Retroactively repairs deployments where the original 0013 was marked
+-- applied without the compression policy actually attaching. The first
+-- shipped version of 0013 attempted `add_compression_policy` on
+-- `llm_answers` without first enabling columnstore on the hypertable;
+-- TimescaleDB rejected it with:
+--   ERROR: columnstore not enabled on hypertable "llm_answers"
+-- Production was patched manually (rows inserted into
+-- `__drizzle_migrations` to skip the failing 0013) which left the
+-- table without columnstore + compression policy. drizzle-kit's
+-- migrator decides what to apply by `created_at` only and never
+-- replays a migration whose content changed, so editing 0013 alone
+-- cannot heal those deployments — this follow-up does.
+--
+-- Idempotent on every front:
+--   - guarded by `pg_extension` so installs without TimescaleDB no-op,
+--   - skips the ALTER when columnstore is already enabled (e.g. fresh
+--     installs that ran the corrected 0013),
+--   - `add_compression_policy(..., if_not_exists => TRUE)` is a no-op
+--     when the policy already exists.
+
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')
+	   AND EXISTS (SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_name = 'llm_answers') THEN
+		IF NOT COALESCE(
+			(SELECT compression_enabled FROM timescaledb_information.hypertables WHERE hypertable_name = 'llm_answers'),
+			false
+		) THEN
+			ALTER TABLE llm_answers SET (
+				timescaledb.compress = true,
+				timescaledb.compress_segmentby = 'project_id, ai_provider',
+				timescaledb.compress_orderby = 'captured_at DESC, id'
+			);
+		END IF;
+		PERFORM add_compression_policy('llm_answers', INTERVAL '7 days', if_not_exists => TRUE);
+	END IF;
+END
+$$;

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
 			"when": 1778600000000,
 			"tag": "0013_ai_search_insights",
 			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1778700000000,
+			"tag": "0014_llm_answers_compression_repair",
+			"breakpoints": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- Fixes the original `0013_ai_search_insights` failure on clean installs by enabling columnstore on `llm_answers` BEFORE `add_compression_policy` runs (TimescaleDB requires it).
- Adds `0014_llm_answers_compression_repair` to retroactively heal production deployments where the broken 0013 was manually marked applied — drizzle-kit decides what to apply by `created_at` only, so editing 0013 alone cannot replay it.
- Both blocks are idempotent: clean installs run 0013 then no-op 0014; broken-prod runs only 0014 and lands in the same final state.

Closes #91.

## Why two migrations

`drizzle-orm/pg-core/dialect.js#migrate` selects the latest applied migration by `created_at desc limit 1` and only runs entries whose `folderMillis` is strictly greater. Hash differences are stored but never compared. That means rewriting 0013 alone leaves any deployment with a 0013 row in `__drizzle_migrations` unrepaired — the runtime accepts the new file silently. 0014 carries a fresh `when` so it actually executes on those systems.

## Verification

Ran end-to-end against `timescale/timescaledb-ha:pg16` ephemeral container:

1. **Clean install** — all 14 migrations apply; `compression_enabled = t`, `policy_compression` job exists with `compress_after = 7 days`, columnstore covers `(project_id, ai_provider)` segmentby + `(captured_at DESC, id ASC)` orderby.
2. **Re-run on healthy state** — drizzle skips both migrations by `created_at`; the `IF NOT compression_enabled` guard + `if_not_exists => TRUE` make a hypothetical replay a no-op.
3. **Broken-prod simulation** — fresh DB pre-loaded to mirror the production state described in #91 (tables present, hypertable created, columnstore disabled, no policy, 0013 row already in `__drizzle_migrations` with the old `created_at = 1778600000000`). After `db:migrate`, only 0014 ran (`migrations_count` 14 → 15) and the final compression configuration matched the clean-install state exactly.

`orderby` is `captured_at DESC, id` so the composite PK `(captured_at, id)` is fully covered — TimescaleDB no longer raises `column "id" should be used for segmenting or ordering`.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm --filter @rankpulse/infrastructure typecheck` clean
- [x] `pnpm --filter @rankpulse/infrastructure test` 19/19 passing
- [x] Clean-install migration verified end-to-end
- [x] Idempotent re-run verified
- [x] Broken-prod heal path verified

## Production rollout note

Once merged, on `srv07` run `pnpm --filter @rankpulse/infrastructure db:migrate` — drizzle picks up 0014 only (0013's existing row is already past), enables columnstore on `llm_answers`, and attaches the 7-day policy. No manual SQL needed.