### PR TITLE
test(application): backfill 18 use-case specs (closes #104)

### DIFF
--- a/packages/application/src/ai-search-insights/use-cases/list-brand-prompts.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/list-brand-prompts.use-case.spec.ts
@@ -1,0 +1,70 @@
+import { AiSearchInsights, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryBrandPromptRepository } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ListBrandPromptsUseCase } from './list-brand-prompts.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const OTHER_PROJECT_ID = '22222222-2222-2222-2222-222222222222' as Uuid as ProjectManagement.ProjectId;
+
+const buildPrompt = (
+	id: string,
+	text: string,
+	projectId: ProjectManagement.ProjectId = PROJECT_ID,
+): AiSearchInsights.BrandPrompt =>
+	AiSearchInsights.BrandPrompt.register({
+		id: id as Uuid as AiSearchInsights.BrandPromptId,
+		organizationId: ORG_ID,
+		projectId,
+		text: AiSearchInsights.PromptText.create(text),
+		kind: 'branded',
+		now: new Date('2026-05-04T10:00:00Z'),
+	});
+
+describe('ListBrandPromptsUseCase', () => {
+	let repo: InMemoryBrandPromptRepository;
+
+	beforeEach(() => {
+		repo = new InMemoryBrandPromptRepository();
+	});
+
+	it('returns an empty array when the project has no prompts', async () => {
+		const useCase = new ListBrandPromptsUseCase(repo);
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+		expect(result).toEqual([]);
+	});
+
+	it('lists every prompt registered against the project', async () => {
+		await repo.save(buildPrompt('11111111-1111-1111-1111-aaaaaaaaaaa1', 'Best CRMs for solo founders?'));
+		await repo.save(buildPrompt('11111111-1111-1111-1111-aaaaaaaaaaa2', 'Top SEO tools 2026'));
+		const useCase = new ListBrandPromptsUseCase(repo);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		expect(result).toHaveLength(2);
+		expect(result.map((p) => p.text).sort()).toEqual(['Best CRMs for solo founders?', 'Top SEO tools 2026']);
+	});
+
+	it('scopes results to the requested project — other projects are excluded', async () => {
+		await repo.save(buildPrompt('11111111-1111-1111-1111-aaaaaaaaaaa1', 'mine'));
+		await repo.save(buildPrompt('11111111-1111-1111-1111-aaaaaaaaaaa2', 'theirs', OTHER_PROJECT_ID));
+		const useCase = new ListBrandPromptsUseCase(repo);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.text).toBe('mine');
+	});
+
+	it('serialises pausedAt and createdAt as ISO strings (and null when active)', async () => {
+		await repo.save(buildPrompt('11111111-1111-1111-1111-aaaaaaaaaaa1', 'an active prompt'));
+		const useCase = new ListBrandPromptsUseCase(repo);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		const dto = result[0];
+		expect(dto?.createdAt).toBe(new Date('2026-05-04T10:00:00Z').toISOString());
+		expect(dto?.pausedAt).toBeNull();
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/pause-brand-prompt.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/pause-brand-prompt.use-case.spec.ts
@@ -1,0 +1,108 @@
+import { AiSearchInsights, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { FakeClock, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { InMemoryBrandPromptRepository, RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PauseBrandPromptUseCase, ResumeBrandPromptUseCase } from './pause-brand-prompt.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid as AiSearchInsights.BrandPromptId;
+
+const buildPrompt = (): AiSearchInsights.BrandPrompt =>
+	AiSearchInsights.BrandPrompt.register({
+		id: PROMPT_ID,
+		organizationId: ORG_ID,
+		projectId: PROJECT_ID,
+		text: AiSearchInsights.PromptText.create('Best CRMs for solo founders?'),
+		kind: 'branded',
+		now: new Date('2026-05-04T10:00:00Z'),
+	});
+
+describe('PauseBrandPromptUseCase', () => {
+	let repo: InMemoryBrandPromptRepository;
+	let clock: FakeClock;
+	let publisher: RecordingEventPublisher;
+	let useCase: PauseBrandPromptUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryBrandPromptRepository();
+		clock = new FakeClock('2026-05-05T12:00:00Z');
+		publisher = new RecordingEventPublisher();
+		useCase = new PauseBrandPromptUseCase(repo, clock, publisher);
+	});
+
+	it('pauses an active prompt and emits BrandPromptPaused', async () => {
+		const prompt = buildPrompt();
+		await repo.save(prompt);
+		// Domain freshly-registered events are kept distinct from pause events;
+		// pull and discard them so the spec asserts only on what THIS use case emits.
+		prompt.pullEvents();
+
+		const result = await useCase.execute({ brandPromptId: PROMPT_ID });
+
+		expect(result.pausedAt).toBe(new Date('2026-05-05T12:00:00Z').toISOString());
+		const persisted = await repo.findById(PROMPT_ID);
+		expect(persisted?.pausedAt).toEqual(new Date('2026-05-05T12:00:00Z'));
+		expect(publisher.publishedTypes()).toContain('BrandPromptPaused');
+	});
+
+	it('is a no-op (no save, no event) when the prompt is already paused', async () => {
+		const prompt = buildPrompt();
+		prompt.pause(new Date('2026-05-04T11:00:00Z'));
+		prompt.pullEvents();
+		await repo.save(prompt);
+
+		const result = await useCase.execute({ brandPromptId: PROMPT_ID });
+
+		expect(result.pausedAt).toBe(new Date('2026-05-04T11:00:00Z').toISOString());
+		expect(publisher.published()).toHaveLength(0);
+	});
+
+	it('throws NotFoundError when the prompt does not exist', async () => {
+		await expect(useCase.execute({ brandPromptId: 'missing' })).rejects.toBeInstanceOf(NotFoundError);
+		expect(publisher.published()).toHaveLength(0);
+	});
+});
+
+describe('ResumeBrandPromptUseCase', () => {
+	let repo: InMemoryBrandPromptRepository;
+	let clock: FakeClock;
+	let publisher: RecordingEventPublisher;
+	let useCase: ResumeBrandPromptUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryBrandPromptRepository();
+		clock = new FakeClock('2026-05-05T12:00:00Z');
+		publisher = new RecordingEventPublisher();
+		useCase = new ResumeBrandPromptUseCase(repo, clock, publisher);
+	});
+
+	it('resumes a paused prompt and emits BrandPromptResumed', async () => {
+		const prompt = buildPrompt();
+		prompt.pause(new Date('2026-05-04T11:00:00Z'));
+		prompt.pullEvents();
+		await repo.save(prompt);
+
+		const result = await useCase.execute({ brandPromptId: PROMPT_ID });
+
+		expect(result.pausedAt).toBeNull();
+		const persisted = await repo.findById(PROMPT_ID);
+		expect(persisted?.pausedAt).toBeNull();
+		expect(publisher.publishedTypes()).toContain('BrandPromptResumed');
+	});
+
+	it('is a no-op (no save, no event) when the prompt is already active', async () => {
+		const prompt = buildPrompt();
+		prompt.pullEvents();
+		await repo.save(prompt);
+
+		const result = await useCase.execute({ brandPromptId: PROMPT_ID });
+
+		expect(result.pausedAt).toBeNull();
+		expect(publisher.published()).toHaveLength(0);
+	});
+
+	it('throws NotFoundError when the prompt does not exist', async () => {
+		await expect(useCase.execute({ brandPromptId: 'missing' })).rejects.toBeInstanceOf(NotFoundError);
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/query-ai-search-sov.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-ai-search-sov.use-case.spec.ts
@@ -1,0 +1,114 @@
+import { AiSearchInsights, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryLlmAnswerReadModel } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryAiSearchSovUseCase } from './query-ai-search-sov.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as AiSearchInsights.BrandPromptId;
+
+describe('QueryAiSearchSovUseCase', () => {
+	let readModel: InMemoryLlmAnswerReadModel;
+	let useCase: QueryAiSearchSovUseCase;
+
+	beforeEach(() => {
+		readModel = new InMemoryLlmAnswerReadModel();
+		useCase = new QueryAiSearchSovUseCase(readModel);
+	});
+
+	it('returns one row per (provider, locale, brand) with computed mention rate', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [
+					{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null },
+					{ brand: 'Competitor', isOwnBrand: false, position: 2, citedUrl: null },
+				],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		// Two distinct brands → two rows
+		expect(result).toHaveLength(2);
+		const own = result.find((r) => r.brand === 'OurBrand');
+		// 2 answers, both mention OurBrand → rate 1.0
+		expect(own?.totalAnswers).toBe(2);
+		expect(own?.answersWithMention).toBe(2);
+		expect(own?.mentionRate).toBe(1);
+		expect(own?.isOwnBrand).toBe(true);
+		const competitor = result.find((r) => r.brand === 'Competitor');
+		// 2 total answers, only 1 mentions Competitor → rate 0.5
+		expect(competitor?.mentionRate).toBe(0.5);
+		expect(competitor?.isOwnBrand).toBe(false);
+	});
+
+	it('returns empty array when no answers exist in the window', async () => {
+		readModel.setRows([]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toEqual([]);
+	});
+
+	it('uses the default 30-day window when from/to omitted', async () => {
+		// The DEFAULT_WINDOW_DAYS = 30 means rows older than ~30 days from now
+		// are excluded. We seed two rows: one inside, one outside.
+		readModel.setRows([
+			{
+				id: 'recent',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date(),
+			},
+			{
+				id: 'too-old',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+			},
+		]);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		// Only the recent row is in scope; the 90-day-old row is dropped.
+		expect(result).toHaveLength(1);
+		expect(result[0]?.totalAnswers).toBe(1);
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/query-competitive-matrix.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-competitive-matrix.use-case.spec.ts
@@ -1,0 +1,109 @@
+import { AiSearchInsights, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryLlmAnswerReadModel } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryCompetitiveMatrixUseCase } from './query-competitive-matrix.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as AiSearchInsights.BrandPromptId;
+
+describe('QueryCompetitiveMatrixUseCase', () => {
+	let readModel: InMemoryLlmAnswerReadModel;
+	let useCase: QueryCompetitiveMatrixUseCase;
+
+	beforeEach(() => {
+		readModel = new InMemoryLlmAnswerReadModel();
+		useCase = new QueryCompetitiveMatrixUseCase(readModel);
+	});
+
+	it('returns one cell per (provider, country, language, brand) with mention rate', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [
+					{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null },
+					{ brand: 'CompetitorX', isOwnBrand: false, position: 2, citedUrl: null },
+				],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		// One cell per brand: OurBrand (own) at 100% and CompetitorX at 50%.
+		expect(result).toHaveLength(2);
+		const own = result.find((c) => c.brand === 'OurBrand');
+		expect(own?.isOwnBrand).toBe(true);
+		expect(own?.mentionRate).toBe(1);
+		const comp = result.find((c) => c.brand === 'CompetitorX');
+		expect(comp?.isOwnBrand).toBe(false);
+		expect(comp?.mentionRate).toBe(0.5);
+	});
+
+	it('separates cells across providers and locales (cells share brand but not provider/locale)', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.ANTHROPIC,
+				country: 'ES',
+				language: 'es',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 2, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((c) => `${c.aiProvider}|${c.country}`).sort()).toEqual(['anthropic|ES', 'openai|US']);
+	});
+
+	it('returns empty array when no answers in window', async () => {
+		readModel.setRows([]);
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toEqual([]);
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/query-llm-answers.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-llm-answers.use-case.spec.ts
@@ -1,0 +1,182 @@
+import { AiSearchInsights, ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryLlmAnswerRepository } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryLlmAnswersUseCase } from './query-llm-answers.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const OTHER_PROJECT_ID = '22222222-2222-2222-2222-222222222222' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_ID_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as AiSearchInsights.BrandPromptId;
+const PROMPT_ID_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid as AiSearchInsights.BrandPromptId;
+
+const buildAnswer = (overrides: {
+	id: string;
+	brandPromptId?: AiSearchInsights.BrandPromptId;
+	projectId?: ProjectManagement.ProjectId;
+	aiProvider?: AiSearchInsights.AiProviderName;
+	country?: string;
+	language?: string;
+	capturedAt: Date;
+}): AiSearchInsights.LlmAnswer =>
+	AiSearchInsights.LlmAnswer.record({
+		id: overrides.id as Uuid as AiSearchInsights.LlmAnswerId,
+		brandPromptId: overrides.brandPromptId ?? PROMPT_ID_A,
+		projectId: overrides.projectId ?? PROJECT_ID,
+		aiProvider: overrides.aiProvider ?? AiSearchInsights.AiProviderNames.OPENAI,
+		model: 'gpt-5-mini',
+		location: ProjectManagement.LocationLanguage.create({
+			country: overrides.country ?? 'US',
+			language: overrides.language ?? 'en',
+		}),
+		rawText: 'sample answer',
+		mentions: [],
+		citations: [],
+		tokenUsage: AiSearchInsights.TokenUsage.zero(),
+		costCents: 0,
+		rawPayloadId: null,
+		now: overrides.capturedAt,
+	});
+
+describe('QueryLlmAnswersUseCase', () => {
+	let repo: InMemoryLlmAnswerRepository;
+	let useCase: QueryLlmAnswersUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryLlmAnswerRepository();
+		useCase = new QueryLlmAnswersUseCase(repo);
+	});
+
+	it('returns answers for the project sorted newest-first', async () => {
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			}),
+		);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.capturedAt).toBe(new Date('2026-05-02T10:00:00Z').toISOString());
+		expect(result[1]?.capturedAt).toBe(new Date('2026-05-01T10:00:00Z').toISOString());
+	});
+
+	it('filters by brandPromptId when supplied', async () => {
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				brandPromptId: PROMPT_ID_A,
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				brandPromptId: PROMPT_ID_B,
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			}),
+		);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID, brandPromptId: PROMPT_ID_A });
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.brandPromptId).toBe(PROMPT_ID_A);
+	});
+
+	it('filters by aiProvider, country, language when supplied', async () => {
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'ES',
+				language: 'es',
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				aiProvider: AiSearchInsights.AiProviderNames.ANTHROPIC,
+				country: 'US',
+				language: 'en',
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+			country: 'ES',
+			language: 'es',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.aiProvider).toBe(AiSearchInsights.AiProviderNames.OPENAI);
+	});
+
+	it('honours from/to window', async () => {
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				capturedAt: new Date('2026-04-15T00:00:00Z'),
+			}),
+		);
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				capturedAt: new Date('2026-05-15T00:00:00Z'),
+			}),
+		);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.capturedAt).toBe(new Date('2026-05-15T00:00:00Z').toISOString());
+	});
+
+	it('respects the limit parameter (default 50, override applied)', async () => {
+		for (let i = 0; i < 5; i++) {
+			await repo.save(
+				buildAnswer({
+					id: `dddddddd-dddd-dddd-dddd-${String(i).padStart(12, '0')}` as Uuid,
+					capturedAt: new Date(`2026-05-0${i + 1}T10:00:00Z`),
+				}),
+			);
+		}
+
+		const result = await useCase.execute({ projectId: PROJECT_ID, limit: 2 });
+
+		expect(result).toHaveLength(2);
+	});
+
+	it('scopes results to the requested project', async () => {
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+		await repo.save(
+			buildAnswer({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				projectId: OTHER_PROJECT_ID,
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			}),
+		);
+
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.projectId).toBe(PROJECT_ID);
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/query-prompt-sov-daily.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-prompt-sov-daily.use-case.spec.ts
@@ -1,0 +1,119 @@
+import { AiSearchInsights, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryLlmAnswerReadModel } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryPromptSovDailyUseCase } from './query-prompt-sov-daily.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as AiSearchInsights.BrandPromptId;
+const OTHER_PROMPT_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid as AiSearchInsights.BrandPromptId;
+
+describe('QueryPromptSovDailyUseCase', () => {
+	let readModel: InMemoryLlmAnswerReadModel;
+	let useCase: QueryPromptSovDailyUseCase;
+
+	beforeEach(() => {
+		readModel = new InMemoryLlmAnswerReadModel();
+		useCase = new QueryPromptSovDailyUseCase(readModel);
+	});
+
+	it('returns one bucket per UTC day with mention rate', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.ANTHROPIC,
+				country: 'US',
+				language: 'en',
+				mentions: [],
+				citations: [],
+				capturedAt: new Date('2026-05-01T20:00:00Z'),
+			},
+			{
+				id: 'a3',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			brandPromptId: PROMPT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		const day1 = result.find((p) => p.day === '2026-05-01');
+		// 2 captures on 2026-05-01, 1 with own mention → rate 0.5
+		expect(day1?.totalAnswers).toBe(2);
+		expect(day1?.answersWithOwnMention).toBe(1);
+		expect(day1?.mentionRate).toBe(0.5);
+		const day2 = result.find((p) => p.day === '2026-05-02');
+		// Single capture, mentioned → rate 1.0
+		expect(day2?.mentionRate).toBe(1);
+	});
+
+	it('returns mentionRate=0 when totalAnswers is 0 (defensive guard against div-by-zero)', async () => {
+		readModel.setRows([]);
+		const result = await useCase.execute({
+			brandPromptId: PROMPT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toEqual([]);
+	});
+
+	it('scopes results to the requested prompt', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: OTHER_PROMPT_ID,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			brandPromptId: PROMPT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.totalAnswers).toBe(1);
+	});
+});

--- a/packages/application/src/bing-webmaster-insights/use-cases/query-bing-traffic.use-case.spec.ts
+++ b/packages/application/src/bing-webmaster-insights/use-cases/query-bing-traffic.use-case.spec.ts
@@ -1,0 +1,162 @@
+import { BingWebmasterInsights, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryBingTrafficUseCase } from './query-bing-traffic.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PROPERTY_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as BingWebmasterInsights.BingPropertyId;
+const OTHER_PROPERTY_ID =
+	'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as BingWebmasterInsights.BingPropertyId;
+
+class InMemoryPropertyRepo implements BingWebmasterInsights.BingPropertyRepository {
+	readonly store = new Map<string, BingWebmasterInsights.BingProperty>();
+	async save(p: BingWebmasterInsights.BingProperty): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(
+		id: BingWebmasterInsights.BingPropertyId,
+	): Promise<BingWebmasterInsights.BingProperty | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndSite(): Promise<BingWebmasterInsights.BingProperty | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly BingWebmasterInsights.BingProperty[]> {
+		return [];
+	}
+}
+
+class InMemoryObsRepo implements BingWebmasterInsights.BingTrafficObservationRepository {
+	readonly rows: BingWebmasterInsights.BingTrafficObservation[] = [];
+	async saveAll(
+		observations: readonly BingWebmasterInsights.BingTrafficObservation[],
+	): Promise<{ inserted: number }> {
+		this.rows.push(...observations);
+		return { inserted: observations.length };
+	}
+	async listForProperty(
+		propertyId: BingWebmasterInsights.BingPropertyId,
+		filter: { from: string; to: string },
+	): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		return this.rows
+			.filter((r) => r.bingPropertyId === propertyId)
+			.filter((r) => r.observedDate >= filter.from && r.observedDate <= filter.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+	async listLatestForProject(): Promise<readonly BingWebmasterInsights.BingTrafficObservation[]> {
+		return [];
+	}
+}
+
+const buildObservation = (overrides: {
+	observedDate: string;
+	clicks?: number;
+	bingPropertyId?: BingWebmasterInsights.BingPropertyId;
+}): BingWebmasterInsights.BingTrafficObservation =>
+	BingWebmasterInsights.BingTrafficObservation.record({
+		bingPropertyId: overrides.bingPropertyId ?? PROPERTY_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		metrics: BingWebmasterInsights.BingTrafficMetrics.create({
+			clicks: overrides.clicks ?? 100,
+			impressions: 2000,
+			avgClickPosition: 4.5,
+			avgImpressionPosition: 12.3,
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryBingTrafficUseCase', () => {
+	let propRepo: InMemoryPropertyRepo;
+	let obsRepo: InMemoryObsRepo;
+	let useCase: QueryBingTrafficUseCase;
+
+	beforeEach(async () => {
+		propRepo = new InMemoryPropertyRepo();
+		obsRepo = new InMemoryObsRepo();
+		useCase = new QueryBingTrafficUseCase(propRepo, obsRepo);
+		await propRepo.save(
+			BingWebmasterInsights.BingProperty.link({
+				id: PROPERTY_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				siteUrl: 'https://example.com/',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns observations in the date window for the property', async () => {
+		await obsRepo.saveAll([
+			buildObservation({ observedDate: '2026-05-01', clicks: 100 }),
+			buildObservation({ observedDate: '2026-05-02', clicks: 50 }),
+		]);
+
+		const result = await useCase.execute({
+			bingPropertyId: PROPERTY_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.clicks)).toEqual([100, 50]);
+	});
+
+	it('throws NotFoundError when the property does not exist', async () => {
+		await expect(
+			useCase.execute({ bingPropertyId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window — observations outside are excluded', async () => {
+		await obsRepo.saveAll([
+			buildObservation({ observedDate: '2026-04-30' }),
+			buildObservation({ observedDate: '2026-05-01' }),
+			buildObservation({ observedDate: '2026-05-03' }),
+		]);
+
+		const result = await useCase.execute({
+			bingPropertyId: PROPERTY_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.observedDate).toBe('2026-05-01');
+	});
+
+	it('scopes results to the requested property', async () => {
+		await propRepo.save(
+			BingWebmasterInsights.BingProperty.link({
+				id: OTHER_PROPERTY_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				siteUrl: 'https://other.com/',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await obsRepo.saveAll([
+			buildObservation({ observedDate: '2026-05-01', clicks: 100 }),
+			buildObservation({
+				observedDate: '2026-05-01',
+				clicks: 999,
+				bingPropertyId: OTHER_PROPERTY_ID,
+			}),
+		]);
+
+		const result = await useCase.execute({
+			bingPropertyId: PROPERTY_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.clicks).toBe(100);
+	});
+});

--- a/packages/application/src/entity-awareness/use-cases/query-wikipedia-pageviews.use-case.spec.ts
+++ b/packages/application/src/entity-awareness/use-cases/query-wikipedia-pageviews.use-case.spec.ts
@@ -1,0 +1,155 @@
+import { EntityAwareness, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryWikipediaPageviewsUseCase } from './query-wikipedia-pageviews.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const ARTICLE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as EntityAwareness.WikipediaArticleId;
+const OTHER_ARTICLE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as EntityAwareness.WikipediaArticleId;
+
+class InMemoryArticleRepo implements EntityAwareness.WikipediaArticleRepository {
+	readonly store = new Map<string, EntityAwareness.WikipediaArticle>();
+	async save(a: EntityAwareness.WikipediaArticle): Promise<void> {
+		this.store.set(a.id, a);
+	}
+	async findById(id: EntityAwareness.WikipediaArticleId): Promise<EntityAwareness.WikipediaArticle | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndSlug(): Promise<EntityAwareness.WikipediaArticle | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly EntityAwareness.WikipediaArticle[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly EntityAwareness.WikipediaArticle[]> {
+		return [];
+	}
+}
+
+class InMemoryObsRepo implements EntityAwareness.WikipediaPageviewObservationRepository {
+	readonly rows: EntityAwareness.WikipediaPageviewObservation[] = [];
+	async saveAll(
+		observations: readonly EntityAwareness.WikipediaPageviewObservation[],
+	): Promise<{ inserted: number }> {
+		this.rows.push(...observations);
+		return { inserted: observations.length };
+	}
+	async listForArticle(
+		articleId: EntityAwareness.WikipediaArticleId,
+		query: { from: Date; to: Date },
+	): Promise<readonly EntityAwareness.WikipediaPageviewObservation[]> {
+		return this.rows
+			.filter((r) => r.articleId === articleId)
+			.filter((r) => r.observedAt >= query.from && r.observedAt <= query.to)
+			.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+	}
+}
+
+const buildObservation = (overrides: {
+	observedAt: Date;
+	views?: number;
+	articleId?: EntityAwareness.WikipediaArticleId;
+}): EntityAwareness.WikipediaPageviewObservation =>
+	EntityAwareness.WikipediaPageviewObservation.record({
+		articleId: overrides.articleId ?? ARTICLE_ID,
+		projectId: PROJECT_ID,
+		observedAt: overrides.observedAt,
+		views: overrides.views ?? 100,
+		access: 'all-access',
+		agent: 'user',
+		granularity: 'daily',
+	});
+
+describe('QueryWikipediaPageviewsUseCase', () => {
+	let articleRepo: InMemoryArticleRepo;
+	let obsRepo: InMemoryObsRepo;
+	let useCase: QueryWikipediaPageviewsUseCase;
+
+	beforeEach(async () => {
+		articleRepo = new InMemoryArticleRepo();
+		obsRepo = new InMemoryObsRepo();
+		useCase = new QueryWikipediaPageviewsUseCase(articleRepo, obsRepo);
+		await articleRepo.save(
+			EntityAwareness.WikipediaArticle.link({
+				id: ARTICLE_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				wikipediaProject: EntityAwareness.WikipediaProject.create('en.wikipedia.org'),
+				slug: EntityAwareness.ArticleSlug.create('OurBrand'),
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns observations in window for the article', async () => {
+		await obsRepo.saveAll([
+			buildObservation({ observedAt: new Date('2026-05-01T00:00:00Z'), views: 100 }),
+			buildObservation({ observedAt: new Date('2026-05-02T00:00:00Z'), views: 150 }),
+		]);
+
+		const result = await useCase.execute({
+			articleId: ARTICLE_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.views)).toEqual([100, 150]);
+	});
+
+	it('throws NotFoundError when the article does not exist', async () => {
+		await expect(
+			useCase.execute({
+				articleId: 'missing',
+				from: new Date('2026-04-01T00:00:00Z'),
+				to: new Date('2026-05-31T00:00:00Z'),
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window', async () => {
+		await obsRepo.saveAll([
+			buildObservation({ observedAt: new Date('2026-04-15T00:00:00Z') }),
+			buildObservation({ observedAt: new Date('2026-05-15T00:00:00Z') }),
+		]);
+
+		const result = await useCase.execute({
+			articleId: ARTICLE_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+	});
+
+	it('scopes to the requested article', async () => {
+		await articleRepo.save(
+			EntityAwareness.WikipediaArticle.link({
+				id: OTHER_ARTICLE_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				wikipediaProject: EntityAwareness.WikipediaProject.create('en.wikipedia.org'),
+				slug: EntityAwareness.ArticleSlug.create('Competitor'),
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await obsRepo.saveAll([
+			buildObservation({ observedAt: new Date('2026-05-01T00:00:00Z'), views: 100 }),
+			buildObservation({
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				views: 999,
+				articleId: OTHER_ARTICLE_ID,
+			}),
+		]);
+
+		const result = await useCase.execute({
+			articleId: ARTICLE_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.views).toBe(100);
+	});
+});

--- a/packages/application/src/experience-analytics/use-cases/query-experience-history.use-case.spec.ts
+++ b/packages/application/src/experience-analytics/use-cases/query-experience-history.use-case.spec.ts
@@ -1,0 +1,156 @@
+import { ExperienceAnalytics, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryExperienceHistoryUseCase } from './query-experience-history.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const CLARITY_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ExperienceAnalytics.ClarityProjectId;
+const OTHER_CLARITY_ID =
+	'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as ExperienceAnalytics.ClarityProjectId;
+
+class InMemoryClarityRepo implements ExperienceAnalytics.ClarityProjectRepository {
+	readonly store = new Map<string, ExperienceAnalytics.ClarityProject>();
+	async save(p: ExperienceAnalytics.ClarityProject): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(
+		id: ExperienceAnalytics.ClarityProjectId,
+	): Promise<ExperienceAnalytics.ClarityProject | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(): Promise<ExperienceAnalytics.ClarityProject | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly ExperienceAnalytics.ClarityProject[]> {
+		return [];
+	}
+}
+
+class InMemorySnapshotRepo implements ExperienceAnalytics.ExperienceSnapshotRepository {
+	readonly rows: ExperienceAnalytics.ExperienceSnapshot[] = [];
+	async save(s: ExperienceAnalytics.ExperienceSnapshot): Promise<{ inserted: boolean }> {
+		this.rows.push(s);
+		return { inserted: true };
+	}
+	async listForClarityProject(
+		clarityProjectId: ExperienceAnalytics.ClarityProjectId,
+		query: { from: string; to: string },
+	): Promise<readonly ExperienceAnalytics.ExperienceSnapshot[]> {
+		return this.rows
+			.filter((r) => r.clarityProjectId === clarityProjectId)
+			.filter((r) => r.observedDate >= query.from && r.observedDate <= query.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+}
+
+const buildSnapshot = (overrides: {
+	observedDate: string;
+	sessionsCount?: number;
+	clarityProjectId?: ExperienceAnalytics.ClarityProjectId;
+}): ExperienceAnalytics.ExperienceSnapshot =>
+	ExperienceAnalytics.ExperienceSnapshot.record({
+		clarityProjectId: overrides.clarityProjectId ?? CLARITY_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		metrics: ExperienceAnalytics.ExperienceMetrics.create({
+			sessionsCount: overrides.sessionsCount ?? 100,
+			botSessionsCount: 5,
+			distinctUserCount: 80,
+			pagesPerSession: 2.4,
+			rageClicks: 3,
+			deadClicks: 2,
+			avgEngagementSeconds: 45.6,
+			avgScrollDepth: 0.6,
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryExperienceHistoryUseCase', () => {
+	let projectsRepo: InMemoryClarityRepo;
+	let snapshotsRepo: InMemorySnapshotRepo;
+	let useCase: QueryExperienceHistoryUseCase;
+
+	beforeEach(async () => {
+		projectsRepo = new InMemoryClarityRepo();
+		snapshotsRepo = new InMemorySnapshotRepo();
+		useCase = new QueryExperienceHistoryUseCase(projectsRepo, snapshotsRepo);
+		await projectsRepo.save(
+			ExperienceAnalytics.ClarityProject.link({
+				id: CLARITY_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				clarityHandle: 'abc123def4',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns snapshots in window for the clarity project', async () => {
+		await snapshotsRepo.save(buildSnapshot({ observedDate: '2026-05-01', sessionsCount: 100 }));
+		await snapshotsRepo.save(buildSnapshot({ observedDate: '2026-05-02', sessionsCount: 200 }));
+
+		const result = await useCase.execute({
+			clarityProjectId: CLARITY_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.sessionsCount)).toEqual([100, 200]);
+	});
+
+	it('throws NotFoundError when the clarity project does not exist', async () => {
+		await expect(
+			useCase.execute({ clarityProjectId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window', async () => {
+		await snapshotsRepo.save(buildSnapshot({ observedDate: '2026-04-30' }));
+		await snapshotsRepo.save(buildSnapshot({ observedDate: '2026-05-15' }));
+
+		const result = await useCase.execute({
+			clarityProjectId: CLARITY_ID,
+			from: '2026-05-01',
+			to: '2026-05-31',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.observedDate).toBe('2026-05-15');
+	});
+
+	it('scopes results to the requested clarity project', async () => {
+		await projectsRepo.save(
+			ExperienceAnalytics.ClarityProject.link({
+				id: OTHER_CLARITY_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				clarityHandle: 'xyz789aaa1',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await snapshotsRepo.save(buildSnapshot({ observedDate: '2026-05-01', sessionsCount: 100 }));
+		await snapshotsRepo.save(
+			buildSnapshot({
+				observedDate: '2026-05-01',
+				sessionsCount: 999,
+				clarityProjectId: OTHER_CLARITY_ID,
+			}),
+		);
+
+		const result = await useCase.execute({
+			clarityProjectId: CLARITY_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.sessionsCount).toBe(100);
+	});
+});

--- a/packages/application/src/macro-context/use-cases/query-radar-history.use-case.spec.ts
+++ b/packages/application/src/macro-context/use-cases/query-radar-history.use-case.spec.ts
@@ -1,0 +1,162 @@
+import { type IdentityAccess, MacroContext, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryRadarHistoryUseCase } from './query-radar-history.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const DOMAIN_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as MacroContext.MonitoredDomainId;
+const OTHER_DOMAIN_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as MacroContext.MonitoredDomainId;
+
+class InMemoryDomainRepo implements MacroContext.MonitoredDomainRepository {
+	readonly store = new Map<string, MacroContext.MonitoredDomain>();
+	async save(d: MacroContext.MonitoredDomain): Promise<void> {
+		this.store.set(d.id, d);
+	}
+	async findById(id: MacroContext.MonitoredDomainId): Promise<MacroContext.MonitoredDomain | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndDomain(): Promise<MacroContext.MonitoredDomain | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly MacroContext.MonitoredDomain[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly MacroContext.MonitoredDomain[]> {
+		return [];
+	}
+}
+
+class InMemorySnapshotRepo implements MacroContext.RadarRankSnapshotRepository {
+	readonly rows: MacroContext.RadarRankSnapshot[] = [];
+	async save(s: MacroContext.RadarRankSnapshot): Promise<{ inserted: boolean }> {
+		this.rows.push(s);
+		return { inserted: true };
+	}
+	async listForDomain(
+		monitoredDomainId: MacroContext.MonitoredDomainId,
+		query: { from: string; to: string },
+	): Promise<readonly MacroContext.RadarRankSnapshot[]> {
+		return this.rows
+			.filter((r) => r.monitoredDomainId === monitoredDomainId)
+			.filter((r) => r.observedDate >= query.from && r.observedDate <= query.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+}
+
+const buildSnapshot = (overrides: {
+	observedDate: string;
+	rank?: number | null;
+	monitoredDomainId?: MacroContext.MonitoredDomainId;
+}): MacroContext.RadarRankSnapshot =>
+	MacroContext.RadarRankSnapshot.record({
+		monitoredDomainId: overrides.monitoredDomainId ?? DOMAIN_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		rank: MacroContext.RadarRank.create({
+			rank: overrides.rank === undefined ? 1234 : overrides.rank,
+			bucket: 'top-10000',
+			categories: { Technology: 50 },
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryRadarHistoryUseCase', () => {
+	let domainRepo: InMemoryDomainRepo;
+	let snapRepo: InMemorySnapshotRepo;
+	let useCase: QueryRadarHistoryUseCase;
+
+	beforeEach(async () => {
+		domainRepo = new InMemoryDomainRepo();
+		snapRepo = new InMemorySnapshotRepo();
+		useCase = new QueryRadarHistoryUseCase(domainRepo, snapRepo);
+		await domainRepo.save(
+			MacroContext.MonitoredDomain.add({
+				id: DOMAIN_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				domain: 'example.com',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns snapshots in window for the monitored domain', async () => {
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-05-01', rank: 1000 }));
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-05-02', rank: 950 }));
+
+		const result = await useCase.execute({
+			monitoredDomainId: DOMAIN_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.rank)).toEqual([1000, 950]);
+		expect(result[0]?.bucket).toBe('top-10000');
+		expect(result[0]?.categories).toEqual({ Technology: 50 });
+	});
+
+	it('throws NotFoundError when the monitored domain does not exist', async () => {
+		await expect(
+			useCase.execute({ monitoredDomainId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window', async () => {
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-04-30' }));
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-05-15' }));
+
+		const result = await useCase.execute({
+			monitoredDomainId: DOMAIN_ID,
+			from: '2026-05-01',
+			to: '2026-05-31',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.observedDate).toBe('2026-05-15');
+	});
+
+	it('serialises rank=null when the domain is unranked', async () => {
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-05-01', rank: null }));
+
+		const result = await useCase.execute({
+			monitoredDomainId: DOMAIN_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result[0]?.rank).toBeNull();
+	});
+
+	it('scopes results to the requested domain', async () => {
+		await domainRepo.save(
+			MacroContext.MonitoredDomain.add({
+				id: OTHER_DOMAIN_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				domain: 'other.com',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await snapRepo.save(buildSnapshot({ observedDate: '2026-05-01', rank: 100 }));
+		await snapRepo.save(
+			buildSnapshot({
+				observedDate: '2026-05-01',
+				rank: 999,
+				monitoredDomainId: OTHER_DOMAIN_ID,
+			}),
+		);
+
+		const result = await useCase.execute({
+			monitoredDomainId: DOMAIN_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.rank).toBe(100);
+	});
+});

--- a/packages/application/src/meta-ads-attribution/use-cases/query-meta-ads-insights.use-case.spec.ts
+++ b/packages/application/src/meta-ads-attribution/use-cases/query-meta-ads-insights.use-case.spec.ts
@@ -1,0 +1,158 @@
+import { type IdentityAccess, MetaAdsAttribution, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryMetaAdsInsightsUseCase } from './query-meta-ads-insights.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const ACCOUNT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as MetaAdsAttribution.MetaAdAccountId;
+const OTHER_ACCOUNT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as MetaAdsAttribution.MetaAdAccountId;
+
+class InMemoryAccountRepo implements MetaAdsAttribution.MetaAdAccountRepository {
+	readonly store = new Map<string, MetaAdsAttribution.MetaAdAccount>();
+	async save(a: MetaAdsAttribution.MetaAdAccount): Promise<void> {
+		this.store.set(a.id, a);
+	}
+	async findById(id: MetaAdsAttribution.MetaAdAccountId): Promise<MetaAdsAttribution.MetaAdAccount | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(): Promise<MetaAdsAttribution.MetaAdAccount | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly MetaAdsAttribution.MetaAdAccount[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly MetaAdsAttribution.MetaAdAccount[]> {
+		return [];
+	}
+}
+
+class InMemoryInsightsRepo implements MetaAdsAttribution.MetaAdsInsightDailyRepository {
+	readonly rows: MetaAdsAttribution.MetaAdsInsightDaily[] = [];
+	async saveAll(rows: readonly MetaAdsAttribution.MetaAdsInsightDaily[]): Promise<{ inserted: number }> {
+		this.rows.push(...rows);
+		return { inserted: rows.length };
+	}
+	async listForAccount(
+		accountId: MetaAdsAttribution.MetaAdAccountId,
+		query: { from: string; to: string },
+	): Promise<readonly MetaAdsAttribution.MetaAdsInsightDaily[]> {
+		return this.rows
+			.filter((r) => r.metaAdAccountId === accountId)
+			.filter((r) => r.observedDate >= query.from && r.observedDate <= query.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+}
+
+const buildInsight = (overrides: {
+	observedDate: string;
+	clicks?: number;
+	metaAdAccountId?: MetaAdsAttribution.MetaAdAccountId;
+}): MetaAdsAttribution.MetaAdsInsightDaily =>
+	MetaAdsAttribution.MetaAdsInsightDaily.record({
+		metaAdAccountId: overrides.metaAdAccountId ?? ACCOUNT_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		metrics: MetaAdsAttribution.MetaAdsInsightMetrics.create({
+			level: 'campaign',
+			entityId: '1234567890',
+			entityName: 'Spring Campaign',
+			impressions: 1000,
+			clicks: overrides.clicks ?? 50,
+			spend: 25.5,
+			conversions: 3,
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryMetaAdsInsightsUseCase', () => {
+	let accountRepo: InMemoryAccountRepo;
+	let insightsRepo: InMemoryInsightsRepo;
+	let useCase: QueryMetaAdsInsightsUseCase;
+
+	beforeEach(async () => {
+		accountRepo = new InMemoryAccountRepo();
+		insightsRepo = new InMemoryInsightsRepo();
+		useCase = new QueryMetaAdsInsightsUseCase(accountRepo, insightsRepo);
+		await accountRepo.save(
+			MetaAdsAttribution.MetaAdAccount.link({
+				id: ACCOUNT_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				adAccountHandle: 'act_1234567890',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns insights in window for the ad account', async () => {
+		await insightsRepo.saveAll([
+			buildInsight({ observedDate: '2026-05-01', clicks: 50 }),
+			buildInsight({ observedDate: '2026-05-02', clicks: 75 }),
+		]);
+
+		const result = await useCase.execute({
+			metaAdAccountId: ACCOUNT_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.clicks)).toEqual([50, 75]);
+		expect(result[0]?.entityName).toBe('Spring Campaign');
+		expect(result[0]?.level).toBe('campaign');
+	});
+
+	it('throws NotFoundError when the ad account does not exist', async () => {
+		await expect(
+			useCase.execute({ metaAdAccountId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window', async () => {
+		await insightsRepo.saveAll([
+			buildInsight({ observedDate: '2026-04-30' }),
+			buildInsight({ observedDate: '2026-05-15' }),
+		]);
+
+		const result = await useCase.execute({
+			metaAdAccountId: ACCOUNT_ID,
+			from: '2026-05-01',
+			to: '2026-05-31',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.observedDate).toBe('2026-05-15');
+	});
+
+	it('scopes results to the requested ad account', async () => {
+		await accountRepo.save(
+			MetaAdsAttribution.MetaAdAccount.link({
+				id: OTHER_ACCOUNT_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				adAccountHandle: 'act_9999999999',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await insightsRepo.saveAll([
+			buildInsight({ observedDate: '2026-05-01', clicks: 50 }),
+			buildInsight({
+				observedDate: '2026-05-01',
+				clicks: 999,
+				metaAdAccountId: OTHER_ACCOUNT_ID,
+			}),
+		]);
+
+		const result = await useCase.execute({
+			metaAdAccountId: ACCOUNT_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.clicks).toBe(50);
+	});
+});

--- a/packages/application/src/meta-ads-attribution/use-cases/query-meta-pixel-events.use-case.spec.ts
+++ b/packages/application/src/meta-ads-attribution/use-cases/query-meta-pixel-events.use-case.spec.ts
@@ -1,0 +1,163 @@
+import { type IdentityAccess, MetaAdsAttribution, type ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryMetaPixelEventsUseCase } from './query-meta-pixel-events.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PIXEL_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as MetaAdsAttribution.MetaPixelId;
+const OTHER_PIXEL_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as MetaAdsAttribution.MetaPixelId;
+
+class InMemoryPixelRepo implements MetaAdsAttribution.MetaPixelRepository {
+	readonly store = new Map<string, MetaAdsAttribution.MetaPixel>();
+	async save(p: MetaAdsAttribution.MetaPixel): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: MetaAdsAttribution.MetaPixelId): Promise<MetaAdsAttribution.MetaPixel | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(): Promise<MetaAdsAttribution.MetaPixel | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly MetaAdsAttribution.MetaPixel[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly MetaAdsAttribution.MetaPixel[]> {
+		return [];
+	}
+}
+
+class InMemoryEventRepo implements MetaAdsAttribution.MetaPixelEventDailyRepository {
+	readonly rows: MetaAdsAttribution.MetaPixelEventDaily[] = [];
+	async saveAll(rows: readonly MetaAdsAttribution.MetaPixelEventDaily[]): Promise<{ inserted: number }> {
+		this.rows.push(...rows);
+		return { inserted: rows.length };
+	}
+	async listForPixel(
+		pixelId: MetaAdsAttribution.MetaPixelId,
+		query: { from: string; to: string },
+	): Promise<readonly MetaAdsAttribution.MetaPixelEventDaily[]> {
+		return this.rows
+			.filter((r) => r.metaPixelId === pixelId)
+			.filter((r) => r.observedDate >= query.from && r.observedDate <= query.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+}
+
+const buildEvent = (overrides: {
+	observedDate: string;
+	eventName?: string;
+	count?: number;
+	valueSum?: number;
+	metaPixelId?: MetaAdsAttribution.MetaPixelId;
+}): MetaAdsAttribution.MetaPixelEventDaily =>
+	MetaAdsAttribution.MetaPixelEventDaily.record({
+		metaPixelId: overrides.metaPixelId ?? PIXEL_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		eventName: overrides.eventName ?? 'Purchase',
+		stats: MetaAdsAttribution.MetaPixelEventStats.create({
+			count: overrides.count ?? 10,
+			valueSum: overrides.valueSum ?? 250.5,
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryMetaPixelEventsUseCase', () => {
+	let pixelRepo: InMemoryPixelRepo;
+	let eventRepo: InMemoryEventRepo;
+	let useCase: QueryMetaPixelEventsUseCase;
+
+	beforeEach(async () => {
+		pixelRepo = new InMemoryPixelRepo();
+		eventRepo = new InMemoryEventRepo();
+		useCase = new QueryMetaPixelEventsUseCase(pixelRepo, eventRepo);
+		await pixelRepo.save(
+			MetaAdsAttribution.MetaPixel.link({
+				id: PIXEL_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				pixelHandle: '1234567890',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns events in window for the pixel', async () => {
+		await eventRepo.saveAll([
+			buildEvent({ observedDate: '2026-05-01', count: 10, valueSum: 250.5 }),
+			buildEvent({ observedDate: '2026-05-02', count: 20, valueSum: 500 }),
+		]);
+
+		const result = await useCase.execute({
+			metaPixelId: PIXEL_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.count)).toEqual([10, 20]);
+		expect(result[0]?.eventName).toBe('Purchase');
+	});
+
+	it('throws NotFoundError when the pixel does not exist', async () => {
+		await expect(
+			useCase.execute({ metaPixelId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('exposes both event count and aggregate valueSum', async () => {
+		await eventRepo.saveAll([
+			buildEvent({ observedDate: '2026-05-01', count: 5, valueSum: 100 }),
+			buildEvent({
+				observedDate: '2026-05-01',
+				count: 3,
+				valueSum: 50,
+				eventName: 'AddToCart',
+			}),
+		]);
+
+		const result = await useCase.execute({
+			metaPixelId: PIXEL_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(2);
+		const purchase = result.find((r) => r.eventName === 'Purchase');
+		expect(purchase?.valueSum).toBe(100);
+		const add = result.find((r) => r.eventName === 'AddToCart');
+		expect(add?.valueSum).toBe(50);
+	});
+
+	it('scopes results to the requested pixel', async () => {
+		await pixelRepo.save(
+			MetaAdsAttribution.MetaPixel.link({
+				id: OTHER_PIXEL_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				pixelHandle: '9999999999',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await eventRepo.saveAll([
+			buildEvent({ observedDate: '2026-05-01', count: 10 }),
+			buildEvent({
+				observedDate: '2026-05-01',
+				count: 999,
+				metaPixelId: OTHER_PIXEL_ID,
+			}),
+		]);
+
+		const result = await useCase.execute({
+			metaPixelId: PIXEL_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.count).toBe(10);
+	});
+});

--- a/packages/application/src/project-management/use-cases/change-project-locations.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/change-project-locations.use-case.spec.ts
@@ -1,0 +1,65 @@
+import { type IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { FakeClock, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { InMemoryProjectRepository, RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AddProjectLocationUseCase } from './change-project-locations.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PORTFOLIO_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd' as Uuid as ProjectManagement.PortfolioId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+const buildProject = (): ProjectManagement.Project =>
+	ProjectManagement.Project.create({
+		id: PROJECT_ID,
+		organizationId: ORG_ID,
+		portfolioId: PORTFOLIO_ID,
+		name: 'Acme',
+		primaryDomain: ProjectManagement.DomainName.create('acme.com'),
+		initialLocations: [ProjectManagement.LocationLanguage.create({ country: 'ES', language: 'es' })],
+		now: new Date('2026-05-04T10:00:00Z'),
+	});
+
+describe('AddProjectLocationUseCase', () => {
+	let repo: InMemoryProjectRepository;
+	let clock: FakeClock;
+	let publisher: RecordingEventPublisher;
+	let useCase: AddProjectLocationUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryProjectRepository();
+		clock = new FakeClock('2026-05-05T12:00:00Z');
+		publisher = new RecordingEventPublisher();
+		useCase = new AddProjectLocationUseCase(repo, clock, publisher);
+	});
+
+	it('persists the new location and publishes ProjectLocationAdded', async () => {
+		const project = buildProject();
+		project.pullEvents();
+		await repo.save(project);
+
+		await useCase.execute({ projectId: PROJECT_ID, country: 'US', language: 'en' });
+
+		const persisted = await repo.findById(PROJECT_ID);
+		const localeStrings = persisted?.locations.map((l) => `${l.country}-${l.language}`);
+		expect(localeStrings).toContain('US-en');
+		expect(publisher.publishedTypes()).toContain('project-management.LocationAdded');
+	});
+
+	it('throws NotFoundError when the project does not exist', async () => {
+		await expect(
+			useCase.execute({ projectId: 'missing', country: 'US', language: 'en' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+		expect(publisher.published()).toHaveLength(0);
+	});
+
+	it('preserves the existing locations when adding a new one', async () => {
+		const project = buildProject();
+		project.pullEvents();
+		await repo.save(project);
+
+		await useCase.execute({ projectId: PROJECT_ID, country: 'US', language: 'en' });
+
+		const persisted = await repo.findById(PROJECT_ID);
+		expect(persisted?.locations).toHaveLength(2);
+	});
+});

--- a/packages/application/src/provider-connectivity/use-cases/record-api-usage.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/record-api-usage.use-case.spec.ts
@@ -1,0 +1,81 @@
+import type { IdentityAccess, ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
+import { FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { RecordApiUsageUseCase } from './record-api-usage.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const CREDENTIAL_ID =
+	'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee' as Uuid as ProviderConnectivity.ProviderCredentialId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const USAGE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid;
+
+class InMemoryApiUsageRepo implements ProviderConnectivity.ApiUsageRepository {
+	readonly entries: ProviderConnectivity.ApiUsageEntry[] = [];
+	async save(entry: ProviderConnectivity.ApiUsageEntry): Promise<void> {
+		this.entries.push(entry);
+	}
+	async sumCostCents(_orgId: IdentityAccess.OrganizationId, _from: Date, _to: Date): Promise<number> {
+		return this.entries.reduce((sum, e) => sum + e.cost.cents, 0);
+	}
+}
+
+describe('RecordApiUsageUseCase', () => {
+	let repo: InMemoryApiUsageRepo;
+	let clock: FakeClock;
+	let publisher: RecordingEventPublisher;
+	let useCase: RecordApiUsageUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryApiUsageRepo();
+		clock = new FakeClock('2026-05-05T12:00:00Z');
+		publisher = new RecordingEventPublisher();
+		useCase = new RecordApiUsageUseCase(repo, clock, new FixedIdGenerator([USAGE_ID]), publisher);
+	});
+
+	it('persists the usage entry and emits ApiUsageRecorded', async () => {
+		const result = await useCase.execute({
+			organizationId: ORG_ID,
+			credentialId: CREDENTIAL_ID,
+			projectId: PROJECT_ID,
+			providerId: 'openai',
+			endpointId: 'openai-responses-with-web-search',
+			calls: 1,
+			costCents: 305,
+		});
+
+		expect(result.usageId).toBe(USAGE_ID);
+		expect(repo.entries).toHaveLength(1);
+		expect(repo.entries[0]?.cost.cents).toBe(305);
+		expect(publisher.publishedTypes()).toContain('ApiUsageRecorded');
+	});
+
+	it('handles a null projectId (org-scope-only credentials)', async () => {
+		const result = await useCase.execute({
+			organizationId: ORG_ID,
+			credentialId: CREDENTIAL_ID,
+			projectId: null,
+			providerId: 'openai',
+			endpointId: 'openai-responses-with-web-search',
+			calls: 1,
+			costCents: 305,
+		});
+
+		expect(result.usageId).toBe(USAGE_ID);
+		expect(repo.entries[0]?.projectId).toBeNull();
+	});
+
+	it('stamps occurredAt from the injected clock', async () => {
+		await useCase.execute({
+			organizationId: ORG_ID,
+			credentialId: CREDENTIAL_ID,
+			projectId: PROJECT_ID,
+			providerId: 'openai',
+			endpointId: 'openai-responses-with-web-search',
+			calls: 1,
+			costCents: 305,
+		});
+
+		expect(repo.entries[0]?.occurredAt).toEqual(new Date('2026-05-05T12:00:00Z'));
+	});
+});

--- a/packages/application/src/rank-tracking/use-cases/query-ranking-history.use-case.spec.ts
+++ b/packages/application/src/rank-tracking/use-cases/query-ranking-history.use-case.spec.ts
@@ -1,0 +1,187 @@
+import { type IdentityAccess, ProjectManagement, RankTracking } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryRankingHistoryUseCase } from './query-ranking-history.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const TRACKED_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as RankTracking.TrackedKeywordId;
+const OTHER_TRACKED_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as RankTracking.TrackedKeywordId;
+
+class InMemoryTrackedRepo implements RankTracking.TrackedKeywordRepository {
+	readonly store = new Map<string, RankTracking.TrackedKeyword>();
+	async save(t: RankTracking.TrackedKeyword): Promise<void> {
+		this.store.set(t.id, t);
+	}
+	async findById(id: RankTracking.TrackedKeywordId): Promise<RankTracking.TrackedKeyword | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findExisting(): Promise<RankTracking.TrackedKeyword | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async listByProjectQuery(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async countForProject(): Promise<number> {
+		return 0;
+	}
+}
+
+class InMemoryObsRepo implements RankTracking.RankingObservationRepository {
+	readonly rows: RankTracking.RankingObservation[] = [];
+	async save(o: RankTracking.RankingObservation): Promise<void> {
+		this.rows.push(o);
+	}
+	async findLatestFor(): Promise<RankTracking.RankingObservation | null> {
+		return null;
+	}
+	async listForKeyword(
+		trackedKeywordId: RankTracking.TrackedKeywordId,
+		from: Date,
+		to: Date,
+	): Promise<readonly RankTracking.RankingObservation[]> {
+		return this.rows
+			.filter((r) => r.trackedKeywordId === trackedKeywordId)
+			.filter((r) => r.observedAt >= from && r.observedAt <= to)
+			.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+	}
+	async listLatestForProject(): Promise<readonly RankTracking.RankingObservation[]> {
+		return [];
+	}
+}
+
+const buildTracked = (id: RankTracking.TrackedKeywordId = TRACKED_ID): RankTracking.TrackedKeyword =>
+	RankTracking.TrackedKeyword.start({
+		id,
+		organizationId: ORG_ID,
+		projectId: PROJECT_ID,
+		domain: ProjectManagement.DomainName.create('controlrondas.com'),
+		phrase: ProjectManagement.KeywordPhrase.create('control de rondas'),
+		location: ProjectManagement.LocationLanguage.create({ country: 'ES', language: 'es' }),
+		device: RankTracking.Devices.DESKTOP,
+		now: new Date('2026-05-04T10:00:00Z'),
+	});
+
+const buildObservation = (overrides: {
+	id: string;
+	observedAt: Date;
+	position: number | null;
+	trackedKeywordId?: RankTracking.TrackedKeywordId;
+}): RankTracking.RankingObservation =>
+	RankTracking.RankingObservation.record({
+		id: overrides.id as Uuid as RankTracking.RankingObservationId,
+		trackedKeywordId: overrides.trackedKeywordId ?? TRACKED_ID,
+		projectId: PROJECT_ID,
+		domain: 'controlrondas.com',
+		phrase: 'control de rondas',
+		country: 'ES',
+		language: 'es',
+		device: RankTracking.Devices.DESKTOP,
+		position: RankTracking.Position.fromNullable(overrides.position),
+		url: 'https://controlrondas.com/',
+		serpFeatures: [],
+		sourceProvider: 'dataforseo',
+		rawPayloadId: null,
+		now: overrides.observedAt,
+	});
+
+describe('QueryRankingHistoryUseCase', () => {
+	let trackedRepo: InMemoryTrackedRepo;
+	let obsRepo: InMemoryObsRepo;
+	let useCase: QueryRankingHistoryUseCase;
+
+	beforeEach(async () => {
+		trackedRepo = new InMemoryTrackedRepo();
+		obsRepo = new InMemoryObsRepo();
+		useCase = new QueryRankingHistoryUseCase(trackedRepo, obsRepo);
+		await trackedRepo.save(buildTracked());
+	});
+
+	it('returns observations ordered by date for the keyword', async () => {
+		await obsRepo.save(
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				position: 5,
+			}),
+		);
+		await obsRepo.save(
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-02T00:00:00Z'),
+				position: 3,
+			}),
+		);
+
+		const result = await useCase.execute({
+			trackedKeywordId: TRACKED_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.position)).toEqual([5, 3]);
+	});
+
+	it('throws NotFoundError when the tracked keyword does not exist', async () => {
+		await expect(
+			useCase.execute({
+				trackedKeywordId: 'missing',
+				from: new Date('2026-05-01T00:00:00Z'),
+				to: new Date('2026-05-31T00:00:00Z'),
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('serialises position=null when out of tracked window', async () => {
+		await obsRepo.save(
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				position: null,
+			}),
+		);
+
+		const result = await useCase.execute({
+			trackedKeywordId: TRACKED_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result[0]?.position).toBeNull();
+	});
+
+	it('scopes results to the requested keyword', async () => {
+		await trackedRepo.save(buildTracked(OTHER_TRACKED_ID));
+		await obsRepo.save(
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000001',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				position: 5,
+			}),
+		);
+		await obsRepo.save(
+			buildObservation({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				position: 99,
+				trackedKeywordId: OTHER_TRACKED_ID,
+			}),
+		);
+
+		const result = await useCase.execute({
+			trackedKeywordId: TRACKED_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-01T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.position).toBe(5);
+	});
+});

--- a/packages/application/src/rank-tracking/use-cases/start-tracking-keyword.use-case.spec.ts
+++ b/packages/application/src/rank-tracking/use-cases/start-tracking-keyword.use-case.spec.ts
@@ -1,0 +1,145 @@
+import { type IdentityAccess, type ProjectManagement, RankTracking } from '@rankpulse/domain';
+import { ConflictError, FakeClock, FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import { RecordingEventPublisher } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { StartTrackingKeywordUseCase } from './start-tracking-keyword.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const TRACKED_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as RankTracking.TrackedKeywordId;
+
+class InMemoryTrackedRepo implements RankTracking.TrackedKeywordRepository {
+	readonly store = new Map<string, RankTracking.TrackedKeyword>();
+	readonly byNaturalKey = new Map<string, RankTracking.TrackedKeyword>();
+
+	private key(input: {
+		projectId: ProjectManagement.ProjectId;
+		domain: string;
+		phrase: string;
+		country: string;
+		language: string;
+		device: string;
+		searchEngine: string;
+	}): string {
+		return [
+			input.projectId,
+			input.domain,
+			input.phrase,
+			input.country,
+			input.language,
+			input.device,
+			input.searchEngine,
+		].join('|');
+	}
+
+	async save(t: RankTracking.TrackedKeyword): Promise<void> {
+		this.store.set(t.id, t);
+		this.byNaturalKey.set(
+			this.key({
+				projectId: t.projectId,
+				domain: t.domain.value,
+				phrase: t.phrase.value,
+				country: t.location.country,
+				language: t.location.language,
+				device: t.device,
+				searchEngine: t.searchEngine,
+			}),
+			t,
+		);
+	}
+	async findById(id: RankTracking.TrackedKeywordId): Promise<RankTracking.TrackedKeyword | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findExisting(input: {
+		projectId: ProjectManagement.ProjectId;
+		domain: string;
+		phrase: string;
+		country: string;
+		language: string;
+		device: string;
+		searchEngine: string;
+	}): Promise<RankTracking.TrackedKeyword | null> {
+		return this.byNaturalKey.get(this.key(input)) ?? null;
+	}
+	async listForProject(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async listByProjectQuery(): Promise<readonly RankTracking.TrackedKeyword[]> {
+		return [];
+	}
+	async countForProject(): Promise<number> {
+		return this.store.size;
+	}
+}
+
+describe('StartTrackingKeywordUseCase', () => {
+	let repo: InMemoryTrackedRepo;
+	let clock: FakeClock;
+	let publisher: RecordingEventPublisher;
+	let useCase: StartTrackingKeywordUseCase;
+
+	beforeEach(() => {
+		repo = new InMemoryTrackedRepo();
+		clock = new FakeClock('2026-05-05T12:00:00Z');
+		publisher = new RecordingEventPublisher();
+		useCase = new StartTrackingKeywordUseCase(repo, clock, new FixedIdGenerator([TRACKED_ID]), publisher);
+	});
+
+	const baseCmd = {
+		organizationId: ORG_ID,
+		projectId: PROJECT_ID,
+		domain: 'controlrondas.com',
+		phrase: 'control de rondas',
+		country: 'ES',
+		language: 'es',
+	};
+
+	it('creates a TrackedKeyword and emits KeywordTrackingStarted', async () => {
+		const result = await useCase.execute(baseCmd);
+
+		expect(result.trackedKeywordId).toBe(TRACKED_ID);
+		const persisted = await repo.findById(TRACKED_ID);
+		expect(persisted?.phrase.value).toBe('control de rondas');
+		expect(persisted?.device).toBe(RankTracking.Devices.DESKTOP);
+		expect(publisher.publishedTypes()).toContain('TrackedKeywordStarted');
+	});
+
+	it('defaults to desktop when device is omitted', async () => {
+		await useCase.execute(baseCmd);
+		const persisted = await repo.findById(TRACKED_ID);
+		expect(persisted?.device).toBe(RankTracking.Devices.DESKTOP);
+	});
+
+	it('honours the device override', async () => {
+		await useCase.execute({ ...baseCmd, device: RankTracking.Devices.MOBILE });
+		const persisted = await repo.findById(TRACKED_ID);
+		expect(persisted?.device).toBe(RankTracking.Devices.MOBILE);
+	});
+
+	it('throws ConflictError when the same (project, domain, phrase, locale, device) already exists', async () => {
+		await useCase.execute(baseCmd);
+		// New use case instance because FixedIdGenerator is single-shot.
+		const second = new StartTrackingKeywordUseCase(
+			repo,
+			clock,
+			new FixedIdGenerator(['ffffffff-ffff-ffff-ffff-ffffffffffff' as Uuid]),
+			publisher,
+		);
+		await expect(second.execute(baseCmd)).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('treats different devices for the same query as distinct (no conflict)', async () => {
+		await useCase.execute(baseCmd);
+		const second = new StartTrackingKeywordUseCase(
+			repo,
+			clock,
+			new FixedIdGenerator(['ffffffff-ffff-ffff-ffff-ffffffffffff' as Uuid]),
+			publisher,
+		);
+		const result = await second.execute({ ...baseCmd, device: RankTracking.Devices.MOBILE });
+		expect(result.trackedKeywordId).toBe('ffffffff-ffff-ffff-ffff-ffffffffffff');
+	});
+});

--- a/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.spec.ts
+++ b/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.spec.ts
@@ -1,0 +1,159 @@
+import { type IdentityAccess, type ProjectManagement, TrafficAnalytics } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryGa4MetricsUseCase } from './query-ga4-metrics.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const GA4_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as TrafficAnalytics.Ga4PropertyId;
+const OTHER_GA4_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as TrafficAnalytics.Ga4PropertyId;
+
+class InMemoryPropertyRepo implements TrafficAnalytics.Ga4PropertyRepository {
+	readonly store = new Map<string, TrafficAnalytics.Ga4Property>();
+	async save(p: TrafficAnalytics.Ga4Property): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: TrafficAnalytics.Ga4PropertyId): Promise<TrafficAnalytics.Ga4Property | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndHandle(): Promise<TrafficAnalytics.Ga4Property | null> {
+		return null;
+	}
+	async listForProject(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly TrafficAnalytics.Ga4Property[]> {
+		return [];
+	}
+}
+
+class InMemoryMetricRepo implements TrafficAnalytics.Ga4DailyMetricRepository {
+	readonly rows: TrafficAnalytics.Ga4DailyMetric[] = [];
+	async saveAll(metrics: readonly TrafficAnalytics.Ga4DailyMetric[]): Promise<{ inserted: number }> {
+		this.rows.push(...metrics);
+		return { inserted: metrics.length };
+	}
+	async listForProperty(
+		propertyId: TrafficAnalytics.Ga4PropertyId,
+		query: { from: string; to: string },
+	): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		return this.rows
+			.filter((r) => r.ga4PropertyId === propertyId)
+			.filter((r) => r.observedDate >= query.from && r.observedDate <= query.to)
+			.sort((a, b) => a.observedDate.localeCompare(b.observedDate));
+	}
+	async listLatestForProject(): Promise<readonly TrafficAnalytics.Ga4DailyMetric[]> {
+		return [];
+	}
+}
+
+const buildMetric = (overrides: {
+	id: string;
+	observedDate: string;
+	sessions?: number;
+	ga4PropertyId?: TrafficAnalytics.Ga4PropertyId;
+}): TrafficAnalytics.Ga4DailyMetric =>
+	TrafficAnalytics.Ga4DailyMetric.record({
+		id: overrides.id as Uuid as TrafficAnalytics.Ga4DailyMetricId,
+		ga4PropertyId: overrides.ga4PropertyId ?? GA4_ID,
+		projectId: PROJECT_ID,
+		observedDate: overrides.observedDate,
+		dimensionsHash: 'hash-' + overrides.observedDate,
+		body: TrafficAnalytics.Ga4DailyDimensionsMetrics.create({
+			dimensions: { country: 'US' },
+			metrics: { sessions: overrides.sessions ?? 100, conversions: 5 },
+		}),
+		rawPayloadId: null,
+	});
+
+describe('QueryGa4MetricsUseCase', () => {
+	let propRepo: InMemoryPropertyRepo;
+	let metricRepo: InMemoryMetricRepo;
+	let useCase: QueryGa4MetricsUseCase;
+
+	beforeEach(async () => {
+		propRepo = new InMemoryPropertyRepo();
+		metricRepo = new InMemoryMetricRepo();
+		useCase = new QueryGa4MetricsUseCase(propRepo, metricRepo);
+		await propRepo.save(
+			TrafficAnalytics.Ga4Property.link({
+				id: GA4_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				propertyHandle: 'properties/123456789',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns metrics in window for the property', async () => {
+		await metricRepo.saveAll([
+			buildMetric({ id: 'dddddddd-dddd-dddd-dddd-000000000001', observedDate: '2026-05-01', sessions: 100 }),
+			buildMetric({ id: 'dddddddd-dddd-dddd-dddd-000000000002', observedDate: '2026-05-02', sessions: 200 }),
+		]);
+
+		const result = await useCase.execute({
+			ga4PropertyId: GA4_ID,
+			from: '2026-05-01',
+			to: '2026-05-02',
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.metrics.sessions)).toEqual([100, 200]);
+		expect(result[0]?.dimensions).toEqual({ country: 'US' });
+	});
+
+	it('throws NotFoundError when the property does not exist', async () => {
+		await expect(
+			useCase.execute({ ga4PropertyId: 'missing', from: '2026-05-01', to: '2026-05-02' }),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('honours the date window', async () => {
+		await metricRepo.saveAll([
+			buildMetric({ id: 'dddddddd-dddd-dddd-dddd-000000000001', observedDate: '2026-04-30' }),
+			buildMetric({ id: 'dddddddd-dddd-dddd-dddd-000000000002', observedDate: '2026-05-15' }),
+		]);
+
+		const result = await useCase.execute({
+			ga4PropertyId: GA4_ID,
+			from: '2026-05-01',
+			to: '2026-05-31',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.observedDate).toBe('2026-05-15');
+	});
+
+	it('scopes results to the requested property', async () => {
+		await propRepo.save(
+			TrafficAnalytics.Ga4Property.link({
+				id: OTHER_GA4_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				propertyHandle: 'properties/987654321',
+				credentialId: null,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await metricRepo.saveAll([
+			buildMetric({ id: 'dddddddd-dddd-dddd-dddd-000000000001', observedDate: '2026-05-01', sessions: 100 }),
+			buildMetric({
+				id: 'dddddddd-dddd-dddd-dddd-000000000002',
+				observedDate: '2026-05-01',
+				sessions: 999,
+				ga4PropertyId: OTHER_GA4_ID,
+			}),
+		]);
+
+		const result = await useCase.execute({
+			ga4PropertyId: GA4_ID,
+			from: '2026-05-01',
+			to: '2026-05-01',
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.metrics.sessions).toBe(100);
+	});
+});

--- a/packages/application/src/web-performance/use-cases/query-page-speed-history.use-case.spec.ts
+++ b/packages/application/src/web-performance/use-cases/query-page-speed-history.use-case.spec.ts
@@ -1,0 +1,160 @@
+import { type IdentityAccess, type ProjectManagement, WebPerformance } from '@rankpulse/domain';
+import { NotFoundError, type Uuid } from '@rankpulse/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryPageSpeedHistoryUseCase } from './query-page-speed-history.use-case.js';
+
+const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const PAGE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as WebPerformance.TrackedPageId;
+const OTHER_PAGE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab' as Uuid as WebPerformance.TrackedPageId;
+
+class InMemoryPageRepo implements WebPerformance.TrackedPageRepository {
+	readonly store = new Map<string, WebPerformance.TrackedPage>();
+	async save(p: WebPerformance.TrackedPage): Promise<void> {
+		this.store.set(p.id, p);
+	}
+	async findById(id: WebPerformance.TrackedPageId): Promise<WebPerformance.TrackedPage | null> {
+		return this.store.get(id) ?? null;
+	}
+	async findByProjectAndUrl(): Promise<WebPerformance.TrackedPage | null> {
+		return null;
+	}
+	async findByTuple(): Promise<WebPerformance.TrackedPage | null> {
+		return null;
+	}
+	async delete(id: WebPerformance.TrackedPageId): Promise<void> {
+		this.store.delete(id);
+	}
+	async listForProject(): Promise<readonly WebPerformance.TrackedPage[]> {
+		return [];
+	}
+	async listForOrganization(): Promise<readonly WebPerformance.TrackedPage[]> {
+		return [];
+	}
+}
+
+class InMemorySnapshotRepo implements WebPerformance.PageSpeedSnapshotRepository {
+	readonly rows: WebPerformance.PageSpeedSnapshot[] = [];
+	async save(s: WebPerformance.PageSpeedSnapshot): Promise<{ inserted: boolean }> {
+		this.rows.push(s);
+		return { inserted: true };
+	}
+	async listForPage(
+		trackedPageId: WebPerformance.TrackedPageId,
+		query: { from: Date; to: Date },
+	): Promise<readonly WebPerformance.PageSpeedSnapshot[]> {
+		return this.rows
+			.filter((r) => r.trackedPageId === trackedPageId)
+			.filter((r) => r.observedAt >= query.from && r.observedAt <= query.to)
+			.sort((a, b) => a.observedAt.getTime() - b.observedAt.getTime());
+	}
+}
+
+const buildSnapshot = (overrides: {
+	observedAt: Date;
+	lcpMs?: number | null;
+	trackedPageId?: WebPerformance.TrackedPageId;
+}): WebPerformance.PageSpeedSnapshot =>
+	WebPerformance.PageSpeedSnapshot.record({
+		trackedPageId: overrides.trackedPageId ?? PAGE_ID,
+		projectId: PROJECT_ID,
+		observedAt: overrides.observedAt,
+		lcpMs: overrides.lcpMs === undefined ? 2400 : overrides.lcpMs,
+		inpMs: 200,
+		cls: 0.05,
+		fcpMs: 1100,
+		ttfbMs: 250,
+		performanceScore: 0.92,
+		seoScore: 0.95,
+		accessibilityScore: 0.88,
+		bestPracticesScore: 0.91,
+	});
+
+describe('QueryPageSpeedHistoryUseCase', () => {
+	let pageRepo: InMemoryPageRepo;
+	let snapshotsRepo: InMemorySnapshotRepo;
+	let useCase: QueryPageSpeedHistoryUseCase;
+
+	beforeEach(async () => {
+		pageRepo = new InMemoryPageRepo();
+		snapshotsRepo = new InMemorySnapshotRepo();
+		useCase = new QueryPageSpeedHistoryUseCase(pageRepo, snapshotsRepo);
+		await pageRepo.save(
+			WebPerformance.TrackedPage.add({
+				id: PAGE_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				url: WebPerformance.PageUrl.create('https://example.com/'),
+				strategy: WebPerformance.PageSpeedStrategies.MOBILE,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+	});
+
+	it('returns snapshots in window for the page', async () => {
+		await snapshotsRepo.save(buildSnapshot({ observedAt: new Date('2026-05-01T00:00:00Z'), lcpMs: 2400 }));
+		await snapshotsRepo.save(buildSnapshot({ observedAt: new Date('2026-05-02T00:00:00Z'), lcpMs: 1900 }));
+
+		const result = await useCase.execute({
+			trackedPageId: PAGE_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.lcpMs)).toEqual([2400, 1900]);
+		expect(result[0]?.performanceScore).toBe(0.92);
+	});
+
+	it('throws NotFoundError when the tracked page does not exist', async () => {
+		await expect(
+			useCase.execute({
+				trackedPageId: 'missing',
+				from: new Date('2026-05-01T00:00:00Z'),
+				to: new Date('2026-05-31T00:00:00Z'),
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('serialises null core-web-vitals when PSI returned no value', async () => {
+		await snapshotsRepo.save(buildSnapshot({ observedAt: new Date('2026-05-01T00:00:00Z'), lcpMs: null }));
+
+		const result = await useCase.execute({
+			trackedPageId: PAGE_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result[0]?.lcpMs).toBeNull();
+	});
+
+	it('scopes results to the requested page', async () => {
+		await pageRepo.save(
+			WebPerformance.TrackedPage.add({
+				id: OTHER_PAGE_ID,
+				organizationId: ORG_ID,
+				projectId: PROJECT_ID,
+				url: WebPerformance.PageUrl.create('https://example.com/other'),
+				strategy: WebPerformance.PageSpeedStrategies.DESKTOP,
+				now: new Date('2026-05-04T10:00:00Z'),
+			}),
+		);
+		await snapshotsRepo.save(buildSnapshot({ observedAt: new Date('2026-05-01T00:00:00Z'), lcpMs: 2400 }));
+		await snapshotsRepo.save(
+			buildSnapshot({
+				observedAt: new Date('2026-05-01T00:00:00Z'),
+				lcpMs: 9999,
+				trackedPageId: OTHER_PAGE_ID,
+			}),
+		);
+
+		const result = await useCase.execute({
+			trackedPageId: PAGE_ID,
+			from: new Date('2026-05-01T00:00:00Z'),
+			to: new Date('2026-05-01T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.lcpMs).toBe(2400);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the 18 remaining \`.use-case.spec.ts\` files that CLAUDE.md §5 requires for every use case. Coverage now sits at **65/65** (was 47/65 — prior PRs filled the rest). The application layer ships with a unit test for every use case.

Closes #104.

## By context

| Context | Specs added |
|---|---|
| ai-search-insights | list-brand-prompts, pause-brand-prompt (covers Pause + Resume), query-llm-answers, query-ai-search-sov, query-prompt-sov-daily, query-competitive-matrix |
| bing-webmaster-insights | query-bing-traffic |
| entity-awareness | query-wikipedia-pageviews |
| experience-analytics | query-experience-history |
| macro-context | query-radar-history |
| meta-ads-attribution | query-meta-ads-insights, query-meta-pixel-events |
| project-management | change-project-locations |
| provider-connectivity | record-api-usage |
| rank-tracking | query-ranking-history, start-tracking-keyword |
| traffic-analytics | query-ga4-metrics |
| web-performance | query-page-speed-history |

## Discipline (CLAUDE.md §5)

- Real domain entities + value objects everywhere — no mocking domain types.
- Reused \`packages/testing\` in-memory adapters when they existed (\`InMemoryBrandPromptRepository\`, \`InMemoryLlmAnswerRepository\`, \`InMemoryLlmAnswerReadModel\`, \`InMemoryProjectRepository\`, \`RecordingEventPublisher\`, \`FakeClock\`, \`FixedIdGenerator\`).
- Inlined small fake classes per-spec where no in-memory adapter existed yet (bing / entity / experience / macro / traffic / meta / provider / rank / web). Kept those scoped to the spec instead of bulking up \`packages/testing\` — the adapters can graduate to shared helpers in a follow-up if a third caller appears.
- Asserts on observable state via repo readback or \`RecordingEventPublisher.publishedTypes()\` — no mock-call-count inspection.

Each spec covers:

- Happy path
- \`NotFoundError\` when the parent aggregate (property / project / keyword / pixel / domain / article / clarity-project / ga4-property / page) doesn't exist
- Scope boundaries (different aggregate doesn't bleed in)
- Date-window honouring
- Mutation use cases also assert the emitted domain events (\`BrandPromptPaused\`, \`BrandPromptResumed\`, \`project-management.LocationAdded\`, \`TrackedKeywordStarted\`, \`ApiUsageRecorded\`)

## Test plan

- [x] \`pnpm lint\` clean (874 files, 0 errors)
- [x] \`pnpm typecheck\` clean (26/26)
- [x] \`pnpm test\` green — \`@rankpulse/application\` 71 test files / 320 tests (was 53 / 247). All packages still pass.
- [x] \`pnpm build\` clean (23/23)

## Acceptance from #104

- [x] All missing \`.use-case.spec.ts\` files added (18 — the issue body's "34 missing" count was a snapshot before recent PRs landed 16 of them)
- [x] All use real entities, value objects, and \`packages/testing\` in-memory adapters where available
- [x] Mock only at port boundaries
- [x] \`pnpm typecheck\` + \`pnpm test\` still pass on every package