### PR TITLE
refactor(application): ContextModule pattern across all 13 contexts (Phase 4)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -168,30 +168,28 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		googleAiStudioProviderManifest,
 	]);
 
-	const registerOrganization = new IAUseCases.RegisterOrganizationUseCase(
+	// ContextModule pattern (ADR 0002 Phase 4 — pilot context). Identity-access
+	// owns its use-case wiring in `packages/application/src/identity-access/module.ts`;
+	// the composition root just hands it the slice of `SharedDeps` it needs and
+	// reads back the instantiated use cases. Other 12 contexts still use the
+	// imperative pattern below — they migrate incrementally in follow-up PRs.
+	const identityAccessDeps: IAUseCases.IdentityAccessDeps = {
+		clock: SystemClock,
+		ids: SystemIdGenerator,
+		events: eventPublisher,
 		orgRepo,
 		userRepo,
 		membershipRepo,
-		passwordHasher,
-		SystemClock,
-		SystemIdGenerator,
-		eventPublisher,
-	);
-	const authenticateUser = new IAUseCases.AuthenticateUserUseCase(userRepo, passwordHasher);
-	const inviteUser = new IAUseCases.InviteUserUseCase(
-		membershipRepo,
-		userRepo,
-		SystemClock,
-		SystemIdGenerator,
-		eventPublisher,
-	);
-	const issueApiToken = new IAUseCases.IssueApiTokenUseCase(
-		membershipRepo,
 		apiTokenRepo,
+		passwordHasher,
 		apiTokenGenerator,
-		SystemClock,
-		SystemIdGenerator,
-	);
+	};
+	const identityAccess = IAUseCases.identityAccessModule.compose(identityAccessDeps as unknown as SharedDeps);
+	const registerOrganization = identityAccess.useCases
+		.RegisterOrganization as IAUseCases.RegisterOrganizationUseCase;
+	const authenticateUser = identityAccess.useCases.AuthenticateUser as IAUseCases.AuthenticateUserUseCase;
+	const inviteUser = identityAccess.useCases.InviteUser as IAUseCases.InviteUserUseCase;
+	const issueApiToken = identityAccess.useCases.IssueApiToken as IAUseCases.IssueApiTokenUseCase;
 
 	const createProject = new PMUseCases.CreateProjectUseCase(
 		projectRepo,

--- a/packages/application/src/ai-search-insights/index.ts
+++ b/packages/application/src/ai-search-insights/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/delete-brand-prompt.use-case.js';
 export * from './use-cases/list-brand-prompts.use-case.js';
 export * from './use-cases/pause-brand-prompt.use-case.js';

--- a/packages/application/src/ai-search-insights/module.ts
+++ b/packages/application/src/ai-search-insights/module.ts
@@ -1,0 +1,64 @@
+import type { AiSearchInsights as AISIDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { DeleteBrandPromptUseCase } from './use-cases/delete-brand-prompt.use-case.js';
+import { ListBrandPromptsUseCase } from './use-cases/list-brand-prompts.use-case.js';
+import {
+	PauseBrandPromptUseCase,
+	ResumeBrandPromptUseCase,
+} from './use-cases/pause-brand-prompt.use-case.js';
+import { QueryAiSearchAlertsUseCase } from './use-cases/query-ai-search-alerts.use-case.js';
+import { QueryAiSearchCitationsUseCase } from './use-cases/query-ai-search-citations.use-case.js';
+import { QueryAiSearchPresenceUseCase } from './use-cases/query-ai-search-presence.use-case.js';
+import { QueryAiSearchSovUseCase } from './use-cases/query-ai-search-sov.use-case.js';
+import { QueryCompetitiveMatrixUseCase } from './use-cases/query-competitive-matrix.use-case.js';
+import { QueryLlmAnswersUseCase } from './use-cases/query-llm-answers.use-case.js';
+import { QueryPromptSovDailyUseCase } from './use-cases/query-prompt-sov-daily.use-case.js';
+import { RecordLlmAnswerUseCase } from './use-cases/record-llm-answer.use-case.js';
+import { RegisterBrandPromptUseCase } from './use-cases/register-brand-prompt.use-case.js';
+
+export interface AiSearchInsightsDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly brandPromptRepo: AISIDomain.BrandPromptRepository;
+	readonly llmAnswerRepo: AISIDomain.LlmAnswerRepository;
+	readonly llmAnswerReadModel: AISIDomain.LlmAnswerReadModel;
+	readonly brandWatchlistResolver: AISIDomain.BrandWatchlistResolver;
+	readonly mentionExtractor: AISIDomain.MentionExtractor;
+}
+
+export const aiSearchInsightsModule: ContextModule = {
+	id: 'ai-search-insights',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as AiSearchInsightsDeps;
+		return {
+			useCases: {
+				RegisterBrandPrompt: new RegisterBrandPromptUseCase(d.brandPromptRepo, d.clock, d.ids, d.events),
+				PauseBrandPrompt: new PauseBrandPromptUseCase(d.brandPromptRepo, d.clock, d.events),
+				ResumeBrandPrompt: new ResumeBrandPromptUseCase(d.brandPromptRepo, d.clock, d.events),
+				DeleteBrandPrompt: new DeleteBrandPromptUseCase(d.brandPromptRepo),
+				ListBrandPrompts: new ListBrandPromptsUseCase(d.brandPromptRepo),
+				RecordLlmAnswer: new RecordLlmAnswerUseCase(
+					d.brandPromptRepo,
+					d.llmAnswerRepo,
+					d.brandWatchlistResolver,
+					d.mentionExtractor,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				QueryLlmAnswers: new QueryLlmAnswersUseCase(d.llmAnswerRepo),
+				QueryAiSearchPresence: new QueryAiSearchPresenceUseCase(d.llmAnswerReadModel),
+				QueryAiSearchSov: new QueryAiSearchSovUseCase(d.llmAnswerReadModel),
+				QueryAiSearchCitations: new QueryAiSearchCitationsUseCase(d.llmAnswerReadModel),
+				QueryPromptSovDaily: new QueryPromptSovDailyUseCase(d.llmAnswerReadModel),
+				QueryCompetitiveMatrix: new QueryCompetitiveMatrixUseCase(d.llmAnswerReadModel),
+				QueryAiSearchAlerts: new QueryAiSearchAlertsUseCase(d.llmAnswerReadModel),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/bing-webmaster-insights/index.ts
+++ b/packages/application/src/bing-webmaster-insights/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/ingest-bing-traffic.use-case.js';
 export * from './use-cases/link-bing-property.use-case.js';
 export * from './use-cases/query-bing-traffic.use-case.js';

--- a/packages/application/src/bing-webmaster-insights/module.ts
+++ b/packages/application/src/bing-webmaster-insights/module.ts
@@ -1,0 +1,31 @@
+import type { BingWebmasterInsights as BWIDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { LinkBingPropertyUseCase } from './use-cases/link-bing-property.use-case.js';
+import { QueryBingTrafficUseCase } from './use-cases/query-bing-traffic.use-case.js';
+import { UnlinkBingPropertyUseCase } from './use-cases/unlink-bing-property.use-case.js';
+
+export interface BingWebmasterInsightsDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly bingPropertyRepo: BWIDomain.BingPropertyRepository;
+	readonly bingTrafficObservationRepo: BWIDomain.BingTrafficObservationRepository;
+}
+
+export const bingWebmasterInsightsModule: ContextModule = {
+	id: 'bing-webmaster-insights',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as BingWebmasterInsightsDeps;
+		return {
+			useCases: {
+				LinkBingProperty: new LinkBingPropertyUseCase(d.bingPropertyRepo, d.clock, d.ids, d.events),
+				UnlinkBingProperty: new UnlinkBingPropertyUseCase(d.bingPropertyRepo, d.clock),
+				QueryBingTraffic: new QueryBingTrafficUseCase(d.bingPropertyRepo, d.bingTrafficObservationRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/entity-awareness/index.ts
+++ b/packages/application/src/entity-awareness/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/ingest-wikipedia-pageviews.use-case.js';
 export * from './use-cases/link-wikipedia-article.use-case.js';
 export * from './use-cases/query-wikipedia-pageviews.use-case.js';

--- a/packages/application/src/entity-awareness/module.ts
+++ b/packages/application/src/entity-awareness/module.ts
@@ -1,0 +1,39 @@
+import type { EntityAwareness as EADomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { LinkWikipediaArticleUseCase } from './use-cases/link-wikipedia-article.use-case.js';
+import { QueryWikipediaPageviewsUseCase } from './use-cases/query-wikipedia-pageviews.use-case.js';
+import { UnlinkWikipediaArticleUseCase } from './use-cases/unlink-wikipedia-article.use-case.js';
+
+export interface EntityAwarenessDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly wikipediaArticleRepo: EADomain.WikipediaArticleRepository;
+	readonly wikipediaPageviewRepo: EADomain.WikipediaPageviewObservationRepository;
+}
+
+export const entityAwarenessModule: ContextModule = {
+	id: 'entity-awareness',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as EntityAwarenessDeps;
+		return {
+			useCases: {
+				LinkWikipediaArticle: new LinkWikipediaArticleUseCase(
+					d.wikipediaArticleRepo,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				UnlinkWikipediaArticle: new UnlinkWikipediaArticleUseCase(d.wikipediaArticleRepo, d.clock, d.events),
+				QueryWikipediaPageviews: new QueryWikipediaPageviewsUseCase(
+					d.wikipediaArticleRepo,
+					d.wikipediaPageviewRepo,
+				),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/experience-analytics/index.ts
+++ b/packages/application/src/experience-analytics/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/link-clarity-project.use-case.js';
 export * from './use-cases/query-experience-history.use-case.js';
 export * from './use-cases/record-experience-snapshot.use-case.js';

--- a/packages/application/src/experience-analytics/module.ts
+++ b/packages/application/src/experience-analytics/module.ts
@@ -1,0 +1,34 @@
+import type { ExperienceAnalytics as EXADomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { LinkClarityProjectUseCase } from './use-cases/link-clarity-project.use-case.js';
+import { QueryExperienceHistoryUseCase } from './use-cases/query-experience-history.use-case.js';
+import { UnlinkClarityProjectUseCase } from './use-cases/unlink-clarity-project.use-case.js';
+
+export interface ExperienceAnalyticsDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly clarityProjectRepo: EXADomain.ClarityProjectRepository;
+	readonly experienceSnapshotRepo: EXADomain.ExperienceSnapshotRepository;
+}
+
+export const experienceAnalyticsModule: ContextModule = {
+	id: 'experience-analytics',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as ExperienceAnalyticsDeps;
+		return {
+			useCases: {
+				LinkClarityProject: new LinkClarityProjectUseCase(d.clarityProjectRepo, d.clock, d.ids, d.events),
+				UnlinkClarityProject: new UnlinkClarityProjectUseCase(d.clarityProjectRepo, d.clock),
+				QueryExperienceHistory: new QueryExperienceHistoryUseCase(
+					d.clarityProjectRepo,
+					d.experienceSnapshotRepo,
+				),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/identity-access/index.ts
+++ b/packages/application/src/identity-access/index.ts
@@ -1,3 +1,4 @@
+export * from './module.js';
 export * from './use-cases/authenticate-user.use-case.js';
 export * from './use-cases/invite-user.use-case.js';
 export * from './use-cases/issue-api-token.use-case.js';

--- a/packages/application/src/identity-access/module.ts
+++ b/packages/application/src/identity-access/module.ts
@@ -1,0 +1,70 @@
+import type { IdentityAccess as IADomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { AuthenticateUserUseCase } from './use-cases/authenticate-user.use-case.js';
+import { InviteUserUseCase } from './use-cases/invite-user.use-case.js';
+import { IssueApiTokenUseCase } from './use-cases/issue-api-token.use-case.js';
+import { RegisterOrganizationUseCase } from './use-cases/register-organization.use-case.js';
+
+/**
+ * Concrete dependencies the identity-access context needs from
+ * `SharedDeps`. Composition root populates these on the opaque
+ * `SharedDeps` brand and `compose` casts down to this narrower view.
+ *
+ * Keeping the cast local to each context module preserves the
+ * application-layer purity (no import from infrastructure or apps —
+ * only domain ports + shared abstractions like Clock / IdGenerator).
+ */
+export interface IdentityAccessDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly orgRepo: IADomain.OrganizationRepository;
+	readonly userRepo: IADomain.UserRepository;
+	readonly membershipRepo: IADomain.MembershipRepository;
+	readonly apiTokenRepo: IADomain.ApiTokenRepository;
+	readonly passwordHasher: IADomain.PasswordHasher;
+	readonly apiTokenGenerator: IADomain.ApiTokenGenerator;
+}
+
+/**
+ * `ContextModule` for identity-access. The composition root iterates
+ * every context's module and merges their `useCases` maps into the DI
+ * registry; `ingestUseCases` and `eventHandlers` are empty here because
+ * identity-access has no provider ingest or auto-schedule today.
+ */
+export const identityAccessModule: ContextModule = {
+	id: 'identity-access',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as IdentityAccessDeps;
+		const registerOrganization = new RegisterOrganizationUseCase(
+			d.orgRepo,
+			d.userRepo,
+			d.membershipRepo,
+			d.passwordHasher,
+			d.clock,
+			d.ids,
+			d.events,
+		);
+		const authenticateUser = new AuthenticateUserUseCase(d.userRepo, d.passwordHasher);
+		const inviteUser = new InviteUserUseCase(d.membershipRepo, d.userRepo, d.clock, d.ids, d.events);
+		const issueApiToken = new IssueApiTokenUseCase(
+			d.membershipRepo,
+			d.apiTokenRepo,
+			d.apiTokenGenerator,
+			d.clock,
+			d.ids,
+		);
+		return {
+			useCases: {
+				RegisterOrganization: registerOrganization,
+				AuthenticateUser: authenticateUser,
+				InviteUser: inviteUser,
+				IssueApiToken: issueApiToken,
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/macro-context/index.ts
+++ b/packages/application/src/macro-context/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/add-monitored-domain.use-case.js';
 export * from './use-cases/query-radar-history.use-case.js';
 export * from './use-cases/record-radar-rank.use-case.js';

--- a/packages/application/src/macro-context/module.ts
+++ b/packages/application/src/macro-context/module.ts
@@ -1,0 +1,31 @@
+import type { MacroContext as MCDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { AddMonitoredDomainUseCase } from './use-cases/add-monitored-domain.use-case.js';
+import { QueryRadarHistoryUseCase } from './use-cases/query-radar-history.use-case.js';
+import { RemoveMonitoredDomainUseCase } from './use-cases/remove-monitored-domain.use-case.js';
+
+export interface MacroContextDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly monitoredDomainRepo: MCDomain.MonitoredDomainRepository;
+	readonly radarRankSnapshotRepo: MCDomain.RadarRankSnapshotRepository;
+}
+
+export const macroContextModule: ContextModule = {
+	id: 'macro-context',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as MacroContextDeps;
+		return {
+			useCases: {
+				AddMonitoredDomain: new AddMonitoredDomainUseCase(d.monitoredDomainRepo, d.clock, d.ids, d.events),
+				RemoveMonitoredDomain: new RemoveMonitoredDomainUseCase(d.monitoredDomainRepo, d.clock),
+				QueryRadarHistory: new QueryRadarHistoryUseCase(d.monitoredDomainRepo, d.radarRankSnapshotRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/meta-ads-attribution/index.ts
+++ b/packages/application/src/meta-ads-attribution/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/ingest-meta-ads-insights.use-case.js';
 export * from './use-cases/ingest-meta-pixel-events.use-case.js';
 export * from './use-cases/link-meta-ad-account.use-case.js';

--- a/packages/application/src/meta-ads-attribution/module.ts
+++ b/packages/application/src/meta-ads-attribution/module.ts
@@ -1,0 +1,39 @@
+import type { MetaAdsAttribution as MAADomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { LinkMetaAdAccountUseCase } from './use-cases/link-meta-ad-account.use-case.js';
+import { LinkMetaPixelUseCase } from './use-cases/link-meta-pixel.use-case.js';
+import { QueryMetaAdsInsightsUseCase } from './use-cases/query-meta-ads-insights.use-case.js';
+import { QueryMetaPixelEventsUseCase } from './use-cases/query-meta-pixel-events.use-case.js';
+import { UnlinkMetaAdAccountUseCase } from './use-cases/unlink-meta-ad-account.use-case.js';
+import { UnlinkMetaPixelUseCase } from './use-cases/unlink-meta-pixel.use-case.js';
+
+export interface MetaAdsAttributionDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly metaPixelRepo: MAADomain.MetaPixelRepository;
+	readonly metaAdAccountRepo: MAADomain.MetaAdAccountRepository;
+	readonly metaPixelEventDailyRepo: MAADomain.MetaPixelEventDailyRepository;
+	readonly metaAdsInsightDailyRepo: MAADomain.MetaAdsInsightDailyRepository;
+}
+
+export const metaAdsAttributionModule: ContextModule = {
+	id: 'meta-ads-attribution',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as MetaAdsAttributionDeps;
+		return {
+			useCases: {
+				LinkMetaPixel: new LinkMetaPixelUseCase(d.metaPixelRepo, d.clock, d.ids, d.events),
+				UnlinkMetaPixel: new UnlinkMetaPixelUseCase(d.metaPixelRepo, d.clock),
+				LinkMetaAdAccount: new LinkMetaAdAccountUseCase(d.metaAdAccountRepo, d.clock, d.ids, d.events),
+				UnlinkMetaAdAccount: new UnlinkMetaAdAccountUseCase(d.metaAdAccountRepo, d.clock),
+				QueryMetaPixelEvents: new QueryMetaPixelEventsUseCase(d.metaPixelRepo, d.metaPixelEventDailyRepo),
+				QueryMetaAdsInsights: new QueryMetaAdsInsightsUseCase(d.metaAdAccountRepo, d.metaAdsInsightDailyRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/project-management/index.ts
+++ b/packages/application/src/project-management/index.ts
@@ -1,3 +1,4 @@
+export * from './module.js';
 export * from './use-cases/add-competitor.use-case.js';
 export * from './use-cases/add-domain-to-project.use-case.js';
 export * from './use-cases/change-project-locations.use-case.js';

--- a/packages/application/src/project-management/module.ts
+++ b/packages/application/src/project-management/module.ts
@@ -1,0 +1,78 @@
+import type { ProjectManagement as PMDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { AddCompetitorUseCase } from './use-cases/add-competitor.use-case.js';
+import { AddDomainToProjectUseCase } from './use-cases/add-domain-to-project.use-case.js';
+import { AddProjectLocationUseCase } from './use-cases/change-project-locations.use-case.js';
+import {
+	DismissCompetitorSuggestionUseCase,
+	ListCompetitorSuggestionsUseCase,
+	PromoteCompetitorSuggestionUseCase,
+} from './use-cases/competitor-suggestions.use-cases.js';
+import { CreateProjectUseCase } from './use-cases/create-project.use-case.js';
+import { ImportKeywordsUseCase } from './use-cases/import-keywords.use-case.js';
+import {
+	CreatePortfolioUseCase,
+	DeletePortfolioUseCase,
+	GetPortfolioUseCase,
+	ListPortfoliosUseCase,
+	RenamePortfolioUseCase,
+} from './use-cases/manage-portfolios.use-cases.js';
+
+export interface ProjectManagementDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly projectRepo: PMDomain.ProjectRepository;
+	readonly portfolioRepo: PMDomain.PortfolioRepository;
+	readonly keywordListRepo: PMDomain.KeywordListRepository;
+	readonly competitorRepo: PMDomain.CompetitorRepository;
+	readonly competitorSuggestionRepo: PMDomain.CompetitorSuggestionRepository;
+	/**
+	 * BACKLOG #18: project-management's `ListCompetitorSuggestions` needs
+	 * the project's tracked-keyword count to evaluate the eligibility
+	 * ratio. Rather than coupling project-management to the rank-tracking
+	 * aggregate, we accept a tiny lambda over the tracked-keyword repo —
+	 * composition root provides the actual `trackedKeywordRepo.countForProject`.
+	 */
+	readonly trackedKeywordCountForProject: (projectId: string) => Promise<number>;
+}
+
+export const projectManagementModule: ContextModule = {
+	id: 'project-management',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as ProjectManagementDeps;
+		return {
+			useCases: {
+				CreateProject: new CreateProjectUseCase(d.projectRepo, d.clock, d.ids, d.events),
+				AddDomainToProject: new AddDomainToProjectUseCase(d.projectRepo, d.clock, d.events),
+				AddProjectLocation: new AddProjectLocationUseCase(d.projectRepo, d.clock, d.events),
+				AddCompetitor: new AddCompetitorUseCase(d.projectRepo, d.competitorRepo, d.clock, d.ids, d.events),
+				ImportKeywords: new ImportKeywordsUseCase(d.projectRepo, d.keywordListRepo, d.clock, d.ids, d.events),
+				CreatePortfolio: new CreatePortfolioUseCase(d.portfolioRepo, d.clock, d.ids, d.events),
+				ListPortfolios: new ListPortfoliosUseCase(d.portfolioRepo),
+				GetPortfolio: new GetPortfolioUseCase(d.portfolioRepo),
+				RenamePortfolio: new RenamePortfolioUseCase(d.portfolioRepo),
+				DeletePortfolio: new DeletePortfolioUseCase(d.portfolioRepo),
+				ListCompetitorSuggestions: new ListCompetitorSuggestionsUseCase(
+					d.competitorSuggestionRepo,
+					d.trackedKeywordCountForProject,
+				),
+				PromoteCompetitorSuggestion: new PromoteCompetitorSuggestionUseCase(
+					d.competitorSuggestionRepo,
+					d.competitorRepo,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				DismissCompetitorSuggestion: new DismissCompetitorSuggestionUseCase(
+					d.competitorSuggestionRepo,
+					d.clock,
+				),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/provider-connectivity/index.ts
+++ b/packages/application/src/provider-connectivity/index.ts
@@ -1,3 +1,4 @@
+export * from './module.js';
 export * from './use-cases/list-job-runs.use-case.js';
 export * from './use-cases/manage-job-definition.use-cases.js';
 export * from './use-cases/record-api-usage.use-case.js';

--- a/packages/application/src/provider-connectivity/module.ts
+++ b/packages/application/src/provider-connectivity/module.ts
@@ -1,0 +1,84 @@
+import type { ProviderConnectivity as PCDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { ListJobRunsUseCase } from './use-cases/list-job-runs.use-case.js';
+import {
+	DeleteJobDefinitionUseCase,
+	GetJobDefinitionUseCase,
+	ListJobDefinitionsUseCase,
+	UpdateJobDefinitionUseCase,
+} from './use-cases/manage-job-definition.use-cases.js';
+import { RecordApiUsageUseCase } from './use-cases/record-api-usage.use-case.js';
+import {
+	type CredentialFormatValidator,
+	RegisterProviderCredentialUseCase,
+} from './use-cases/register-provider-credential.use-case.js';
+import { ResolveProviderCredentialUseCase } from './use-cases/resolve-provider-credential.use-case.js';
+import {
+	type EndpointParamsValidator,
+	ScheduleEndpointFetchUseCase,
+} from './use-cases/schedule-endpoint-fetch.use-case.js';
+import { TriggerJobDefinitionRunUseCase } from './use-cases/trigger-job-definition-run.use-case.js';
+
+export interface ProviderConnectivityDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly credentialRepo: PCDomain.CredentialRepository;
+	readonly credentialVault: PCDomain.CredentialVault;
+	readonly jobDefRepo: PCDomain.JobDefinitionRepository;
+	readonly jobRunRepo: PCDomain.JobRunRepository;
+	readonly apiUsageRepo: PCDomain.ApiUsageRepository;
+	readonly jobScheduler: PCDomain.JobScheduler;
+	/**
+	 * Tiny adapter the composition root builds over the actual provider
+	 * registry. Keeps the application layer decoupled from
+	 * `@rankpulse/provider-core` (the use cases only need a `validate`
+	 * callback shape).
+	 */
+	readonly credentialFormatValidator: CredentialFormatValidator;
+	/** Same idea for endpoint params validation — adapter over the registry. */
+	readonly endpointParamsValidator: EndpointParamsValidator;
+}
+
+export const providerConnectivityModule: ContextModule = {
+	id: 'provider-connectivity',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as ProviderConnectivityDeps;
+		return {
+			useCases: {
+				RegisterProviderCredential: new RegisterProviderCredentialUseCase(
+					d.credentialRepo,
+					d.credentialVault,
+					d.credentialFormatValidator,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				ResolveProviderCredential: new ResolveProviderCredentialUseCase(
+					d.credentialRepo,
+					d.credentialVault,
+					d.clock,
+				),
+				ScheduleEndpointFetch: new ScheduleEndpointFetchUseCase(
+					d.jobDefRepo,
+					d.jobScheduler,
+					d.endpointParamsValidator,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				TriggerJobDefinitionRun: new TriggerJobDefinitionRunUseCase(d.jobDefRepo, d.jobScheduler, d.ids),
+				ListJobDefinitions: new ListJobDefinitionsUseCase(d.jobDefRepo),
+				GetJobDefinition: new GetJobDefinitionUseCase(d.jobDefRepo),
+				UpdateJobDefinition: new UpdateJobDefinitionUseCase(d.jobDefRepo, d.jobScheduler),
+				DeleteJobDefinition: new DeleteJobDefinitionUseCase(d.jobDefRepo, d.jobScheduler),
+				ListJobRuns: new ListJobRunsUseCase(d.jobRunRepo),
+				RecordApiUsage: new RecordApiUsageUseCase(d.apiUsageRepo, d.clock, d.ids, d.events),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/rank-tracking/index.ts
+++ b/packages/application/src/rank-tracking/index.ts
@@ -1,3 +1,4 @@
+export * from './module.js';
 export * from './use-cases/query-ranking-history.use-case.js';
 export * from './use-cases/record-ranking-observation.use-case.js';
 export * from './use-cases/start-tracking-keyword.use-case.js';

--- a/packages/application/src/rank-tracking/module.ts
+++ b/packages/application/src/rank-tracking/module.ts
@@ -1,0 +1,42 @@
+import type {
+	ProjectManagement as PMDomain,
+	RankTracking as RTDomain,
+	SharedKernel,
+} from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { QueryRankingHistoryUseCase } from './use-cases/query-ranking-history.use-case.js';
+import { RecordRankingObservationUseCase } from './use-cases/record-ranking-observation.use-case.js';
+import { StartTrackingKeywordUseCase } from './use-cases/start-tracking-keyword.use-case.js';
+
+export interface RankTrackingDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly trackedKeywordRepo: RTDomain.TrackedKeywordRepository;
+	readonly observationRepo: RTDomain.RankingObservationRepository;
+	readonly projectRepo: PMDomain.ProjectRepository;
+}
+
+export const rankTrackingModule: ContextModule = {
+	id: 'rank-tracking',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as RankTrackingDeps;
+		return {
+			useCases: {
+				StartTrackingKeyword: new StartTrackingKeywordUseCase(d.trackedKeywordRepo, d.clock, d.ids, d.events),
+				RecordRankingObservation: new RecordRankingObservationUseCase(
+					d.trackedKeywordRepo,
+					d.observationRepo,
+					d.clock,
+					d.ids,
+					d.events,
+				),
+				QueryRankingHistory: new QueryRankingHistoryUseCase(d.trackedKeywordRepo, d.observationRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/search-console-insights/index.ts
+++ b/packages/application/src/search-console-insights/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/ingest-gsc-rows.use-case.js';
 export * from './use-cases/link-gsc-property.use-case.js';
 export * from './use-cases/query-gsc-performance.use-case.js';

--- a/packages/application/src/search-console-insights/module.ts
+++ b/packages/application/src/search-console-insights/module.ts
@@ -1,0 +1,37 @@
+import type { SearchConsoleInsights as SCIDomain, SharedKernel } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { IngestGscRowsUseCase } from './use-cases/ingest-gsc-rows.use-case.js';
+import { LinkGscPropertyUseCase } from './use-cases/link-gsc-property.use-case.js';
+import { QueryGscPerformanceUseCase } from './use-cases/query-gsc-performance.use-case.js';
+
+export interface SearchConsoleInsightsDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly gscPropertyRepo: SCIDomain.GscPropertyRepository;
+	readonly gscObservationRepo: SCIDomain.GscPerformanceObservationRepository;
+}
+
+export const searchConsoleInsightsModule: ContextModule = {
+	id: 'search-console-insights',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as SearchConsoleInsightsDeps;
+		return {
+			useCases: {
+				LinkGscProperty: new LinkGscPropertyUseCase(d.gscPropertyRepo, d.clock, d.ids, d.events),
+				IngestGscRows: new IngestGscRowsUseCase(
+					d.gscPropertyRepo,
+					d.gscObservationRepo,
+					d.ids,
+					d.events,
+					d.clock,
+				),
+				QueryGscPerformance: new QueryGscPerformanceUseCase(d.gscPropertyRepo, d.gscObservationRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/traffic-analytics/index.ts
+++ b/packages/application/src/traffic-analytics/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/ingest-ga4-rows.use-case.js';
 export * from './use-cases/link-ga4-property.use-case.js';
 export * from './use-cases/query-ga4-metrics.use-case.js';

--- a/packages/application/src/traffic-analytics/module.ts
+++ b/packages/application/src/traffic-analytics/module.ts
@@ -1,0 +1,31 @@
+import type { SharedKernel, TrafficAnalytics as TADomain } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { LinkGa4PropertyUseCase } from './use-cases/link-ga4-property.use-case.js';
+import { QueryGa4MetricsUseCase } from './use-cases/query-ga4-metrics.use-case.js';
+import { UnlinkGa4PropertyUseCase } from './use-cases/unlink-ga4-property.use-case.js';
+
+export interface TrafficAnalyticsDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly ga4PropertyRepo: TADomain.Ga4PropertyRepository;
+	readonly ga4DailyMetricRepo: TADomain.Ga4DailyMetricRepository;
+}
+
+export const trafficAnalyticsModule: ContextModule = {
+	id: 'traffic-analytics',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as TrafficAnalyticsDeps;
+		return {
+			useCases: {
+				LinkGa4Property: new LinkGa4PropertyUseCase(d.ga4PropertyRepo, d.clock, d.ids, d.events),
+				UnlinkGa4Property: new UnlinkGa4PropertyUseCase(d.ga4PropertyRepo, d.clock),
+				QueryGa4Metrics: new QueryGa4MetricsUseCase(d.ga4PropertyRepo, d.ga4DailyMetricRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};

--- a/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.spec.ts
+++ b/packages/application/src/traffic-analytics/use-cases/query-ga4-metrics.use-case.spec.ts
@@ -58,7 +58,7 @@ const buildMetric = (overrides: {
 		ga4PropertyId: overrides.ga4PropertyId ?? GA4_ID,
 		projectId: PROJECT_ID,
 		observedDate: overrides.observedDate,
-		dimensionsHash: 'hash-' + overrides.observedDate,
+		dimensionsHash: `hash-${overrides.observedDate}`,
 		body: TrafficAnalytics.Ga4DailyDimensionsMetrics.create({
 			dimensions: { country: 'US' },
 			metrics: { sessions: overrides.sessions ?? 100, conversions: 5 },

--- a/packages/application/src/web-performance/index.ts
+++ b/packages/application/src/web-performance/index.ts
@@ -1,4 +1,5 @@
 export * from './event-handlers/auto-schedule.config.js';
+export * from './module.js';
 export * from './use-cases/query-page-speed-history.use-case.js';
 export * from './use-cases/record-page-speed-snapshot.use-case.js';
 export * from './use-cases/track-page.use-case.js';

--- a/packages/application/src/web-performance/module.ts
+++ b/packages/application/src/web-performance/module.ts
@@ -1,0 +1,31 @@
+import type { SharedKernel, WebPerformance as WPDomain } from '@rankpulse/domain';
+import type { Clock, IdGenerator } from '@rankpulse/shared';
+import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { QueryPageSpeedHistoryUseCase } from './use-cases/query-page-speed-history.use-case.js';
+import { TrackPageUseCase } from './use-cases/track-page.use-case.js';
+import { UntrackPageUseCase } from './use-cases/untrack-page.use-case.js';
+
+export interface WebPerformanceDeps {
+	readonly clock: Clock;
+	readonly ids: IdGenerator;
+	readonly events: SharedKernel.EventPublisher;
+	readonly trackedPageRepo: WPDomain.TrackedPageRepository;
+	readonly pageSpeedSnapshotRepo: WPDomain.PageSpeedSnapshotRepository;
+}
+
+export const webPerformanceModule: ContextModule = {
+	id: 'web-performance',
+	compose(deps: SharedDeps): ContextRegistrations {
+		const d = deps as unknown as WebPerformanceDeps;
+		return {
+			useCases: {
+				TrackPage: new TrackPageUseCase(d.trackedPageRepo, d.clock, d.ids, d.events),
+				UntrackPage: new UntrackPageUseCase(d.trackedPageRepo),
+				QueryPageSpeedHistory: new QueryPageSpeedHistoryUseCase(d.trackedPageRepo, d.pageSpeedSnapshotRepo),
+			},
+			ingestUseCases: {},
+			eventHandlers: [],
+			schemaTables: [],
+		};
+	},
+};


### PR DESCRIPTION
## Summary

Closes the module-creation milestone for ADR 0002 Phase 4. Every one of the 13 bounded contexts now exports a `<context>Module: ContextModule` factory:

| Context | Use cases |
|---|---|
| ai-search-insights | 13 |
| bing-webmaster-insights | 3 |
| entity-awareness | 3 |
| experience-analytics | 3 |
| identity-access | 4 (pilot) |
| macro-context | 3 |
| meta-ads-attribution | 6 |
| project-management | 13 |
| provider-connectivity | 10 |
| rank-tracking | 3 |
| search-console-insights | 3 |
| traffic-analytics | 3 |
| web-performance | 3 |

Total: **70 use cases** distributed across 13 modules.

Closes #98 (modules created). Composition-root adoption is deliberately incremental (see "Out of scope" below).

## Pattern

Each module:

1. Declares a context-local `<Context>Deps` interface — the slice of `SharedDeps` it actually needs (clock, ids, events, the repos and ports relevant to this context).
2. Exports `<context>Module: ContextModule` with `compose(deps): ContextRegistrations` that casts the opaque `SharedDeps` brand to its `<Context>Deps` and returns instantiated use cases keyed by token name.
3. The `useCases` map keys match `Tokens.X.description` so composition-root can do `value(Tokens.X, registrations.useCases[X])` directly.

The cast is scoped to each module — application layer stays decoupled from infrastructure concrete types. Composition root knows everything; modules know only what they need; the type union is opaque on the application side.

## What's wired now

- **identity-access** is the pilot — composition-root replaces 24 lines of imperative `new IAUseCases.RegisterOrganizationUseCase(...)` etc. with a deps object + one `compose` call + 4 typed reads through `registrations.useCases`.
- **The other 12 contexts** ship their `module.ts` files but composition-root keeps the imperative wiring for them. Replacing each block with `module.compose(deps)` is the mechanical follow-up.

## Why ship in this shape

I considered porting the full composition-root in this PR, but each context has small quirks (some have validator adapters around a provider registry, some have multiple ingest use cases, some need `trackedKeywordCountForProject` lambdas crossing context boundaries). A one-shot 13-context refactor risks a regression that's hard to bisect. Shipping the modules + a single pilot adoption establishes the pattern unambiguously; subsequent migrations are 12 small, reviewable PRs.

## Out of scope (intentional)

- **`ingestUseCases` map populated**: currently empty for every context. Worker still wires per-context ingest use cases imperatively — they migrate when worker adopts the module pattern.
- **`eventHandlers` map populated**: currently empty. Auto-schedule still goes through the centralized `buildAutoScheduleHandlers(...)` call — will split per-context in a follow-up so each module owns its handlers.
- **`schemaTables` map populated**: deferred to Phase 2 (#102 — schema split per bounded context, blocked on drizzle-kit upgrade).
- **Composition-root migration for the other 12**: mechanical follow-ups, separable PRs.

## Test plan

- [x] `pnpm lint` clean (887 files, 0 errors)
- [x] `pnpm typecheck` clean (26/26)
- [x] `pnpm test` green — application 320/320, api 16/16, all packages still pass
- [x] `pnpm build` green (23/23)
- [x] Identity-access pilot: controllers + jwt service still resolve their tokens (no change to NestJS DI surface)