### PR TITLE
fix: worker crash loop + AI Brand Radar read-model 500s

### DIFF
--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -30,6 +30,15 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,
 	): Promise<AiSearchInsights.AiSearchPresenceSummary> {
+		// postgres-js (v3.4.x) does not auto-coerce `Date` objects passed
+		// as `sql\`...\`` template parameters — Bind packet writer hits
+		// `Buffer.byteLength(<Date>)` and throws ERR_INVALID_ARG_TYPE,
+		// surfacing as a 500 from this read endpoint. Coercing to ISO
+		// strings here keeps the query semantically identical (postgres
+		// parses them as `timestamptz`) without round-tripping through
+		// the driver's type registry.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		const rows = await this.db.execute(sql<{
 			total_answers: number;
 			answers_with_own_mention: number;
@@ -43,7 +52,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
 				FROM llm_answers
 				WHERE project_id = ${projectId}
-				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			)
 			SELECT
 				COUNT(*)::int AS total_answers,
@@ -84,6 +93,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,
 	): Promise<readonly AiSearchInsights.AiSearchSovRow[]> {
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		const rows = await this.db.execute(sql<{
 			ai_provider: string;
 			country: string;
@@ -101,7 +113,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
 				FROM llm_answers
 				WHERE project_id = ${projectId}
-				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			),
 			totals AS (
 				SELECT ai_provider, country, language, COUNT(*)::int AS total_answers
@@ -180,6 +192,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 	): Promise<readonly AiSearchInsights.AiSearchCitationRow[]> {
 		const onlyOwn = filter.onlyOwnDomains ?? false;
 		const aiProvider = filter.aiProvider ?? null;
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		const rows = await this.db.execute(sql<{
 			url: string;
 			domain: string;
@@ -201,7 +216,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
 				) c
 				WHERE a.project_id = ${projectId}
-				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 				  AND (${aiProvider}::text IS NULL OR a.ai_provider = ${aiProvider}::text)
 			)
 			SELECT
@@ -245,6 +260,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		brandPromptId: AiSearchInsights.BrandPromptId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,
 	): Promise<readonly AiSearchInsights.AiSearchSovDailyPoint[]> {
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		const rows = await this.db.execute(sql<{
 			day: string;
 			total_answers: number;
@@ -256,7 +274,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
 				FROM llm_answers
 				WHERE brand_prompt_id = ${brandPromptId}
-				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			)
 			SELECT
 				to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
@@ -309,6 +327,10 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 	): Promise<readonly AiSearchInsights.AiSearchWeeklySovDelta[]> {
 		const thisWeekStart = new Date(asOf.getTime() - 7 * 24 * 60 * 60 * 1000);
 		const lastWeekStart = new Date(asOf.getTime() - 14 * 24 * 60 * 60 * 1000);
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const asOfIso = asOf.toISOString();
+		const thisWeekStartIso = thisWeekStart.toISOString();
+		const lastWeekStartIso = lastWeekStart.toISOString();
 		const rows = await this.db.execute(sql<{
 			ai_provider: string;
 			country: string;
@@ -323,24 +345,24 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
 				FROM llm_answers
 				WHERE project_id = ${projectId}
-				  AND captured_at >= ${lastWeekStart}
-				  AND captured_at <= ${asOf}
+				  AND captured_at >= ${lastWeekStartIso}
+				  AND captured_at <= ${asOfIso}
 			)
 			SELECT
 				ai_provider,
 				country,
 				language,
-				COUNT(*) FILTER (WHERE captured_at >= ${thisWeekStart})::int AS this_week_total,
+				COUNT(*) FILTER (WHERE captured_at >= ${thisWeekStartIso})::int AS this_week_total,
 				COUNT(*) FILTER (
-					WHERE captured_at >= ${thisWeekStart}
+					WHERE captured_at >= ${thisWeekStartIso}
 					  AND jsonb_path_exists(mentions, '$[*] ? (@.isOwnBrand == true)')
 				)::int AS this_week_own_mentions,
 				COUNT(*) FILTER (
-					WHERE captured_at >= ${lastWeekStart} AND captured_at < ${thisWeekStart}
+					WHERE captured_at >= ${lastWeekStartIso} AND captured_at < ${thisWeekStartIso}
 				)::int AS last_week_total,
 				COUNT(*) FILTER (
-					WHERE captured_at >= ${lastWeekStart}
-					  AND captured_at < ${thisWeekStart}
+					WHERE captured_at >= ${lastWeekStartIso}
+					  AND captured_at < ${thisWeekStartIso}
 					  AND jsonb_path_exists(mentions, '$[*] ? (@.isOwnBrand == true)')
 				)::int AS last_week_own_mentions
 			FROM base
@@ -382,6 +404,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,
 	): Promise<readonly AiSearchInsights.AiSearchOwnCitationStreak[]> {
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		// Streak detection: for each (own_url × provider × locale) look at the
 		// per-day citation presence and find the longest run of consecutive
 		// days. The "currentlyCited" bit is the presence of the URL in the
@@ -412,7 +437,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
 				) c
 				WHERE a.project_id = ${projectId}
-				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 				  AND COALESCE((c->>'isOwnDomain')::bool, false) = true
 				GROUP BY a.ai_provider, a.country, a.language, c->>'url', c->>'domain', day
 			),
@@ -436,7 +461,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					MAX(captured_at AT TIME ZONE 'UTC')::date AS last_capture_day
 				FROM llm_answers
 				WHERE project_id = ${projectId}
-				  AND captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 				GROUP BY ai_provider, country, language
 			),
 			top_streak AS (
@@ -453,7 +478,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				t.language,
 				t.streak_days::int,
 				(t.last_day || 'T00:00:00Z')::timestamptz AS last_seen_at,
-				(t.last_day = l.last_capture_day) AS currently_cited
+				(t.last_day::date = l.last_capture_day) AS currently_cited
 			FROM top_streak t
 			JOIN latest_per_locale l USING (ai_provider, country, language)
 		`);
@@ -485,6 +510,9 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,
 	): Promise<readonly AiSearchInsights.AiSearchPositionLead[]> {
+		// See `presenceForProject` for the postgres-js Date binding rationale.
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
 		const rows = await this.db.execute(sql<{
 			ai_provider: string;
 			country: string;
@@ -503,7 +531,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(a.mentions) = 'array' THEN a.mentions ELSE '[]'::jsonb END
 				) m
 				WHERE a.project_id = ${projectId}
-				  AND a.captured_at BETWEEN ${filter.from} AND ${filter.to}
+				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 			),
 			own_pos AS (
 				SELECT ai_provider, country, language, AVG(position)::float AS own_avg_position

--- a/packages/providers/dataforseo/src/manifest.ts
+++ b/packages/providers/dataforseo/src/manifest.ts
@@ -106,12 +106,27 @@ const endpoints: readonly EndpointManifest[] = [
 	{
 		descriptor: serpGoogleOrganicLiveDescriptor,
 		fetch: adapt(fetchSerpGoogleOrganicLive),
-		ingest: rankTrackingIngest as IngestBinding,
+		// Ranking observations stay router-bypass: the processor's legacy
+		// if-else fans ONE SERP fetch out across N tracked-keyword domains
+		// (BACKLOG #15) — `1 fetch → N rows of the same shape` is exactly
+		// what the IngestRouter does NOT model. The fan-out reads the
+		// project's tracked keywords + competitor list and emits
+		// per-domain RankingObservations, plus seeds CompetitorSuggestion
+		// candidates from top-10 (BACKLOG #18). When Phase 5 lands the
+		// `1 def per trackedKeywordId` schedule shape (so rows-per-call
+		// collapses to 1), `rankTrackingIngest` can be wired back here.
+		// Until then, leaving this set crashes the worker bootstrap with
+		// `IngestRouter: no IngestUseCase registered for key
+		// 'rank-tracking:record-ranking-observation'` because the
+		// fan-out pipeline has no use-case registered against the router
+		// key (it's executed inline against the use case object).
+		ingest: null,
 	},
 	{
 		descriptor: serpGoogleOrganicAdvancedDescriptor,
 		fetch: adapt(fetchSerpGoogleOrganicAdvanced),
-		ingest: rankTrackingIngest as IngestBinding,
+		// Same router-bypass rationale as serp-google-organic-live above.
+		ingest: null,
 	},
 	{
 		descriptor: keywordsDataSearchVolumeDescriptor,

--- a/packages/providers/meta/src/manifest.ts
+++ b/packages/providers/meta/src/manifest.ts
@@ -169,7 +169,20 @@ const endpoints: readonly EndpointManifest[] = [
 	{
 		descriptor: pixelEventsStatsDescriptor,
 		fetch: adapt<PixelEventsStatsParams, PixelEventsStatsResponse>(fetchPixelEventsStats),
-		ingest: pixelEventsIngest as IngestBinding,
+		// Router-bypass: the processor's legacy if-else dispatch (line ~400)
+		// reads `meta-pixel-events-stats` raw payloads through
+		// `extractPixelEventRows(...)` + `ingestMetaPixelEventsUseCase` directly,
+		// because the ACL needs the resolved `dateBucket` fallback (Meta's pixel
+		// events stats sometimes return rows with null `date_start`, and the
+		// fallback uses `metaParams.endDate` from the resolved-token params).
+		// That orchestration is per-call and lives in the processor; the
+		// `IngestRouter` only models stateless `(response, ctx) -> rows` ACLs.
+		// Leaving `pixelEventsIngest` set crashes worker bootstrap with
+		// `IngestRouter: no IngestUseCase registered for key
+		// 'meta-ads-attribution:ingest-meta-pixel-events'`. When the
+		// router gains a `dateBucketResolver` extension this can be wired
+		// back; until then, `null` is the contract.
+		ingest: null,
 	},
 	{
 		descriptor: adsInsightsDescriptor,


### PR DESCRIPTION
**Hotfix v1.0.1** — three production bugs that left RankPulse in a half-deployed state after #92/#97 landed.

## Symptoms in prod (verified on srv07 before fix)

| Symptom | Where |
|---------|-------|
| Worker stuck in `waiting restart` with 318+ restarts, **0 jobs processed** | `pm2 list` |
| 4/5 AI Brand Radar read endpoints returning **500** | `/projects/:id/ai-search/{citations,matrix,sov,presence,alerts}` |
| `run-now` returns 200 + runId, but the run never appears in `/runs` | All providers, including Gemini |

## Root causes

### 1. Worker bootstrap crash — IngestRouter precondition

`buildIngestRouter()` (apps/worker/src/processors/ingest-router.ts:85) throws on every endpoint whose manifest declares `ingest: <binding>` for a `useCaseKey` that has no entry in the worker's `ingestUseCases` map.

Two endpoints fall in this gap **by design** — they're handled by the processor's legacy if-else dispatch because they need orchestration the router doesn't model:

- `dataforseo / serp-google-organic-{live,advanced}` — fan-out 1 SERP → N RankingObservations (BACKLOG #15) plus competitor-suggestion seeding from top-10 (BACKLOG #18). The router only models stateless `(response, ctx) -> rows[]`.
- `meta / meta-pixel-events-stats` — needs the resolved-token `dateBucket` fallback for rows with null `date_start`.

Both manifests previously declared `ingest: <binding>` pointing at keys (`rank-tracking:record-ranking-observation`, `meta-ads-attribution:ingest-meta-pixel-events`) that the router never had a use case for, so the worker crashed at line 357 of `worker/main.ts` **before reaching `worker.processJob()`**. 

**Fix:** switch both to `ingest: null`. Documented inline as the contract until Phase 5 lands the per-trackedKeyword schedule shape (which collapses the SERP fan-out to 1 row) and the router gains a `dateBucketResolver` extension.

### 2. AI Brand Radar read endpoints 500 — postgres-js Date binding

`DrizzleLlmAnswerReadModel`'s 7 aggregation queries pass `Date` objects directly into `` sql`...` `` template parameters. postgres-js 3.4.x's Bind packet writer hits `Buffer.byteLength(<Date>)` at `bytes.js:22` and throws `ERR_INVALID_ARG_TYPE`, surfacing as the 500 from `/api/v1/projects/:id/ai-search/{citations,sov,presence,matrix,alerts}`.

**Fix:** coerce `filter.from`/`filter.to`/`asOf`/`lastWeekStart`/`thisWeekStart` to ISO strings at the top of each method — postgres parses them as `timestamptz`, semantics unchanged.

### 3. `ownCitationStreaksForProject` text = date comparison

The streak query joined `top_streak.last_day` (text from `to_char(captured_at, 'YYYY-MM-DD')`) against `latest_per_locale.last_capture_day` (date from `MAX(captured_at)::date`). Postgres rejects with `operator does not exist: text = date`, so `/ai-search/alerts` crashed even after fix 2.

**Fix:** `t.last_day::date = l.last_capture_day`.

## Verified post-deploy on srv07

- `pm2 list` — worker `online` for 117s, no further restarts.
- `POST /providers/google-ai-studio/.../run-now` — appears in `/runs` as `succeeded` within 25s (was: never appeared, even at +60s).
- All 5 endpoints under `/projects/:id/ai-search/*` return **200**. `citations` ships 200 rows (was: 500 every call).
- LLM answers in DB **up from 27 → 44** across PT ES + PT EN. OpenAI now captures (6 PT ES + 7 PT EN). Anthropic PT EN still empty but it's an account credit issue (`credit balance is too low`), not a code bug.

## What's intentionally NOT in this PR

- Re-enabling the 260 paused DataForSEO definitions — credit refill, separate task.
- Wiring `rank-tracking:record-ranking-observation` and `meta-ads-attribution:ingest-meta-pixel-events` into the router. Both want a router extension first (per-call orchestration) and the `1 def per trackedKeywordId` migration for ranking. Left as inline comments in the manifests so the path is explicit.