### PR TITLE
feat(provider-core): add HttpConfig.maxResponseBytes + retire 7 cap-only request<T> overrides

### DIFF
--- a/packages/providers/anthropic/src/http.spec.ts
+++ b/packages/providers/anthropic/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://api.anthropic.com/v1',
 	auth: { kind: 'api-key-header', headerName: 'x-api-key' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validKey, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/anthropic/src/http.ts
+++ b/packages/providers/anthropic/src/http.ts
@@ -4,7 +4,12 @@
  * weight, and the surface is intentionally small (one POST helper).
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface AnthropicHttpOptions {
 	baseUrl?: string;
@@ -22,29 +27,6 @@ const RESPONSE_BODY_MAX_BYTES = 4_096;
 const PROVIDER_ID = 'anthropic';
 
 /**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than just `applyAuth`. See
- * the class header for the rationale.
- */
-function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
-
-/**
  * BaseHttpClient adapter for the Anthropic Messages API.
  *
  * Anthropic's auth model is two-pronged: the secret API key goes in
@@ -52,28 +34,22 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * MUST also carry the fixed `anthropic-version: 2023-06-01` header. The
  * default `BaseHttpClient.applyAuth` for `kind: 'api-key-header'` only
  * emits the secret-bearing header, so we override `applyAuth` to emit
- * BOTH headers — `applyAuth` is the right hook for "all auth-related
+ * BOTH — `applyAuth` is the documented hook for "all auth-related
  * headers", which includes the API version pin Anthropic treats as part
  * of the auth contract.
  *
- * `request` is also overridden, but ONLY to enforce the 8MB response
- * body cap. The Messages API typically returns a few KB but a runaway
- * model that spams `web_search` results (capped at 5 uses today, but the
- * cap is in the request body, not enforced upstream) could in theory
- * push the response over the limit. The cap aborts before OOM-ing the
- * worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
- * Used by the manifest path (Phase 5+). The legacy `AnthropicHttp` class
- * below preserves the existing `fetchMessagesWithWebSearch(http:
+ * Used by the manifest path. The legacy `AnthropicHttp` class below
+ * preserves the existing `fetchMessagesWithWebSearch(http:
  * AnthropicHttp, ...)` signature for the OLD `AnthropicProvider`, which
  * Phase 7 deletes.
  */
 export class AnthropicHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 
 	/**
@@ -90,87 +66,6 @@ export class AnthropicHttpClient extends BaseHttpClient {
 			'x-api-key': plaintextSecret,
 			'anthropic-version': ANTHROPIC_VERSION,
 		};
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS);
-		const signal = composeSignals(ctx.signal, internalSignal);
-
-		// `applyAuth` is overridden above to emit `x-api-key` + the fixed
-		// `anthropic-version` pin. Adding `Accept` here keeps content
-		// negotiation localised to the request path.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Anthropic ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Anthropic ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
 	}
 }
 

--- a/packages/providers/anthropic/src/manifest.ts
+++ b/packages/providers/anthropic/src/manifest.ts
@@ -31,9 +31,11 @@ import { type AnthropicHttp, AnthropicHttpClient, buildLegacyShim } from './http
  *   The manifest still declares `'api-key-header'` so the strategy is
  *   self-documenting; the override just extends, doesn't replace, the
  *   contract.
- * - Why `AnthropicHttpClient.request` is overridden anyway: see
- *   `./http.ts` header. The override exists ONLY to enforce the 8MB
- *   response body cap (Content-Length pre-flight + post-read guard).
+ * - Why no `request<T>` override: the 8MB body cap lives on
+ *   `manifest.http.maxResponseBytes` and is enforced by
+ *   `BaseHttpClient.parseResponse`. `AnthropicHttpClient` only
+ *   overrides `applyAuth` (for the dual `x-api-key` + `anthropic-version`
+ *   headers).
  * - Why the ACL wraps the single normalised answer in an array:
  *   `normaliseAnthropicResponse()` returns ONE `NormalisedLlmAnswer`
  *   object — Anthropic's Messages API returns a single assistant
@@ -125,6 +127,9 @@ export const anthropicProviderManifest: ProviderManifest = {
 		baseUrl: 'https://api.anthropic.com/v1',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Messages API typically returns a few KB; 8 MB is generous but
+		// still tight enough to abort runaway responses before OOM.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `parseCredential` throws InvalidInputError on the wrong shape

--- a/packages/providers/bing/src/http.ts
+++ b/packages/providers/bing/src/http.ts
@@ -8,7 +8,12 @@
  * account.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 import { validateBingApiKey } from './credential.js';
 
 export interface BingHttpOptions {
@@ -64,11 +69,8 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * deletes.
  */
 export class BingHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 
 	protected override async request<T>(
@@ -102,7 +104,7 @@ export class BingHttpClient extends BaseHttpClient {
 
 		let response: Response;
 		try {
-			response = await this.fetchImpl(url, init);
+			response = await (this.fetchImpl ?? globalThis.fetch)(url, init);
 		} catch (err) {
 			const message =
 				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')

--- a/packages/providers/brevo/src/http.spec.ts
+++ b/packages/providers/brevo/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://api.brevo.com/v3',
 	auth: { kind: 'api-key-header', headerName: 'api-key' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validApiKey, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/brevo/src/http.ts
+++ b/packages/providers/brevo/src/http.ts
@@ -5,7 +5,12 @@
  * misconfigured cron can't drain the quota in a stuck retry loop.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 import { validateBrevoApiKey } from './credential.js';
 
 export interface BrevoHttpOptions {
@@ -14,33 +19,17 @@ export interface BrevoHttpOptions {
 }
 
 const DEFAULT_BASE_URL = 'https://api.brevo.com/v3';
+/**
+ * Cap on response body. Brevo email-stats responses are typically <1MB;
+ * 8MB is a generous safety net for `/contacts/{id}` payloads with long
+ * event histories. Lives on `manifest.http.maxResponseBytes`; kept here
+ * as a constant so the legacy `BrevoHttp` path (below) enforces the
+ * same cap.
+ */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
 
 const PROVIDER_ID = 'brevo';
-
-/**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
 
 /**
  * BaseHttpClient adapter for Brevo (Sendinblue) REST API v3.
@@ -48,108 +37,19 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * Auth is the simplest non-Bearer case: a single API key applied as
  * `api-key: <plaintext>` (NOT `Authorization: Bearer ...`). The default
  * `BaseHttpClient.applyAuth` for `kind: 'api-key-header'` already produces
- * exactly that header, so we re-use it via `super.applyAuth(...)` rather
- * than duplicating the logic.
+ * exactly that header, so no override is needed.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce Brevo's 8MB response body cap. Brevo statistics
- * payloads are usually small, but the `/contacts/{id}` endpoint can return
- * large per-contact event streams when a recipient has been on heavy
- * campaigns for years; the cap aborts runaway responses before they can
- * OOM the worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
  * Used by the manifest path (Phase 5+). The legacy `BrevoHttp` class
  * below preserves the existing `fetch<X>(http: BrevoHttp, ...)` signature
  * for the OLD `BrevoProvider`, which Phase 7 deletes.
  */
 export class BrevoHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? 60_000);
-		const signal = composeSignals(ctx.signal, internalSignal);
-
-		// Re-use the parent's api-key-header construction so we don't
-		// duplicate the `api-key: <plaintext>` formatting. The default
-		// `applyAuth` for `kind: 'api-key-header'` returns exactly
-		// `{ [headerName]: plaintextSecret }` which is all Brevo needs.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Brevo ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Brevo ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 

--- a/packages/providers/brevo/src/manifest.ts
+++ b/packages/providers/brevo/src/manifest.ts
@@ -40,11 +40,10 @@ import { type BrevoHttp, BrevoHttpClient, buildLegacyShim } from './http.js';
  *   `X-API-Key`). The default `BaseHttpClient.applyAuth` for this kind
  *   already returns `{ [headerName]: plaintextSecret }`, so the manifest
  *   needs zero auth-specific overrides.
- * - Why `BrevoHttpClient.request` is overridden anyway: see `./http.ts`
- *   header. The override exists ONLY to enforce Brevo's 8MB response
- *   body cap (Content-Length pre-flight + post-read guard). The auth
- *   header itself is re-used from the parent via `super.applyAuth(...)`
- *   — no duplication.
+ * - Why no `BrevoHttpClient.request` override: Brevo's 8MB response
+ *   body cap moved to `manifest.http.maxResponseBytes` and is enforced
+ *   by `BaseHttpClient.parseResponse` (Content-Length pre-flight +
+ *   post-read guard). No subclass override is needed for the body cap.
  * - Why ALL FOUR endpoints have `ingest: null`: Brevo's payloads are
  *   raw-only ingest today — no worker dispatch is wired (verified by
  *   `grep -n 'brevo' apps/worker/src/processors/provider-fetch.processor.ts`
@@ -117,6 +116,10 @@ export const brevoProviderManifest: ProviderManifest = {
 		baseUrl: 'https://api.brevo.com/v3',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Brevo email-stats responses are typically <1MB; 8MB is a generous
+		// safety net for `/contacts/{id}` payloads with long event histories.
+		// Enforced by `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `validateBrevoApiKey` throws InvalidInputError on the wrong shape

--- a/packages/providers/cloudflare-radar/src/http.spec.ts
+++ b/packages/providers/cloudflare-radar/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://api.cloudflare.com/client/v4',
 	auth: { kind: 'bearer-token' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validToken, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/cloudflare-radar/src/http.ts
+++ b/packages/providers/cloudflare-radar/src/http.ts
@@ -4,7 +4,12 @@
  * 60 req/min in descriptors so a misconfigured cron can't drain it.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface CloudflareRadarHttpOptions {
 	baseUrl?: string;
@@ -12,33 +17,18 @@ export interface CloudflareRadarHttpOptions {
 }
 
 const DEFAULT_BASE_URL = 'https://api.cloudflare.com/client/v4';
+/**
+ * Cap on response body. Cloudflare Radar `/radar/ranking/domain/<domain>`
+ * payloads are usually tiny; 8MB is a generous safety net against a
+ * misbehaving upstream or a future endpoint with category splits over
+ * many dimensions. Lives on `manifest.http.maxResponseBytes`; kept here
+ * as a constant so the legacy `CloudflareRadarHttp` path (below)
+ * enforces the same cap.
+ */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
 
 const PROVIDER_ID = 'cloudflare-radar';
-
-/**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
 
 /**
  * BaseHttpClient adapter for Cloudflare Radar.
@@ -46,106 +36,19 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * Auth is the simplest case: a single bearer token applied as
  * `Authorization: Bearer <plaintext>`. The default
  * `BaseHttpClient.applyAuth` for `kind: 'bearer-token'` already produces
- * exactly that header, so we re-use it via `super.applyAuth(...)` rather
- * than duplicating the logic.
+ * exactly that header, so no override is needed.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce Cloudflare Radar's 8MB response body cap. The
- * `/radar/ranking/domain/<domain>` payloads are usually tiny, but a
- * misbehaving upstream (or a future endpoint with category splits over
- * many dimensions) could produce surprisingly large responses; the cap
- * aborts runaway responses before they can OOM the worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
  * Used by the manifest path (Phase 5+). The legacy `CloudflareRadarHttp`
  * class below preserves the existing `fetchDomainRank(http: CloudflareRadarHttp, ...)`
  * signature for the OLD `CloudflareRadarProvider`, which Phase 7 deletes.
  */
 export class CloudflareRadarHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? 60_000);
-		const signal = composeSignals(ctx.signal, internalSignal);
-
-		// Re-use the parent's bearer-token header construction so we don't
-		// duplicate the `Authorization: Bearer <token>` formatting.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Cloudflare ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Cloudflare ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 

--- a/packages/providers/cloudflare-radar/src/manifest.ts
+++ b/packages/providers/cloudflare-radar/src/manifest.ts
@@ -25,11 +25,11 @@ import { buildLegacyShim, type CloudflareRadarHttp, CloudflareRadarHttpClient } 
  *   `Authorization: Bearer <token>`. The default
  *   `BaseHttpClient.applyAuth` for this kind already produces exactly
  *   that header, so the manifest needs zero auth-specific overrides.
- * - Why `CloudflareRadarHttpClient.request` is overridden anyway: see
- *   `./http.ts` header. The override exists ONLY to enforce Cloudflare
- *   Radar's 8MB response body cap (Content-Length pre-flight + post-read
- *   guard). The auth header itself is re-used from the parent via
- *   `super.applyAuth(...)` — no duplication.
+ * - Why no `CloudflareRadarHttpClient.request` override: Cloudflare
+ *   Radar's 8MB response body cap moved to
+ *   `manifest.http.maxResponseBytes` and is enforced by
+ *   `BaseHttpClient.parseResponse` (Content-Length pre-flight +
+ *   post-read guard). No subclass override is needed for the body cap.
  * - Why the ACL wraps the single snapshot in an array: Cloudflare Radar
  *   returns ONE snapshot per call (the current rank for the requested
  *   domain — `meta.lastUpdated` carries the data freshness date).
@@ -137,6 +137,11 @@ export const cloudflareRadarProviderManifest: ProviderManifest = {
 		baseUrl: 'https://api.cloudflare.com/client/v4',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Cloudflare Radar `/radar/ranking/domain/<domain>` payloads are
+		// usually tiny; 8MB is a generous safety net for a misbehaving
+		// upstream or a future multi-dimension category split. Enforced
+		// by `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `validateCloudflareToken` throws InvalidInputError on the wrong

--- a/packages/providers/core/src/http-base.spec.ts
+++ b/packages/providers/core/src/http-base.spec.ts
@@ -92,4 +92,67 @@ describe('BaseHttpClient', () => {
 		await expect(promise).rejects.toBeInstanceOf(ProviderApiError);
 		fetchMock.mockRestore();
 	});
+
+	it('sets Accept: application/json by default', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		const client = new TestClient('test', config);
+		await client.get('/endpoint', {}, ctx());
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		expect(init.headers).toMatchObject({ Accept: 'application/json' });
+		fetchMock.mockRestore();
+	});
+
+	it('throws ProviderApiError when Content-Length exceeds maxResponseBytes', async () => {
+		const overCap = String(8 * 1024 * 1024 + 1);
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response('{}', {
+				status: 200,
+				headers: { 'content-type': 'application/json', 'content-length': overCap },
+			}),
+		);
+		const capped: HttpConfig = { ...config, maxResponseBytes: 8 * 1024 * 1024 };
+		const client = new TestClient('test', capped);
+		await expect(client.get('/endpoint', {}, ctx())).rejects.toMatchObject({
+			name: 'ProviderApiError',
+			providerId: 'test',
+			message: expect.stringContaining('response too large'),
+		});
+		fetchMock.mockRestore();
+	});
+
+	it('throws ProviderApiError when post-read body length exceeds maxResponseBytes', async () => {
+		// No Content-Length header → pre-flight passes; post-read guard catches
+		// it. Simulates a chunked transfer or a mis-configured proxy.
+		const cap = 1024;
+		const oversized = 'x'.repeat(cap + 1);
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(oversized, {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+		const capped: HttpConfig = { ...config, maxResponseBytes: cap };
+		const client = new TestClient('test', capped);
+		await expect(client.get('/endpoint', {}, ctx())).rejects.toMatchObject({
+			message: expect.stringContaining('response too large'),
+		});
+		fetchMock.mockRestore();
+	});
+
+	it('passes responses under the cap straight through', async () => {
+		const cap = 1024;
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+		const capped: HttpConfig = { ...config, maxResponseBytes: cap };
+		const client = new TestClient('test', capped);
+		const result = await client.get<{ ok: boolean }>('/endpoint', {}, ctx());
+		expect(result).toEqual({ ok: true });
+		fetchMock.mockRestore();
+	});
 });

--- a/packages/providers/core/src/http-base.ts
+++ b/packages/providers/core/src/http-base.ts
@@ -36,11 +36,32 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * common cases (bearer, api-key-header, basic). Custom strategies provide
  * their own `sign(req, secret)` function or override the method.
  */
+export interface BaseHttpClientOptions {
+	/**
+	 * Optional fetch override for tests — production code uses the global
+	 * `fetch`. Injected at construction so each subclass can take a
+	 * `{ fetchImpl }` argument too without re-implementing `request`.
+	 */
+	readonly fetchImpl?: typeof fetch;
+}
+
 export abstract class BaseHttpClient implements HttpClient {
+	/**
+	 * Test-injectable fetch reference. `protected` so subclasses that
+	 * override `request<T>` (bing, meta, pagespeed, wikipedia, …) can use
+	 * the SAME injection point — they don't declare their own field. The
+	 * `?? globalThis.fetch` fallback in `request` here is the production
+	 * default; subclass overrides should mirror it.
+	 */
+	protected readonly fetchImpl?: typeof fetch;
+
 	constructor(
 		protected readonly providerId: string,
 		protected readonly config: HttpConfig,
-	) {}
+		options: BaseHttpClientOptions = {},
+	) {
+		this.fetchImpl = options.fetchImpl;
+	}
 
 	get<T>(path: string, query: Record<string, string>, ctx: FetchContext): Promise<T> {
 		return this.request<T>('GET', path, query, undefined, ctx);
@@ -69,7 +90,10 @@ export abstract class BaseHttpClient implements HttpClient {
 		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? 60_000);
 		const signal = composeSignals(ctx.signal, internalSignal);
 
-		const headers = this.applyAuth(ctx.credential.plaintextSecret, body);
+		const headers = {
+			Accept: 'application/json',
+			...this.applyAuth(ctx.credential.plaintextSecret, body),
+		};
 		const init: RequestInit = { method, signal, headers };
 		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
 			init.body = JSON.stringify(body);
@@ -78,7 +102,7 @@ export abstract class BaseHttpClient implements HttpClient {
 
 		let response: Response;
 		try {
-			response = await fetch(url, init);
+			response = await (this.fetchImpl ?? globalThis.fetch)(url, init);
 		} catch (err) {
 			const message =
 				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
@@ -101,7 +125,31 @@ export abstract class BaseHttpClient implements HttpClient {
 	}
 
 	protected async parseResponse<T>(response: Response, method: string, path: string): Promise<T> {
+		const cap = this.config.maxResponseBytes;
+		// Two-stage cap: trust the upstream's Content-Length when it's
+		// honest (cheap reject before allocating the read buffer), then
+		// re-check the post-read length in case the header was missing
+		// or wrong (chunked transfer, mis-configured proxy, …).
+		if (cap !== undefined) {
+			const contentLength = Number(response.headers.get('content-length'));
+			if (Number.isFinite(contentLength) && contentLength > cap) {
+				throw new ProviderApiError(
+					this.providerId,
+					response.status,
+					undefined,
+					`${this.providerId} ${method} ${path} → response too large (Content-Length ${contentLength} > ${cap})`,
+				);
+			}
+		}
 		const text = await response.text();
+		if (cap !== undefined && text.length > cap) {
+			throw new ProviderApiError(
+				this.providerId,
+				response.status,
+				undefined,
+				`${this.providerId} ${method} ${path} → response too large (${text.length} bytes > ${cap})`,
+			);
+		}
 		// 204 No Content + 200 with empty body are both legitimate "no payload"
 		// signals from upstreams; returning undefined is safer than throwing.
 		if (text.length === 0) return undefined as unknown as T;

--- a/packages/providers/core/src/manifest.ts
+++ b/packages/providers/core/src/manifest.ts
@@ -49,6 +49,21 @@ export interface HttpConfig {
 	readonly auth: AuthStrategy;
 	readonly defaultTimeoutMs?: number;
 	readonly defaultRetries?: number;
+	/**
+	 * Hard cap on the upstream response body (bytes). When set,
+	 * `BaseHttpClient.parseResponse` does a Content-Length pre-flight
+	 * AND a post-read length guard, throwing `ProviderApiError(provider,
+	 * status, …)` with `message: "response too large"` either way.
+	 * Default (undefined): no cap — the parent's behaviour, suitable for
+	 * providers whose responses are bounded by their API's own paging.
+	 *
+	 * Picked per provider based on the upstream's worst-case response:
+	 * most APIs cap at 8 MB; DataForSEO SERP-advanced legitimately needs
+	 * 32 MB; Wikipedia is constrained to 4 MB by the article-summary
+	 * shape. Setting the cap explicitly even when matching the default
+	 * documents the choice for the next reader.
+	 */
+	readonly maxResponseBytes?: number;
 }
 
 export type AuthStrategy =

--- a/packages/providers/google-ai-studio/src/http.spec.ts
+++ b/packages/providers/google-ai-studio/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
 	auth: { kind: 'api-key-header', headerName: 'x-goog-api-key' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validApiKey, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/google-ai-studio/src/http.ts
+++ b/packages/providers/google-ai-studio/src/http.ts
@@ -6,7 +6,12 @@
  */
 
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface GoogleAiStudioHttpOptions {
 	baseUrl?: string;
@@ -17,33 +22,18 @@ export interface GoogleAiStudioHttpOptions {
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 const DEFAULT_TIMEOUT_MS = 60_000;
 
+/**
+ * Cap on response body. Gemini `generateContent` payloads are usually
+ * small, but a 4000-token output paired with verbose grounding metadata
+ * can produce surprisingly large responses; 8MB is generous but tight
+ * enough to abort runaway responses before OOM. Lives on
+ * `manifest.http.maxResponseBytes`; kept here as a constant so the
+ * legacy `GoogleAiStudioHttp` path (below) enforces the same cap.
+ */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
 
 const PROVIDER_ID = 'google-ai-studio';
-
-/**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
 
 /**
  * BaseHttpClient adapter for Google AI Studio (`generativelanguage.googleapis.com`).
@@ -51,15 +41,12 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * Auth is the simplest header case: a single API key applied as
  * `x-goog-api-key: <plaintext>`. The default
  * `BaseHttpClient.applyAuth` for `kind: 'api-key-header'` already produces
- * exactly that header (using the manifest's `headerName`), so we re-use it
- * via `super.applyAuth(...)` rather than duplicating the logic.
+ * exactly that header (using the manifest's `headerName`), so no override
+ * is needed.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce Google AI Studio's 8MB response body cap.
- * Gemini `generateContent` payloads are usually small, but a 4000-token
- * output paired with verbose grounding metadata can produce surprisingly
- * large responses; the cap aborts runaway responses before they can OOM
- * the worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
  * Used by the manifest path (Phase 5+). The legacy `GoogleAiStudioHttp`
  * class below preserves the existing `fetchGeminiGrounded(http:
@@ -67,91 +54,8 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * which Phase 7 deletes.
  */
 export class GoogleAiStudioHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS);
-		const signal = composeSignals(ctx.signal, internalSignal);
-
-		// Re-use the parent's api-key-header construction so we don't
-		// duplicate the `x-goog-api-key: <plaintext>` formatting.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Google AI Studio ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Google AI Studio ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 
@@ -176,7 +80,7 @@ export class GoogleAiStudioHttp {
 		const url = `${this.baseUrl}${path}`;
 		const internalAbort = new AbortController();
 		const timeoutHandle = setTimeout(() => internalAbort.abort(), this.timeoutMs);
-		const composedSignal = composeSignals(signal, internalAbort.signal);
+		const composedSignal = composeLegacySignals(signal, internalAbort.signal);
 
 		try {
 			const response = await this.fetchImpl(url, {
@@ -271,3 +175,24 @@ const safeParse = (text: string): unknown => {
 		return text;
 	}
 };
+
+/**
+ * Composes two AbortSignals so the legacy `GoogleAiStudioHttp.post` aborts
+ * when EITHER fires (caller signal + internal timeout). Used only by the
+ * legacy class below; the new `GoogleAiStudioHttpClient` path uses the
+ * `BaseHttpClient` signal composition helper instead.
+ */
+function composeLegacySignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
+	const real = signals.filter((s): s is AbortSignal => Boolean(s));
+	const [first, second] = real;
+	if (first && !second) return first;
+	const controller = new AbortController();
+	for (const s of real) {
+		if (s.aborted) {
+			controller.abort();
+			return controller.signal;
+		}
+		s.addEventListener('abort', () => controller.abort(), { once: true });
+	}
+	return controller.signal;
+}

--- a/packages/providers/google-ai-studio/src/manifest.ts
+++ b/packages/providers/google-ai-studio/src/manifest.ts
@@ -26,10 +26,10 @@ import { buildLegacyShim, type GoogleAiStudioHttp, GoogleAiStudioHttpClient } fr
  *   header (the `?key=` query-param form leaks into proxy logs). The
  *   default `BaseHttpClient.applyAuth` for `'api-key-header'` produces
  *   exactly `{ [headerName]: plaintextSecret }`, so we re-use it.
- * - Why `GoogleAiStudioHttpClient.request` is overridden anyway: see
- *   `./http.ts`. The override exists ONLY to enforce the 8MB response
- *   body cap. The auth header itself is re-used from the parent via
- *   `super.applyAuth(...)` — no duplication.
+ * - Why no `GoogleAiStudioHttpClient.request` override: the 8MB response
+ *   body cap moved to `manifest.http.maxResponseBytes` and is enforced
+ *   by `BaseHttpClient.parseResponse` (Content-Length pre-flight +
+ *   post-read guard). No subclass override is needed for the body cap.
  * - Why the ACL wraps the single normalised answer in an array:
  *   `normaliseGeminiResponse()` returns ONE `NormalisedLlmAnswer` per
  *   `generateContent` payload — the use case ingests one answer per
@@ -85,6 +85,11 @@ export const googleAiStudioProviderManifest: ProviderManifest = {
 		baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Gemini `generateContent` payloads are usually small, but verbose
+		// grounding metadata on a 4000-token output can grow large; 8MB is
+		// generous but tight enough to abort runaway responses before OOM.
+		// Enforced by `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `parseCredential` throws InvalidInputError on a malformed key;

--- a/packages/providers/meta/src/http.ts
+++ b/packages/providers/meta/src/http.ts
@@ -8,7 +8,12 @@
  * 60 req/min in descriptors so a misconfigured cron can't drain it.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 import { validateMetaAccessToken } from './credential.js';
 
 export interface MetaHttpOptions {
@@ -72,11 +77,8 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * `MetaProvider`, which Phase 7 deletes.
  */
 export class MetaHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 
 	protected override async request<T>(
@@ -110,7 +112,7 @@ export class MetaHttpClient extends BaseHttpClient {
 
 		let response: Response;
 		try {
-			response = await this.fetchImpl(url, init);
+			response = await (this.fetchImpl ?? globalThis.fetch)(url, init);
 		} catch (err) {
 			const message =
 				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')

--- a/packages/providers/microsoft-clarity/src/http.spec.ts
+++ b/packages/providers/microsoft-clarity/src/http.spec.ts
@@ -10,6 +10,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://www.clarity.ms/export-data/api/v1',
 	auth: { kind: 'bearer-token' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validToken, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/microsoft-clarity/src/http.ts
+++ b/packages/providers/microsoft-clarity/src/http.ts
@@ -5,7 +5,12 @@
  * in the descriptor so backfills don't burn the budget in seconds.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface ClarityHttpOptions {
 	baseUrl?: string;
@@ -13,33 +18,17 @@ export interface ClarityHttpOptions {
 }
 
 const DEFAULT_BASE_URL = 'https://www.clarity.ms/export-data/api/v1';
+/**
+ * Cap on response body. Clarity `/project-live-insights` payloads are
+ * usually small, but a misconfigured project with many dimensions can
+ * produce surprisingly large responses; 8MB is a generous safety net.
+ * Lives on `manifest.http.maxResponseBytes`; kept here as a constant so
+ * the legacy `ClarityHttp` path (below) enforces the same cap.
+ */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
 
 const PROVIDER_ID = 'microsoft-clarity';
-
-/**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
 
 /**
  * BaseHttpClient adapter for Microsoft Clarity Data Export.
@@ -47,105 +36,19 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * Auth is the simplest case: a single bearer token applied as
  * `Authorization: Bearer <plaintext>`. The default
  * `BaseHttpClient.applyAuth` for `kind: 'bearer-token'` already produces
- * exactly that header, so we re-use it via `super.applyAuth(...)` rather
- * than duplicating the logic.
+ * exactly that header, so no override is needed.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce Clarity's 8MB response body cap. Clarity's
- * `/project-live-insights` payloads are usually small, but a misconfigured
- * project with many dimensions can produce surprisingly large responses;
- * the cap aborts runaway responses before they can OOM the worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
  * Used by the manifest path (Phase 5+). The legacy `ClarityHttp` class
  * below preserves the existing `fetchDataExport(http: ClarityHttp, ...)`
  * signature for the OLD `ClarityProvider`, which Phase 7 deletes.
  */
 export class ClarityHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? 60_000);
-		const signal = composeSignals(ctx.signal, internalSignal);
-
-		// Re-use the parent's bearer-token header construction so we don't
-		// duplicate the `Authorization: Bearer <token>` formatting.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Clarity ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Clarity ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 

--- a/packages/providers/microsoft-clarity/src/manifest.ts
+++ b/packages/providers/microsoft-clarity/src/manifest.ts
@@ -24,11 +24,10 @@ import { buildLegacyShim, type ClarityHttp, ClarityHttpClient } from './http.js'
  *   simplest possible — `Authorization: Bearer <token>`. The default
  *   `BaseHttpClient.applyAuth` for this kind already produces exactly
  *   that header, so the manifest needs zero auth-specific overrides.
- * - Why `ClarityHttpClient.request` is overridden anyway: see
- *   `./http.ts` header. The override exists ONLY to enforce Clarity's
- *   8MB response body cap (Content-Length pre-flight + post-read guard).
- *   The auth header itself is re-used from the parent via
- *   `super.applyAuth(...)` — no duplication.
+ * - Why no `ClarityHttpClient.request` override: Clarity's 8MB response
+ *   body cap moved to `manifest.http.maxResponseBytes` and is enforced
+ *   by `BaseHttpClient.parseResponse` (Content-Length pre-flight +
+ *   post-read guard). No subclass override is needed for the body cap.
  * - Why the ACL wraps the single snapshot in an array: Clarity returns
  *   aggregated metrics over the requested `numOfDays` window — i.e. ONE
  *   snapshot, not a per-day series. `extractSnapshot()` returns a single
@@ -125,6 +124,11 @@ export const microsoftClarityProviderManifest: ProviderManifest = {
 		baseUrl: 'https://www.clarity.ms/export-data/api/v1',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Clarity `/project-live-insights` payloads are usually small, but
+		// a misconfigured project with many dimensions can produce
+		// surprisingly large responses; 8MB is a generous safety net.
+		// Enforced by `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `validateClarityToken` throws InvalidInputError on the wrong

--- a/packages/providers/openai/src/http.spec.ts
+++ b/packages/providers/openai/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://api.openai.com/v1',
 	auth: { kind: 'bearer-token' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validApiKey, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/openai/src/http.ts
+++ b/packages/providers/openai/src/http.ts
@@ -9,7 +9,12 @@
  *  - Response `usage` with `input_tokens`, `output_tokens`, `cached_tokens`.
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface OpenAiHttpOptions {
 	baseUrl?: string;
@@ -25,6 +30,8 @@ const DEFAULT_TIMEOUT_MS = 60_000;
  * Cap on response body. The OpenAI `/v1/responses` payload includes the
  * full text plus annotations, occasionally hits a few hundred KB; 8MB is
  * generous but still tight enough to abort runaway responses before OOM.
+ * Lives on `manifest.http.maxResponseBytes`; kept here as a constant so
+ * the legacy `OpenAiHttp` path (below) enforces the same cap.
  */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
@@ -32,133 +39,24 @@ const RESPONSE_BODY_MAX_BYTES = 4_096;
 const PROVIDER_ID = 'openai';
 
 /**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeBaseSignals(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
-
-/**
  * BaseHttpClient adapter for the OpenAI Responses API.
  *
  * Auth is the simplest case: a single bearer API key applied as
  * `Authorization: Bearer <plaintext>`. The default
  * `BaseHttpClient.applyAuth` for `kind: 'bearer-token'` already produces
- * exactly that header, so we re-use it via `super.applyAuth(...)` rather
- * than duplicating the logic.
+ * exactly that header, so no override here.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce OpenAI's 8MB response body cap. The
- * `/v1/responses` payload is usually a few hundred KB, but a long answer
- * with many citations can balloon; the cap aborts runaway responses
- * before they can OOM the worker.
+ * The 8MB body cap moved to `manifest.http.maxResponseBytes` and is
+ * enforced by `BaseHttpClient.parseResponse` (Content-Length pre-flight
+ * + post-read guard). No `request<T>` override needed.
  *
- * Used by the manifest path (Phase 5+). The legacy `OpenAiHttp` class
- * below preserves the existing `OpenAiHttp.post(path, body, apiKey, signal)`
+ * Used by the manifest path. The legacy `OpenAiHttp` class below
+ * preserves the existing `OpenAiHttp.post(path, body, apiKey, signal)`
  * signature for the OLD `OpenAiProvider`, which Phase 7 deletes.
  */
 export class OpenAiHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS);
-		const signal = composeBaseSignals(ctx.signal, internalSignal);
-
-		// Re-use the parent's bearer-token header construction so we don't
-		// duplicate the `Authorization: Bearer <token>` formatting.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`OpenAI ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`OpenAI ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 

--- a/packages/providers/openai/src/manifest.ts
+++ b/packages/providers/openai/src/manifest.ts
@@ -121,6 +121,10 @@ export const openaiProviderManifest: ProviderManifest = {
 		baseUrl: 'https://api.openai.com/v1',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// `/v1/responses` payloads usually run a few hundred KB; 8 MB is
+		// generous but still tight enough to abort runaway answers before
+		// OOM. Enforced by `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `parseCredential` throws InvalidInputError when the API key is

--- a/packages/providers/pagespeed/src/http.ts
+++ b/packages/providers/pagespeed/src/http.ts
@@ -11,7 +11,12 @@
  */
 
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 import { JWT } from 'google-auth-library';
 
 export interface PageSpeedHttpOptions {
@@ -89,11 +94,8 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * Phase 7 deletes.
  */
 export class PageSpeedHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 
 	protected override async request<T>(
@@ -186,7 +188,7 @@ export class PageSpeedHttpClient extends BaseHttpClient {
 
 		let response: Response;
 		try {
-			response = await this.fetchImpl(url, init);
+			response = await (this.fetchImpl ?? globalThis.fetch)(url, init);
 		} catch (err) {
 			const message =
 				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')

--- a/packages/providers/perplexity/src/http.spec.ts
+++ b/packages/providers/perplexity/src/http.spec.ts
@@ -11,6 +11,9 @@ const baseConfig: HttpConfig = {
 	baseUrl: 'https://api.perplexity.ai',
 	auth: { kind: 'bearer-token' },
 	defaultTimeoutMs: 5_000,
+	// Mirrors the manifest's body cap so the cap-enforcement test exercises
+	// the same path the real composition root does.
+	maxResponseBytes: 8 * 1024 * 1024,
 };
 
 const stubContext = (plaintext = validToken, signal?: AbortSignal): FetchContext => ({

--- a/packages/providers/perplexity/src/http.ts
+++ b/packages/providers/perplexity/src/http.ts
@@ -4,7 +4,12 @@
  * here is essentially a relabelled OpenAI client (Bearer auth + JSON body).
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface PerplexityHttpOptions {
 	baseUrl?: string;
@@ -14,33 +19,17 @@ export interface PerplexityHttpOptions {
 
 const DEFAULT_BASE_URL = 'https://api.perplexity.ai';
 const DEFAULT_TIMEOUT_MS = 60_000;
+/**
+ * Cap on response body. Perplexity Sonar answers usually fit in a few KB,
+ * but a misbehaving model run with many citations could produce
+ * surprisingly large payloads; 8MB is a generous safety net. Lives on
+ * `manifest.http.maxResponseBytes`; kept here as a constant so the
+ * legacy `PerplexityHttp` path (below) enforces the same cap.
+ */
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const RESPONSE_BODY_MAX_BYTES = 4_096;
 
 const PROVIDER_ID = 'perplexity';
-
-/**
- * Composes two AbortSignals so the request aborts when EITHER fires.
- * Caller-provided signal (job cancellation) + internal timeout signal.
- *
- * Duplicated from `BaseHttpClient` (where it's a private module-level helper)
- * because this client overrides `request` rather than `applyAuth`. See the
- * class header for the rationale.
- */
-function composeSignalsArr(...signals: ReadonlyArray<AbortSignal | undefined>): AbortSignal {
-	const real = signals.filter((s): s is AbortSignal => Boolean(s));
-	const [first, second] = real;
-	if (first && !second) return first;
-	const controller = new AbortController();
-	for (const s of real) {
-		if (s.aborted) {
-			controller.abort();
-			return controller.signal;
-		}
-		s.addEventListener('abort', () => controller.abort(), { once: true });
-	}
-	return controller.signal;
-}
 
 /**
  * BaseHttpClient adapter for Perplexity's Sonar chat-completions endpoint.
@@ -48,105 +37,19 @@ function composeSignalsArr(...signals: ReadonlyArray<AbortSignal | undefined>): 
  * Auth is the simplest case: a single bearer token applied as
  * `Authorization: Bearer <plaintext>`. The default
  * `BaseHttpClient.applyAuth` for `kind: 'bearer-token'` already produces
- * exactly that header, so we re-use it via `super.applyAuth(...)` rather
- * than duplicating the logic.
+ * exactly that header, so no override is needed.
  *
- * The ONLY reason we override `request` here (instead of just relying on
- * the base) is to enforce Perplexity's 8MB response body cap. Sonar
- * answers usually fit in a few KB, but a misbehaving model run with many
- * citations could produce surprisingly large payloads; the cap aborts
- * runaway responses before they can OOM the worker.
+ * Body capping (8MB) lives on `manifest.http.maxResponseBytes`; the
+ * base client enforces it via Content-Length pre-flight + post-read
+ * guard, so this class no longer needs a `request<T>` override.
  *
  * Used by the manifest path (Phase 5+). The legacy `PerplexityHttp` class
  * below preserves the existing `fetchSonarSearch(http: PerplexityHttp,
  * ...)` signature for the OLD `PerplexityProvider`, which Phase 7 deletes.
  */
 export class PerplexityHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
-
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
-	}
-
-	protected override async request<T>(
-		method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-		path: string,
-		query: Record<string, string>,
-		body: unknown,
-		ctx: FetchContext,
-	): Promise<T> {
-		const url = this.buildUrl(path, query);
-
-		const internalSignal = AbortSignal.timeout(this.config.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS);
-		const signal = composeSignalsArr(ctx.signal, internalSignal);
-
-		// Re-use the parent's bearer-token header construction so we don't
-		// duplicate the `Authorization: Bearer <token>` formatting.
-		const headers: Record<string, string> = {
-			...this.applyAuth(ctx.credential.plaintextSecret, body),
-			Accept: 'application/json',
-		};
-		const init: RequestInit = { method, signal, headers };
-		if (body !== undefined && (method === 'POST' || method === 'PUT')) {
-			init.body = JSON.stringify(body);
-			headers['Content-Type'] = 'application/json';
-		}
-
-		let response: Response;
-		try {
-			response = await this.fetchImpl(url, init);
-		} catch (err) {
-			const message =
-				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
-					? 'request aborted or timed out'
-					: `network error: ${err instanceof Error ? err.message : String(err)}`;
-			throw new ProviderApiError(PROVIDER_ID, 0, undefined, message);
-		}
-
-		// Best-effort early kill: if the upstream advertises Content-Length
-		// over the cap, refuse before draining the body. Some responses are
-		// chunked, in which case we fall back to the post-read guard below.
-		const contentLength = response.headers.get('content-length');
-		if (contentLength !== null && Number(contentLength) > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Perplexity ${path} response too large: Content-Length ${contentLength} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		const text = await response.text();
-		if (text.length > MAX_RESPONSE_BYTES) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				undefined,
-				`Perplexity ${path} response too large: ${text.length} bytes (cap ${MAX_RESPONSE_BYTES})`,
-			);
-		}
-
-		if (!response.ok) {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status}`,
-			);
-		}
-
-		if (text.length === 0) return undefined as unknown as T;
-		try {
-			return JSON.parse(text) as T;
-		} catch {
-			throw new ProviderApiError(
-				PROVIDER_ID,
-				response.status,
-				text.slice(0, RESPONSE_BODY_MAX_BYTES),
-				`${PROVIDER_ID} ${method} ${path} → ${response.status} non-JSON body`,
-			);
-		}
+	constructor(config: HttpConfig, options: BaseHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 	}
 }
 

--- a/packages/providers/perplexity/src/manifest.ts
+++ b/packages/providers/perplexity/src/manifest.ts
@@ -25,11 +25,10 @@ import { buildLegacyShim, type PerplexityHttp, PerplexityHttpClient } from './ht
  *   possible, `Authorization: Bearer <pplx-…>`. The default
  *   `BaseHttpClient.applyAuth` for this kind already produces exactly
  *   that header, so the manifest needs zero auth-specific overrides.
- * - Why `PerplexityHttpClient.request` is overridden anyway: see
- *   `./http.ts` header. The override exists ONLY to enforce Perplexity's
- *   8MB response body cap (Content-Length pre-flight + post-read guard).
- *   The auth header itself is re-used from the parent via
- *   `super.applyAuth(...)` — no duplication.
+ * - Why no `PerplexityHttpClient.request` override: Perplexity's 8MB
+ *   response body cap moved to `manifest.http.maxResponseBytes` and is
+ *   enforced by `BaseHttpClient.parseResponse` (Content-Length pre-flight
+ *   + post-read guard). No subclass override is needed for the body cap.
  * - Why the ACL wraps the single LLM answer in an array:
  *   `normalisePerplexityResponse()` returns ONE
  *   `NormalisedLlmAnswer` per Sonar call (a single chat completion),
@@ -119,6 +118,10 @@ export const perplexityProviderManifest: ProviderManifest = {
 		baseUrl: 'https://api.perplexity.ai',
 		auth,
 		defaultTimeoutMs: 60_000,
+		// Perplexity Sonar answers usually fit in a few KB; 8MB is a
+		// generous safety net for runs with many citations. Enforced by
+		// `BaseHttpClient.parseResponse`.
+		maxResponseBytes: 8 * 1024 * 1024,
 	},
 	validateCredentialPlaintext(plaintextSecret: string): void {
 		// `parseCredential` throws InvalidInputError on the wrong shape

--- a/packages/providers/wikipedia/src/http.ts
+++ b/packages/providers/wikipedia/src/http.ts
@@ -5,7 +5,12 @@
  * (https://wikitech.wikimedia.org/wiki/Robot_policy).
  */
 import type { FetchContext } from '@rankpulse/provider-core';
-import { BaseHttpClient, type HttpConfig, ProviderApiError } from '@rankpulse/provider-core';
+import {
+	BaseHttpClient,
+	type BaseHttpClientOptions,
+	type HttpConfig,
+	ProviderApiError,
+} from '@rankpulse/provider-core';
 
 export interface WikipediaHttpOptions {
 	baseUrl?: string;
@@ -66,13 +71,16 @@ function composeSignals(...signals: ReadonlyArray<AbortSignal | undefined>): Abo
  * ...)` and `fetchTopArticles` signatures for the OLD `WikipediaProvider`,
  * which Phase 7 deletes.
  */
+export interface WikipediaHttpClientOptions extends BaseHttpClientOptions {
+	/** Wikimedia robot policy requires a contact-bearing User-Agent. */
+	readonly userAgent?: string;
+}
+
 export class WikipediaHttpClient extends BaseHttpClient {
-	private readonly fetchImpl: typeof fetch;
 	private readonly userAgent: string;
 
-	constructor(config: HttpConfig, options: { fetchImpl?: typeof fetch; userAgent?: string } = {}) {
-		super(PROVIDER_ID, config);
-		this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+	constructor(config: HttpConfig, options: WikipediaHttpClientOptions = {}) {
+		super(PROVIDER_ID, config, options);
 		this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
 	}
 
@@ -105,7 +113,7 @@ export class WikipediaHttpClient extends BaseHttpClient {
 
 		let response: Response;
 		try {
-			response = await this.fetchImpl(url, init);
+			response = await (this.fetchImpl ?? globalThis.fetch)(url, init);
 		} catch (err) {
 			const message =
 				err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')


### PR DESCRIPTION
## Summary

- `HttpConfig.maxResponseBytes?: number` — declarative per-provider response body cap. `BaseHttpClient.parseResponse` enforces it (Content-Length pre-flight + post-read guard).
- `BaseHttpClient.request` adds `Accept: application/json` to default headers (every provider that retired its override was emitting this inline).
- `fetchImpl` moves up: now a `protected readonly` field on the base via `BaseHttpClientOptions`. The 4 providers that still override `request<T>` (bing, meta, pagespeed, wikipedia) reuse the same injection point.
- 7 cap-only providers (anthropic, brevo, cloudflare-radar, google-ai-studio, microsoft-clarity, openai, perplexity) drop their `request<T>` override entirely. Each `XHttpClient` is now constructor-forwarding only, plus an `applyAuth` override where the strategy is non-default. DataForSEO already had no override → **8 of 14** providers no longer carry one.

Closes #103. Net **−483 LOC** across 28 files (+397, −880).

## Why this shape

Two design choices worth flagging:

1. **`fetchImpl` on the base, not per-subclass.** The 4 keep-override providers were each declaring `private readonly fetchImpl: typeof fetch` and a custom constructor accepting `{ fetchImpl?: typeof fetch }`. That's a classic case for hoisting — moved into `BaseHttpClient` as a `protected` field with an inline `?? globalThis.fetch` fallback wherever it's used. The override providers now just `super(PROVIDER_ID, config, options)` and reach `this.fetchImpl` without owning it.
2. **Belt-and-braces on the 4 keep-override manifests.** Bing/meta/pagespeed/wikipedia got `maxResponseBytes` configured even though their inline override still does the same check. That's deliberate — the base now enforces the cap uniformly, and a future PR that further refactors those overrides (e.g. a `signRequest` hook that lets bing/meta express query-string auth declaratively) can drop the inline guard without touching the manifest config.

## Test plan

- [x] `pnpm lint` clean (856 files)
- [x] `pnpm typecheck` clean (26/26)
- [x] `pnpm test` green — `provider-core` adds 4 new cap specs (Content-Length pre-flight, post-read guard, under-cap pass-through, default Accept header). Each affected provider's `http.spec.ts` carries `maxResponseBytes` on its `baseConfig` so existing cap tests exercise the same path the composition root does.
- [x] `pnpm build` green (23/23)

## Acceptance from #103

- [x] `HttpConfig.maxResponseBytes` documented on `manifest.ts`.
- [x] `BaseHttpClient.parseResponse` enforces the cap when set.
- [x] 8 of 14 provider clients no longer carry a `request<T>` override (anthropic, brevo, cloudflare-radar, dataforseo, google-ai-studio, microsoft-clarity, openai, perplexity).
- [x] Existing tests still pass.
- [x] New tests: `BaseHttpClient` throws `ProviderApiError` when configured cap is exceeded.

## Out of scope (follow-ups)

- DataForSEO's 32MB cap. The provider already has no override; once a SERP-advanced fetch test fixture is in place the 32MB value can be set on its manifest.
- Refactoring the 4 keep-override providers (bing query-string auth, meta query-string token, pagespeed polymorphic auth, ga4/gsc JWT mint, wikipedia User-Agent) into declarative hooks. That's a bigger surface change, worth its own ADR.