### PR TITLE
fix(search-console-insights): treat null/undefined dimension filters as no filter

### DIFF
--- a/apps/api/src/modules/search-console-insights/gsc.controller.ts
+++ b/apps/api/src/modules/search-console-insights/gsc.controller.ts
@@ -84,10 +84,10 @@ export class GscController {
 			gscPropertyId: id,
 			from,
 			to,
-			query: q.query ?? null,
-			page: q.page ?? null,
-			country: q.country ?? null,
-			device: q.device ?? null,
+			query: q.query,
+			page: q.page,
+			country: q.country,
+			device: q.device,
 		});
 	}
 

--- a/packages/application/src/search-console-insights/use-cases/query-gsc-performance.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-gsc-performance.use-case.spec.ts
@@ -1,0 +1,235 @@
+import { type IdentityAccess, type ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryGscPerformanceObservationRepository } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryGscPerformanceUseCase } from './query-gsc-performance.use-case.js';
+
+const propertyId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as SearchConsoleInsights.GscPropertyId;
+const otherPropertyId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as SearchConsoleInsights.GscPropertyId;
+const projectId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid as ProjectManagement.ProjectId;
+const orgId = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+
+class PropertyRepo implements SearchConsoleInsights.GscPropertyRepository {
+	store = new Map<string, SearchConsoleInsights.GscProperty>();
+	async save(p: SearchConsoleInsights.GscProperty): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: SearchConsoleInsights.GscPropertyId): Promise<SearchConsoleInsights.GscProperty | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndSite(): Promise<SearchConsoleInsights.GscProperty | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly SearchConsoleInsights.GscProperty[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly SearchConsoleInsights.GscProperty[]> {
+		return [];
+	}
+}
+
+const buildObservation = (overrides: {
+	observedAt: Date;
+	query: string | null;
+	page: string | null;
+	country: string | null;
+	device: string | null;
+	id?: string;
+	gscPropertyId?: SearchConsoleInsights.GscPropertyId;
+}): SearchConsoleInsights.GscPerformanceObservation =>
+	SearchConsoleInsights.GscPerformanceObservation.record({
+		id: (overrides.id ??
+			'dddddddd-dddd-dddd-dddd-dddddddddddd') as Uuid as SearchConsoleInsights.GscObservationId,
+		gscPropertyId: overrides.gscPropertyId ?? propertyId,
+		projectId,
+		observedAt: overrides.observedAt,
+		query: overrides.query,
+		page: overrides.page,
+		country: overrides.country,
+		device: overrides.device,
+		metrics: SearchConsoleInsights.PerformanceMetrics.create({
+			clicks: 1,
+			impressions: 10,
+			ctr: 0.1,
+			position: 5,
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryGscPerformanceUseCase', () => {
+	let propertyRepo: PropertyRepo;
+	let obsRepo: InMemoryGscPerformanceObservationRepository;
+	let useCase: QueryGscPerformanceUseCase;
+
+	beforeEach(async () => {
+		propertyRepo = new PropertyRepo();
+		obsRepo = new InMemoryGscPerformanceObservationRepository();
+		await propertyRepo.save(
+			SearchConsoleInsights.GscProperty.link({
+				id: propertyId,
+				organizationId: orgId,
+				projectId,
+				siteUrl: 'https://controlrondas.com/',
+				propertyType: SearchConsoleInsights.GscPropertyTypes.URL_PREFIX,
+				credentialId: null,
+				now: new Date('2026-04-01T00:00:00Z'),
+			}),
+		);
+		useCase = new QueryGscPerformanceUseCase(propertyRepo, obsRepo);
+	});
+
+	// Regression for #77: an unfiltered request was returning [] because the
+	// repo treated `null`/`undefined` as "filter for empty string".
+	it('returns all observations in the date window when no dimension filter is supplied', async () => {
+		await obsRepo.saveAll([
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				query: 'control de rondas',
+				page: 'https://controlrondas.com/',
+				country: 'esp',
+				device: 'desktop',
+			}),
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-02T00:00:00Z'),
+				query: 'app rondas',
+				page: 'https://controlrondas.com/app',
+				country: 'mex',
+				device: 'mobile',
+			}),
+		]);
+		const result = await useCase.execute({
+			gscPropertyId: propertyId,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toHaveLength(2);
+		expect(result.map((p) => p.query)).toEqual(['control de rondas', 'app rondas']);
+	});
+
+	it('filters by exact query when supplied', async () => {
+		await obsRepo.saveAll([
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				query: 'control de rondas',
+				page: null,
+				country: null,
+				device: null,
+			}),
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-02T00:00:00Z'),
+				query: 'app rondas',
+				page: null,
+				country: null,
+				device: null,
+			}),
+		]);
+		const result = await useCase.execute({
+			gscPropertyId: propertyId,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+			query: 'app rondas',
+		});
+		expect(result).toHaveLength(1);
+		expect(result[0]?.query).toBe('app rondas');
+	});
+
+	it('treats explicit empty string as "filter for absent dimension"', async () => {
+		await obsRepo.saveAll([
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				query: 'control de rondas',
+				page: null,
+				country: null,
+				device: null,
+			}),
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-02T00:00:00Z'),
+				query: null, // GSC API didn't return the query dimension on this row
+				page: null,
+				country: null,
+				device: null,
+			}),
+		]);
+		const result = await useCase.execute({
+			gscPropertyId: propertyId,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+			query: '',
+		});
+		expect(result).toHaveLength(1);
+		expect(result[0]?.query).toBe(null);
+	});
+
+	it('honours the date window', async () => {
+		await obsRepo.saveAll([
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-04-15T00:00:00Z'),
+				query: 'old',
+				page: null,
+				country: null,
+				device: null,
+			}),
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-15T00:00:00Z'),
+				query: 'new',
+				page: null,
+				country: null,
+				device: null,
+			}),
+		]);
+		const result = await useCase.execute({
+			gscPropertyId: propertyId,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toHaveLength(1);
+		expect(result[0]?.query).toBe('new');
+	});
+
+	it('scopes results to the requested property', async () => {
+		await obsRepo.saveAll([
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				query: 'mine',
+				page: null,
+				country: null,
+				device: null,
+			}),
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				query: 'theirs',
+				page: null,
+				country: null,
+				device: null,
+				gscPropertyId: otherPropertyId,
+			}),
+		]);
+		const result = await useCase.execute({
+			gscPropertyId: propertyId,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toHaveLength(1);
+		expect(result[0]?.query).toBe('mine');
+	});
+
+	it('throws NotFoundError when the property does not exist', async () => {
+		await expect(
+			useCase.execute({
+				gscPropertyId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+				from: new Date('2026-04-01T00:00:00Z'),
+				to: new Date('2026-05-31T00:00:00Z'),
+			}),
+		).rejects.toMatchObject({ code: 'NOT_FOUND' });
+	});
+});

--- a/packages/application/src/search-console-insights/use-cases/query-gsc-performance.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-gsc-performance.use-case.ts
@@ -38,10 +38,10 @@ export class QueryGscPerformanceUseCase {
 		const rows = await this.observations.listForProperty(id, {
 			from: cmd.from,
 			to: cmd.to,
-			query: cmd.query ?? null,
-			page: cmd.page ?? null,
-			country: cmd.country ?? null,
-			device: cmd.device ?? null,
+			query: cmd.query,
+			page: cmd.page,
+			country: cmd.country,
+			device: cmd.device,
 		});
 		return rows.map((o) => ({
 			observedAt: o.observedAt.toISOString(),

--- a/packages/domain/src/search-console-insights/ports/gsc-performance-observation-repository.ts
+++ b/packages/domain/src/search-console-insights/ports/gsc-performance-observation-repository.ts
@@ -5,6 +5,14 @@ import type { GscPropertyId } from '../value-objects/identifiers.js';
 export interface GscObservationQuery {
 	from: Date;
 	to: Date;
+	/**
+	 * Dimension filter semantics (apply identically to query/page/country/device):
+	 *   - `undefined` or `null` → no filter on this dimension.
+	 *   - `''` (explicit empty string) → match rows where the dimension was
+	 *     absent in the GSC API response (storage uses `''` instead of NULL
+	 *     so the natural-key PK can cover every row without COALESCE).
+	 *   - any other string → exact match on that value.
+	 */
 	query?: string | null;
 	page?: string | null;
 	country?: string | null;

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts
@@ -55,12 +55,14 @@ export class DrizzleGscPerformanceObservationRepository
 			eq(gscObservations.gscPropertyId, propertyId),
 			between(gscObservations.observedAt, query.from, query.to),
 		];
-		// Empty-string filter = "rows where this dimension was absent in
-		// the GSC API response", consistent with the saveAll bridge.
-		if (query.query !== undefined) conditions.push(eq(gscObservations.query, query.query ?? ''));
-		if (query.page !== undefined) conditions.push(eq(gscObservations.page, query.page ?? ''));
-		if (query.country !== undefined) conditions.push(eq(gscObservations.country, query.country ?? ''));
-		if (query.device !== undefined) conditions.push(eq(gscObservations.device, query.device ?? ''));
+		// `undefined`/`null` = "no filter on this dimension"; `''` (explicit
+		// empty string) = "filter for rows where this dimension was absent
+		// in the GSC API response" (storage uses `''` instead of NULL so
+		// the natural-key PK can cover every row without COALESCE indexes).
+		if (query.query != null) conditions.push(eq(gscObservations.query, query.query));
+		if (query.page != null) conditions.push(eq(gscObservations.page, query.page));
+		if (query.country != null) conditions.push(eq(gscObservations.country, query.country));
+		if (query.device != null) conditions.push(eq(gscObservations.device, query.device));
 
 		const rows = await this.db
 			.select()

--- a/packages/testing/src/in-memory/in-memory-gsc-performance-observation-repository.ts
+++ b/packages/testing/src/in-memory/in-memory-gsc-performance-observation-repository.ts
@@ -1,0 +1,46 @@
+import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
+
+/**
+ * Mirrors the corrected Drizzle repo contract: `undefined`/`null` on a
+ * dimension filter means "no filter on this dimension"; `''` (explicit
+ * empty string) targets rows where the dimension was absent in the GSC
+ * API response (storage represents absent-dimension via `''` because
+ * the natural-key PK can't tolerate NULL).
+ */
+export class InMemoryGscPerformanceObservationRepository
+	implements SearchConsoleInsights.GscPerformanceObservationRepository
+{
+	private rows: SearchConsoleInsights.GscPerformanceObservation[] = [];
+
+	async saveAll(
+		observations: readonly SearchConsoleInsights.GscPerformanceObservation[],
+	): Promise<{ inserted: number }> {
+		this.rows.push(...observations);
+		return { inserted: observations.length };
+	}
+
+	async listForProperty(
+		propertyId: SearchConsoleInsights.GscPropertyId,
+		query: SearchConsoleInsights.GscObservationQuery,
+	): Promise<readonly SearchConsoleInsights.GscPerformanceObservation[]> {
+		return this.rows
+			.filter((r) => r.gscPropertyId === propertyId)
+			.filter((r) => r.observedAt >= query.from && r.observedAt <= query.to)
+			.filter((r) => (query.query != null ? (r.query ?? '') === query.query : true))
+			.filter((r) => (query.page != null ? (r.page ?? '') === query.page : true))
+			.filter((r) => (query.country != null ? (r.country ?? '') === query.country : true))
+			.filter((r) => (query.device != null ? (r.device ?? '') === query.device : true))
+			.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+	}
+
+	async listLatestForProject(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly SearchConsoleInsights.GscPerformanceObservation[]> {
+		const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+		return this.rows
+			.filter((r) => r.projectId === projectId)
+			.filter((r) => r.observedAt >= since)
+			.sort((a, b) => b.observedAt.getTime() - a.observedAt.getTime())
+			.slice(0, 500);
+	}
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -8,6 +8,7 @@ export * from './in-memory/fake-password-hasher.js';
 export * from './in-memory/in-memory-api-token-repository.js';
 export * from './in-memory/in-memory-brand-prompt-repository.js';
 export * from './in-memory/in-memory-competitor-repository.js';
+export * from './in-memory/in-memory-gsc-performance-observation-repository.js';
 export * from './in-memory/in-memory-keyword-list-repository.js';
 export * from './in-memory/in-memory-llm-answer-read-model.js';
 export * from './in-memory/in-memory-llm-answer-repository.js';


### PR DESCRIPTION
## Summary

- Fixes the GSC performance read endpoint returning `[]` for unfiltered requests.
- The Drizzle repo treated `null` as "filter for empty string"; the controller and use case were both sending `null` whenever a dimension filter was absent (via `?? null`). Net effect: every unfiltered SELECT carried `eq(query, '')` AND `eq(page, '')` AND `eq(country, '')` AND `eq(device, '')`, which excluded every row the worker had actually written.
- Cleaned up the contract end-to-end so the bug can't return.

Closes #77.

## Root cause

`packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-performance-observation.repository.ts:60-63` (before):

```ts
if (query.query !== undefined) conditions.push(eq(gscObservations.query, query.query ?? ''));
```

`null !== undefined` is `true`, so `null` falls into the branch and the SELECT gains `query = ''`. Storage uses `''` only when the GSC API didn't return that dimension on the row — present-dimension rows have populated values, so unfiltered reads matched nothing.

The controller (`apps/api/.../gsc.controller.ts:87-90`) and use case (`packages/application/.../query-gsc-performance.use-case.ts:41-44`) both fed the repo `q.query ?? null`, which is what made `null` the practical default for "no filter".

## Fix

| Layer | Change |
|---|---|
| Drizzle repo | `!== undefined` → `!= null`; doc updated. `null`/`undefined` = no filter. `''` keeps "match absent-dimension rows". |
| Use case | Dropped `?? null` from the four dimension fields; preserves `undefined` straight through. |
| Controller | Same — dropped `?? null` so the absent-filter case stays as `undefined`. |
| Domain port | Documented the dimension-filter contract on `GscObservationQuery` so the next reader can't replay the ambiguity. |

## Regression coverage

- New `InMemoryGscPerformanceObservationRepository` in `packages/testing` mirrors the corrected Drizzle contract — any future use case test or scenario can exercise the same filter behavior in-memory.
- `query-gsc-performance.use-case.spec.ts` (new, 6 specs):
  - **direct repro for #77**: unfiltered request returns all rows in window
  - exact-match dimension filter
  - explicit `''` filter targets only absent-dimension rows (the original semantic, now reachable but no longer the accidental default)
  - date window honored
  - results scoped to the requested property
  - `NotFoundError` when the property doesn't exist

## Test plan

- [x] `pnpm lint` clean (854 files)
- [x] `pnpm typecheck` clean (26/26)
- [x] `pnpm test` passes (53 test files / 247 tests in `@rankpulse/application`, all packages green)
- [x] `pnpm build` clean (23/23)
- [ ] Manual smoke after merge: deploy → curl `/api/v1/gsc/properties/<id>/performance?from=2026-04-01&to=2026-05-06` → expect non-empty array on properties with ingested data.