### PR TITLE
fix(provider-core): wire costFor on AI Brand Radar descriptors so api_usage charges actuals

### DIFF
--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -285,20 +285,22 @@ export class ProviderFetchProcessor {
 			});
 			await this.deps.rawPayloadRepo.save(rawPayload);
 
-			// BACKLOG #4 fix — endpoints that bill per item (e.g. search-volume
-			// at $0.005/keyword) declare a `costFor(params)` that returns the
-			// real cost for THIS call. Falls back to `cost.amount` (worst-case)
-			// for endpoints with flat per-call billing OR if costFor throws
-			// on a malformed params shape (we charge worst-case AND log so
-			// the operator sees the misconfigure).
+			// Endpoints that bill per item (DataForSEO search-volume,
+			// $0.005/keyword) or per consumed unit (OpenAI/Anthropic
+			// tokens + web_search) declare `costFor(params, response)` so
+			// api_usage reflects the real upstream cost instead of the
+			// worst-case `cost.amount`. Falls back to `cost.amount` for
+			// flat-billed endpoints OR if costFor throws on a malformed
+			// payload (we charge worst-case AND log so the operator sees
+			// the misconfigure).
 			let realCostCents = endpointDescriptor.cost.amount;
 			if (endpointDescriptor.costFor) {
 				try {
-					realCostCents = endpointDescriptor.costFor(resolvedParams);
+					realCostCents = endpointDescriptor.costFor(resolvedParams, fetchResult);
 				} catch (err) {
 					runLog.warn(
 						{ err: err instanceof Error ? err.message : String(err) },
-						'costFor() threw on resolvedParams — billing worst-case for this run',
+						'costFor() threw on resolvedParams/fetchResult — billing worst-case for this run',
 					);
 				}
 			}

--- a/packages/providers/anthropic/src/acl/messages-to-llm-answer.acl.spec.ts
+++ b/packages/providers/anthropic/src/acl/messages-to-llm-answer.acl.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { normaliseAnthropicResponse } from './messages-to-llm-answer.acl.js';
+import { messagesWithWebSearchDescriptor } from '../endpoints/messages-with-web-search.js';
+import { costFromRawPayload, normaliseAnthropicResponse } from './messages-to-llm-answer.acl.js';
 
 describe('normaliseAnthropicResponse', () => {
 	it('joins text blocks, dedupes citation URLs, counts web_search requests', () => {
@@ -68,5 +69,45 @@ describe('normaliseAnthropicResponse', () => {
 			],
 		});
 		expect(result.rawText).toBe('final answer');
+	});
+});
+
+describe('costFromRawPayload (Anthropic)', () => {
+	it('matches the cost computed by normaliseAnthropicResponse on the same payload', () => {
+		const raw = {
+			model: 'claude-sonnet-4-6',
+			content: [],
+			usage: {
+				input_tokens: 200,
+				output_tokens: 800,
+				cache_creation_input_tokens: 100,
+				cache_read_input_tokens: 50,
+				server_tool_use: { web_search_requests: 2 },
+			},
+		};
+		expect(costFromRawPayload(raw)).toBe(normaliseAnthropicResponse(raw).costCents);
+	});
+
+	it('returns 0 when usage is missing — defensive against malformed responses', () => {
+		expect(costFromRawPayload({})).toBe(0);
+	});
+});
+
+describe('messagesWithWebSearchDescriptor.costFor', () => {
+	it('charges typical-call cost (well below the 11¢ worst-case)', () => {
+		const typical = {
+			model: 'claude-sonnet-4-6',
+			usage: {
+				input_tokens: 200,
+				output_tokens: 800,
+				server_tool_use: { web_search_requests: 2 },
+			},
+		};
+		const cost = messagesWithWebSearchDescriptor.costFor?.({}, typical) ?? -1;
+		expect(cost).toBeGreaterThan(0);
+		expect(cost).toBeLessThan(messagesWithWebSearchDescriptor.cost.amount);
+		// 2 web_search × 1¢ + tokens (~200 × $3/1M + 800 × $15/1M ≈ 1.26¢)
+		// → ~3.26¢, well below the 11¢ worst-case ledger reservation.
+		expect(cost).toBeCloseTo(3.26, 1);
 	});
 });

--- a/packages/providers/anthropic/src/acl/messages-to-llm-answer.acl.ts
+++ b/packages/providers/anthropic/src/acl/messages-to-llm-answer.acl.ts
@@ -81,6 +81,26 @@ export const normaliseAnthropicResponse = (raw: AnthropicMessagesPayload): Norma
 	};
 };
 
+/**
+ * Lightweight cost-only projection for the descriptor's `costFor` hook.
+ * Skips text and citation extraction (the worker only needs the cents
+ * for the api_usage ledger; the full normalisation runs later inside
+ * the IngestRouter). Defensive against undefined `usage` so a malformed
+ * response degrades to zero cost instead of throwing — the worker logs
+ * any throw and bills worst-case in that case.
+ */
+export const costFromRawPayload = (raw: AnthropicMessagesPayload): number => {
+	const model = raw.model ?? 'claude-sonnet-4-6';
+	const tokenUsage = AiSearchInsights.TokenUsage.create({
+		inputTokens: raw.usage?.input_tokens ?? 0,
+		outputTokens: raw.usage?.output_tokens ?? 0,
+		cachedInputTokens: raw.usage?.cache_read_input_tokens ?? 0,
+		webSearchCalls: raw.usage?.server_tool_use?.web_search_requests ?? 0,
+	});
+	const cacheWrites = raw.usage?.cache_creation_input_tokens ?? 0;
+	return computeCostCents(model, tokenUsage, cacheWrites);
+};
+
 const extractText = (content: AnthropicMessagesPayload['content']): string => {
 	if (!Array.isArray(content)) return '';
 	const parts: string[] = [];

--- a/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
+++ b/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
@@ -1,5 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
+import { costFromRawPayload } from '../acl/messages-to-llm-answer.acl.js';
 import { parseCredential } from '../credential.js';
 import type { AnthropicHttp } from '../http.js';
 
@@ -34,9 +35,12 @@ export type MessagesWithWebSearchParams = z.infer<typeof MessagesWithWebSearchPa
  *
  * Worst-case call: 200 input + 4000 output tokens + 5 searches
  *   ≈ $0.0006 input + $0.06 output + $0.05 search ≈ 11.06 cents.
- * Typical call: 200 input + 800 output tokens + 2 searches
- *   ≈ ~3.2 cents. Pinning the descriptor at 11 cents is the safe ledger
- * upper bound; `costFor` below computes the precise figure post-fetch.
+ * Typical call: 200 input + 800 output tokens + 2 searches ≈ ~3.2 cents.
+ *
+ * `cost.amount` reserves the 11¢ worst-case in the ledger so budget
+ * alerts stay safe; `costFor` reads the actual `usage` block off the
+ * response and returns the precise figure post-fetch — that's what
+ * api_usage actually charges.
  */
 export const MESSAGES_WORST_CASE_COST_CENTS = 11;
 const WEB_SEARCH_MAX_USES = 5;
@@ -49,6 +53,7 @@ export const messagesWithWebSearchDescriptor: EndpointDescriptor = {
 		'Calls Anthropic /v1/messages with the web_search_20250305 tool enabled, captures the grounded answer + URL citations, and ships the raw text + citations to the AI Brand Radar pipeline.',
 	paramsSchema: MessagesWithWebSearchParams,
 	cost: { unit: 'usd_cents', amount: MESSAGES_WORST_CASE_COST_CENTS },
+	costFor: (_params, response) => costFromRawPayload(response as AnthropicMessagesPayload),
 	defaultCron: '0 7 * * *',
 	rateLimit: { max: 50, durationMs: 60_000 },
 };

--- a/packages/providers/core/src/types.ts
+++ b/packages/providers/core/src/types.ts
@@ -32,14 +32,29 @@ export interface EndpointDescriptor {
 	readonly paramsSchema: ZodTypeAny;
 	readonly cost: { unit: 'usd_cents'; amount: number };
 	/**
-	 * Optional dynamic cost calculator. Endpoints that scale per item
-	 * (e.g. DataForSEO search-volume bills per-keyword on a 1000-keyword
-	 * batch) implement this so the api_usage ledger reflects the real
-	 * upstream cost instead of the worst-case `cost.amount`.
+	 * Optional dynamic cost calculator. The worker calls this once it has
+	 * both the resolved params AND the parsed upstream response, so two
+	 * billing models are supported:
 	 *
-	 * If absent, the worker falls back to `cost.amount`.
+	 * - **Params-driven**: endpoints whose cost is fully predictable from
+	 *   the request shape. Example: DataForSEO search-volume bills
+	 *   per-keyword and the keyword count is in the params, so the
+	 *   descriptor only inspects `params` and ignores `response`.
+	 *
+	 * - **Response-driven**: endpoints whose cost depends on what the
+	 *   upstream actually returned (token usage, web_search count, page
+	 *   characters consumed, …). Example: OpenAI/Anthropic AI Brand Radar
+	 *   bill per token + per web_search call; the descriptor delegates to
+	 *   the provider's ACL helper to derive the real figure from the raw
+	 *   payload.
+	 *
+	 * If absent, the worker falls back to `cost.amount` (worst-case).
+	 *
+	 * Implementations MUST be defensive: a thrown error causes the worker
+	 * to bill worst-case for that run AND log a warning, so a malformed
+	 * upstream payload won't break ingest.
 	 */
-	readonly costFor?: (params: unknown) => number;
+	readonly costFor?: (params: unknown, response: unknown) => number;
 	/**
 	 * BACKLOG #21 — DIRECTIVA: every endpoint MUST declare a default cron
 	 * so the scheduling layer can auto-wire a JobDefinition without the

--- a/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
+++ b/packages/providers/dataforseo/src/endpoints/keywords-data-search-volume.ts
@@ -27,14 +27,16 @@ export const keywordsDataSearchVolumeDescriptor: EndpointDescriptor = {
 		'Monthly search volume, CPC and competition for up to 1000 keywords in a country/language. Underpins keyword prioritisation.',
 	paramsSchema: KeywordsDataSearchVolumeParams,
 	cost: { unit: 'usd_cents', amount: SEARCH_VOLUME_COST_CENTS_MAX },
-	costFor: (raw) => {
+	// Search-volume billing is fully predictable from the request shape
+	// (cost = keywords × $0.005), so the response argument is unused here.
+	costFor: (params) => {
 		// Reuses the descriptor's own zod schema for safety. The processor
 		// already validated `params` against this schema before dispatch,
 		// so a parse failure here means the resolvedParams object lost
 		// its shape between scheduling and billing — surface it loudly so
 		// the operator notices rather than silently absorbing the worst-
 		// case cost forever.
-		const parsed = KeywordsDataSearchVolumeParams.safeParse(raw);
+		const parsed = KeywordsDataSearchVolumeParams.safeParse(params);
 		if (!parsed.success) {
 			throw new Error(
 				`keywords-data-search-volume costFor: malformed params (${parsed.error.message}); falling back to worst-case`,

--- a/packages/providers/openai/src/acl/responses-to-llm-answer.acl.spec.ts
+++ b/packages/providers/openai/src/acl/responses-to-llm-answer.acl.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { normaliseOpenAiResponse } from './responses-to-llm-answer.acl.js';
+import { responsesWithWebSearchDescriptor } from '../endpoints/responses-with-web-search.js';
+import { costFromRawPayload, normaliseOpenAiResponse } from './responses-to-llm-answer.acl.js';
 
 describe('normaliseOpenAiResponse', () => {
 	it('joins text spans, dedupes citations, counts web_search_calls', () => {
@@ -80,5 +81,43 @@ describe('normaliseOpenAiResponse', () => {
 		expect(result.citationUrls).toEqual([]);
 		expect(result.model).toBe('gpt-5-mini');
 		expect(result.costCents).toBe(0);
+	});
+});
+
+describe('costFromRawPayload (OpenAI)', () => {
+	it('matches the cost computed by normaliseOpenAiResponse on the same payload', () => {
+		const raw = {
+			model: 'gpt-5-mini',
+			output: [
+				{ type: 'web_search_call', id: 'ws_1', status: 'completed' },
+				{ type: 'web_search_call', id: 'ws_2', status: 'completed' },
+			],
+			usage: {
+				input_tokens: 1_000,
+				output_tokens: 2_000,
+				input_tokens_details: { cached_tokens: 200 },
+			},
+		};
+		expect(costFromRawPayload(raw)).toBe(normaliseOpenAiResponse(raw).costCents);
+	});
+
+	it('returns 0 when usage is missing — defensive against malformed responses', () => {
+		expect(costFromRawPayload({})).toBe(0);
+	});
+});
+
+describe('responsesWithWebSearchDescriptor.costFor', () => {
+	it('charges typical-call cost (well below the 3.5¢ worst-case)', () => {
+		const typical = {
+			usage: { input_tokens: 200, output_tokens: 500 },
+			output: [{ type: 'web_search_call' }],
+		};
+		const cost = responsesWithWebSearchDescriptor.costFor?.({}, typical) ?? -1;
+		expect(cost).toBeGreaterThan(0);
+		expect(cost).toBeLessThan(responsesWithWebSearchDescriptor.cost.amount);
+		// 1 web_search × 3¢ + tokens (200 × $0.40/M + 500 × $1.60/M ≈ 0.088¢)
+		// → ~3.09¢. Range allows for pricing nudges without being brittle.
+		expect(cost).toBeGreaterThanOrEqual(3);
+		expect(cost).toBeLessThan(3.2);
 	});
 });

--- a/packages/providers/openai/src/acl/responses-to-llm-answer.acl.ts
+++ b/packages/providers/openai/src/acl/responses-to-llm-answer.acl.ts
@@ -75,6 +75,25 @@ export const normaliseOpenAiResponse = (raw: OpenAiResponsePayload): NormalisedL
 	};
 };
 
+/**
+ * Lightweight cost-only projection for the descriptor's `costFor` hook.
+ * Skips text and citation extraction (the worker only needs the cents
+ * for the api_usage ledger; the full normalisation runs later inside
+ * the IngestRouter). Defensive against undefined `usage` so a malformed
+ * response degrades to zero cost instead of throwing — the worker logs
+ * any throw and bills worst-case in that case.
+ */
+export const costFromRawPayload = (raw: OpenAiResponsePayload): number => {
+	const model = raw.model ?? 'gpt-5-mini';
+	const tokenUsage = AiSearchInsights.TokenUsage.create({
+		inputTokens: raw.usage?.input_tokens ?? 0,
+		outputTokens: raw.usage?.output_tokens ?? 0,
+		cachedInputTokens: raw.usage?.input_tokens_details?.cached_tokens ?? 0,
+		webSearchCalls: countWebSearchCalls(raw.output),
+	});
+	return computeCostCents(model, tokenUsage);
+};
+
 const extractTextFromOutput = (output: OpenAiResponsePayload['output']): string => {
 	if (!Array.isArray(output)) return '';
 	const parts: string[] = [];

--- a/packages/providers/openai/src/endpoints/responses-with-web-search.ts
+++ b/packages/providers/openai/src/endpoints/responses-with-web-search.ts
@@ -1,5 +1,6 @@
 import type { EndpointDescriptor, FetchContext } from '@rankpulse/provider-core';
 import { z } from 'zod';
+import { costFromRawPayload } from '../acl/responses-to-llm-answer.acl.js';
 import { parseCredential } from '../credential.js';
 import type { OpenAiHttp } from '../http.js';
 
@@ -44,8 +45,10 @@ export type ResponsesWithWebSearchParams = z.infer<typeof ResponsesWithWebSearch
  *  - Token component for gpt-5-mini: input $0.40/1M, output $1.60/1M.
  *  - Average response (~200 input + 500 output tokens) → ~0.1 cents in tokens.
  *
- * We pin the descriptor's `cost.amount` to the worst case (3.5 cents) and
- * compute the precise figure in `costFor` once the response usage is known.
+ * `cost.amount` is the worst-case ledger reservation (used when costFor is
+ * unavailable or throws on a malformed payload). `costFor` reads the parsed
+ * usage off the response and returns the precise figure — that's what
+ * api_usage actually charges.
  */
 export const RESPONSES_WORST_CASE_COST_CENTS = 3.5;
 
@@ -57,6 +60,7 @@ export const responsesWithWebSearchDescriptor: EndpointDescriptor = {
 		'Calls OpenAI /v1/responses with the web_search tool enabled, captures the grounded answer + URL citations, and ships the raw text + citations to the AI Brand Radar pipeline.',
 	paramsSchema: ResponsesWithWebSearchParams,
 	cost: { unit: 'usd_cents', amount: RESPONSES_WORST_CASE_COST_CENTS },
+	costFor: (_params, response) => costFromRawPayload(response as OpenAiResponsePayload),
 	defaultCron: '0 7 * * *',
 	rateLimit: { max: 500, durationMs: 60_000 },
 };


### PR DESCRIPTION
## Summary

- Both AI Brand Radar descriptors documented a `costFor` they never actually declared, so api_usage was silently billing worst-case on every fetch (~17% inflation on OpenAI, >3× on Anthropic).
- Extended `EndpointDescriptor.costFor` to `(params, response) => number` so descriptors that bill on response-derived units (tokens, web_search calls) can stay the source of truth for cost.
- Wired the OpenAI and Anthropic descriptors to a small `costFromRawPayload` helper exported from each provider's ACL.
- DataForSEO `keywords-data-search-volume` already had a `costFor` — kept it, just updated the signature to ignore the new second arg.

Closes #95.

## Why this option (over the alternative)

The issue body sketched two paths: extend the descriptor signature so `costFor` can read the response, or have the worker call the ACL's cost helper directly. I went with the signature extension because:

- The descriptor stays the single source of truth for cost — the worker doesn't need a per-provider switch.
- Symmetric: every endpoint that needs response-derived cost just adds a second param. Future providers (e.g. PageSpeed when we measure CrUX coverage) will land into the same hook.
- Only one existing `costFor` call site to update (DataForSEO search-volume — params-only, response unused).

## Cost helper, not full normalisation

`costFromRawPayload` is a light-weight projection of `normaliseXxxResponse`: it builds the same `TokenUsage` and runs `computeCostCents`, but skips text + citation extraction. The IngestRouter still runs the full normalise downstream — there's no double work, the heavyweight pass happens exactly once.

## Defensive behaviour

The worker already wraps `costFor` in try/catch — a thrown error logs and falls back to `cost.amount` (worst-case). The new helpers are also defensive against missing `usage` (return 0) so a malformed upstream payload degrades to "tokens unknown, charge web_search only" rather than throwing.

## Test plan

- [x] `pnpm lint` clean (854 files)
- [x] `pnpm typecheck` clean (26/26)
- [x] `pnpm test` green — 4 new specs across OpenAI + Anthropic providers verify (a) `costFromRawPayload` matches `normaliseXxxResponse.costCents` on the same payload, (b) returns 0 on missing usage, (c) each descriptor's `costFor` lands under the worst-case on a typical-call payload.
- [x] `pnpm build` green (23/23)
- [ ] Production smoke after merge: monitor `api_usage.cost_cents` distributions for `openai-responses-with-web-search` and `anthropic-messages-with-web-search` — should drop to typical-call ranges (~3¢ for both) instead of always landing at the worst-case ceiling.

## Acceptance criteria from #95

- [x] `recordApiUsage` records the precise post-fetch cost for both OpenAI and Anthropic AI Brand Radar fetches.
- [x] `WORST_CASE_COST_CENTS` constants stay as the budgeting upper bound (`cost.amount`).
- [ ] Cost dashboards / per-org spend reports reconcile with provider invoices ±5% — verifiable post-deploy.
- [x] Pricing comments on the descriptors reflect the wired-up reality.