### PR TITLE
refactor(ai-search-insights): unify project-access guard in controller

### DIFF
--- a/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
+++ b/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
@@ -60,11 +60,7 @@ export class AiSearchInsightsController {
 		@Body(new ZodValidationPipe(AiSearchInsightsContracts.RegisterBrandPromptRequest))
 		body: RegisterBrandPromptRequest,
 	): Promise<RegisterBrandPromptResponse> {
-		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
-		if (!project) {
-			throw new NotFoundError(`Project ${projectId} not found`);
-		}
-		await this.orgMembership.require(principal, project.organizationId);
+		const project = await this.requireProjectAccess(principal, projectId);
 		const result = await this.registerPrompt.execute({
 			organizationId: project.organizationId,
 			projectId,
@@ -79,11 +75,7 @@ export class AiSearchInsightsController {
 		@Principal() principal: AuthPrincipal,
 		@Param('projectId') projectId: string,
 	): Promise<ListBrandPromptsResponse> {
-		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
-		if (!project) {
-			throw new NotFoundError(`Project ${projectId} not found`);
-		}
-		await this.orgMembership.require(principal, project.organizationId);
+		await this.requireProjectAccess(principal, projectId);
 		const items = await this.listPrompts.execute({ projectId });
 		return { items: items.map((i) => ({ ...i })) };
 	}
@@ -145,11 +137,7 @@ export class AiSearchInsightsController {
 		@Query(new ZodValidationPipe(AiSearchInsightsContracts.ListLlmAnswersQuery))
 		query: ListLlmAnswersQuery,
 	): Promise<ListLlmAnswersResponse> {
-		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
-		if (!project) {
-			throw new NotFoundError(`Project ${projectId} not found`);
-		}
-		await this.orgMembership.require(principal, project.organizationId);
+		await this.requireProjectAccess(principal, projectId);
 		const items = await this.queryAnswers.execute({
 			projectId,
 			brandPromptId: query.brandPromptId,
@@ -272,11 +260,7 @@ export class AiSearchInsightsController {
 		projectId: string,
 		promptId: string,
 	): Promise<AiSearchInsights.BrandPrompt> {
-		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
-		if (!project) {
-			throw new NotFoundError(`Project ${projectId} not found`);
-		}
-		await this.orgMembership.require(principal, project.organizationId);
+		const project = await this.requireProjectAccess(principal, projectId);
 		const prompt = await this.promptRepo.findById(promptId as AiSearchInsights.BrandPromptId);
 		if (!prompt || prompt.projectId !== project.id) {
 			throw new NotFoundError(`BrandPrompt ${promptId} not found in project ${projectId}`);


### PR DESCRIPTION
## Summary

- Three brand-prompt handlers (`create`, `list`, `listAnswersForProject`) inlined the same 4-line project-access snippet that the dashboard endpoints already centralised in `requireProjectAccess`.
- The private `requirePrompt` helper inlined the same lines a fourth time before its own prompt lookup.
- Replaced all four with calls to `requireProjectAccess`. `create` captures the returned project for `registerPrompt`'s `organizationId`; the others discard it. `requirePrompt` now delegates to `requireProjectAccess` before its prompt lookup.

Closes #96.

## Why bundle requirePrompt with the three issue-named call sites

The issue body called out the three handler-level inlines, but `requirePrompt` carried an exact duplicate of the same logic — including the `findById` + `if (!project) throw` + `orgMembership.require` triplet. Leaving it untouched would mean the next reviewer still has two copies of the guard to keep aligned. The change is the same shape and stays inside the same scope (project-access guard unification), so it lands in this PR rather than spinning a follow-up.

## Test plan

- [x] `pnpm lint` clean (854 files)
- [x] `pnpm --filter @rankpulse/api typecheck` clean
- [x] `pnpm --filter @rankpulse/api test` green (16/16)
- [x] No behavioural change — same `NotFoundError` on missing project, same `OrgMembership.require` 403 on cross-org access. Diff is `+4 −20`, all guard plumbing.