### PR TITLE
refactor(ai-search-insights): tighten read-model + citations use case

### DIFF
--- a/packages/application/src/ai-search-insights/use-cases/query-ai-search-citations.use-case.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-ai-search-citations.use-case.ts
@@ -1,4 +1,5 @@
 import type { AiSearchInsights, ProjectManagement } from '@rankpulse/domain';
+import { safeIso } from '@rankpulse/shared';
 import { normaliseDashboardWindow } from './window-guards.js';
 
 export interface QueryAiSearchCitationsQuery {
@@ -38,11 +39,11 @@ export class QueryAiSearchCitationsUseCase {
 			onlyOwnDomains: query.onlyOwnDomains,
 			aiProvider: query.aiProvider,
 		});
-		const safeIso = (d: Date): string =>
-			Number.isFinite(d.getTime()) ? d.toISOString() : new Date(0).toISOString();
 		return rows.map((r) => ({
 			url: r.url,
-			domain: r.domain ?? '',
+			// `domain` is `COALESCE(domain, '') AS domain` SQL-side, so it
+			// arrives non-null here — no further fallback needed.
+			domain: r.domain,
 			isOwnDomain: r.isOwnDomain,
 			totalCitations: r.totalCitations,
 			providers: r.providers,

--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -4,6 +4,15 @@ import { sql } from 'drizzle-orm';
 import type { DrizzleDatabase } from '../../client.js';
 
 /**
+ * Bridges the two postgres-js result shapes drizzle-orm can return —
+ * `pg-core`'s `Result` exposes the rows on a `.rows` property, while the
+ * `postgres` driver returns the array directly. Each read-model method
+ * needs the array shape; centralising the cast keeps the SQL focus on
+ * what's interesting (the query).
+ */
+const unwrap = <T>(rows: unknown): T[] => ((rows as { rows?: unknown[] }).rows ?? (rows as unknown[])) as T[];
+
+/**
  * On-the-fly aggregation queries against `llm_answers`. Each query relies on
  * the existing `(project_id, captured_at)` and
  * `(project_id, ai_provider, country, language, captured_at)` indexes; jsonb
@@ -55,14 +64,13 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				), 0)::int AS competitor_mention_count
 			FROM base
 		`);
-		const row = (rows as unknown as { rows?: unknown[] }).rows?.[0] ?? rows[0];
-		const r = row as {
+		const r = unwrap<{
 			total_answers: number;
 			answers_with_own_mention: number;
 			own_citation_count: number;
 			own_avg_position: number | null;
 			competitor_mention_count: number;
-		};
+		}>(rows)[0];
 		return {
 			totalAnswers: Number(r?.total_answers ?? 0),
 			answersWithOwnMention: Number(r?.answers_with_own_mention ?? 0),
@@ -134,7 +142,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			GROUP BY e.ai_provider, e.country, e.language, e.brand, t.total_answers
 			ORDER BY t.total_answers DESC, e.brand
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			ai_provider: string;
 			country: string;
 			language: string;
@@ -144,7 +152,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			answers_with_mention: number;
 			avg_position: number | null;
 			citation_count: number;
-		}>;
+		}>(rows);
 		return list.map((r) => {
 			if (!AiSearchInsights.isAiProviderName(r.ai_provider)) {
 				throw new InvalidInputError(`SoV query returned unknown ai_provider "${r.ai_provider}"`);
@@ -211,7 +219,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			ORDER BY total_citations DESC
 			LIMIT 200
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			url: string;
 			domain: string;
 			is_own_domain: boolean;
@@ -219,7 +227,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			providers: string[];
 			first_seen_at: Date | string;
 			last_seen_at: Date | string;
-		}>;
+		}>(rows);
 		return list.map((r) => ({
 			url: r.url,
 			domain: r.domain,
@@ -260,11 +268,11 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			GROUP BY day
 			ORDER BY day
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			day: string;
 			total_answers: number;
 			answers_with_own_mention: number;
-		}>;
+		}>(rows);
 		return list.map((r) => ({
 			day: r.day,
 			totalAnswers: Number(r.total_answers ?? 0),
@@ -338,7 +346,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			FROM base
 			GROUP BY ai_provider, country, language
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			ai_provider: string;
 			country: string;
 			language: string;
@@ -346,7 +354,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			this_week_own_mentions: number;
 			last_week_total: number;
 			last_week_own_mentions: number;
-		}>;
+		}>(rows);
 		return list
 			.filter((r) => AiSearchInsights.isAiProviderName(r.ai_provider))
 			.map((r) => {
@@ -449,7 +457,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			FROM top_streak t
 			JOIN latest_per_locale l USING (ai_provider, country, language)
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			url: string;
 			domain: string;
 			ai_provider: string;
@@ -458,7 +466,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			streak_days: number;
 			last_seen_at: Date | string;
 			currently_cited: boolean;
-		}>;
+		}>(rows);
 		return list
 			.filter((r) => AiSearchInsights.isAiProviderName(r.ai_provider))
 			.map((r) => ({
@@ -521,14 +529,14 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			LEFT JOIN own_pos o
 				ON o.ai_provider = c.ai_provider AND o.country = c.country AND o.language = c.language
 		`);
-		const list = ((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{
+		const list = unwrap<{
 			ai_provider: string;
 			country: string;
 			language: string;
 			own_avg_position: number | null;
 			competitor_brand: string;
 			competitor_avg_position: number | null;
-		}>;
+		}>(rows);
 		return list
 			.filter((r) => AiSearchInsights.isAiProviderName(r.ai_provider))
 			.map((r) => ({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,5 @@ export * from './date-tokens.js';
 export * from './either.js';
 export * from './errors.js';
 export * from './ids.js';
+export * from './iso.js';
 export * from './result.js';

--- a/packages/shared/src/iso.spec.ts
+++ b/packages/shared/src/iso.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { safeIso } from './iso.js';
+
+describe('safeIso', () => {
+	it('returns the ISO-8601 string for a valid date', () => {
+		expect(safeIso(new Date('2026-05-07T12:34:56.789Z'))).toBe('2026-05-07T12:34:56.789Z');
+	});
+
+	it('returns the epoch when the date is invalid (NaN time)', () => {
+		expect(safeIso(new Date(Number.NaN))).toBe('1970-01-01T00:00:00.000Z');
+	});
+
+	it('returns the epoch when the date is an Invalid Date sentinel', () => {
+		expect(safeIso(new Date('not-a-date'))).toBe('1970-01-01T00:00:00.000Z');
+	});
+});

--- a/packages/shared/src/iso.ts
+++ b/packages/shared/src/iso.ts
@@ -1,0 +1,10 @@
+/**
+ * Serialises a `Date` to ISO-8601, defaulting to the epoch when the input
+ * is an invalid `Date` (e.g. `new Date(NaN)` or a `MIN`/`MAX` aggregate
+ * over an empty result set). Use whenever a `Date` flowed in from raw
+ * SQL or an external boundary and the caller can't guarantee validity —
+ * `Date.toISOString()` throws on invalid dates, which would otherwise
+ * cascade into a 500.
+ */
+export const safeIso = (d: Date): string =>
+	Number.isFinite(d.getTime()) ? d.toISOString() : new Date(0).toISOString();


### PR DESCRIPTION
## Summary

Three DX cleanups inside the AI Brand Radar slice, no behaviour change:

- **`unwrap<T>` helper extracted** in `drizzle-llm-answer-read-model.ts`. The 4-line `((rows as unknown as { rows?: unknown[] }).rows ?? rows) as Array<{...}>` incantation appeared 7 times to bridge the two postgres-js result shapes drizzle-orm can return. One module-scope generic now covers all call sites.
- **`safeIso` promoted to `@rankpulse/shared`.** The ISO-date serialiser that defaults to the epoch on invalid `Date` instances now lives next to `Clock` instead of inline in `query-ai-search-citations.use-case.ts`. Came with a 3-spec test file.
- **Redundant `r.domain ?? ''` dropped** in the citations use case. The SQL already has `COALESCE(domain, '') AS domain`, so the JS fallback was dead. Inline comment notes the SQL guarantee for the next reader.

Closes #94.

## Test plan

- [x] `pnpm lint` clean (856 files)
- [x] `pnpm typecheck` clean (26/26)
- [x] `pnpm test` green — `@rankpulse/shared` 32/32 (incl. new `safeIso` specs), `@rankpulse/application` 247/247, all packages green.
- [x] `pnpm build` green (23/23)

## Acceptance from #94

- [x] `unwrap<T>` helper extracted, all 7 read-model methods use it.
- [x] `safeIso` lives in `@rankpulse/shared` and is imported by the citations use case.
- [x] Redundant `?? ''` removed.
- [x] No behaviour change — existing tests still pass without modification.