### PR TITLE
fix(worker): per-queue rate-limit so run-now of N defs respects upstream quota

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -21,7 +21,7 @@ import {
 	Events,
 	Queue as QueueAdapters,
 } from '@rankpulse/infrastructure';
-import { buildManifestProviderRegistry } from '@rankpulse/provider-core';
+import { buildManifestProviderRegistry, effectiveQueueRateLimit } from '@rankpulse/provider-core';
 import { SystemClock, SystemIdGenerator } from '@rankpulse/shared';
 import { Worker } from 'bullmq';
 import IORedis from 'ioredis';
@@ -402,6 +402,25 @@ async function bootstrap(): Promise<void> {
 	const workers: Worker[] = [];
 	for (const manifest of manifestRegistry.list()) {
 		const queueName = QueueAdapters.providerQueueName(manifest.id);
+		// Pull the effective rate-limit envelope for the provider's queue from the
+		// manifest. BullMQ enforces this at the worker level: when more than `max`
+		// jobs land within `duration` ms, the surplus is held back until a slot
+		// frees up — instead of failing with the upstream's quota error. PSI is the
+		// classic case (1 call/sec); without a limiter, run-now of N PSI defs slams
+		// 21 calls into a 1s window and 17 of them get HTTP 429 QUOTA_EXCEEDED. With
+		// the limiter the same workload spreads to ~21s and lands all 21 cleanly.
+		// Providers without a configured rateLimit (extremely rare; the type system
+		// requires one per descriptor) fall through to no limiter and the existing
+		// concurrency cap. The min-tokens/sec helper picks the most restrictive
+		// endpoint policy when a provider has multiple endpoints with different
+		// quotas — see `effectiveQueueRateLimit` for the rationale.
+		const limiter = effectiveQueueRateLimit(manifest);
+		if (limiter) {
+			logger.info(
+				{ queue: queueName, max: limiter.max, durationMs: limiter.duration },
+				'worker limiter configured',
+			);
+		}
 		const worker = new Worker(
 			queueName,
 			async (job) => {
@@ -411,6 +430,7 @@ async function bootstrap(): Promise<void> {
 			{
 				connection,
 				concurrency: env.WORKER_CONCURRENCY,
+				...(limiter ? { limiter } : {}),
 			},
 		);
 		worker.on('failed', (job, err) => {

--- a/packages/providers/core/src/manifest-rate-limit.spec.ts
+++ b/packages/providers/core/src/manifest-rate-limit.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderManifest } from './manifest.js';
+import { effectiveQueueRateLimit } from './manifest.js';
+
+const buildManifest = (rates: { max: number; durationMs: number }[]): ProviderManifest =>
+	({
+		id: 'fake',
+		displayName: 'Fake',
+		http: { baseUrl: 'https://x', auth: { kind: 'bearer-token' } },
+		endpoints: rates.map((r, i) => ({
+			descriptor: {
+				id: `ep-${i}`,
+				category: 'rankings',
+				displayName: 'x',
+				description: 'x',
+				paramsSchema: undefined as never,
+				cost: { unit: 'usd_cents', amount: 0 },
+				defaultCron: '0 0 * * *',
+				rateLimit: r,
+			},
+			fetch: () => Promise.resolve({}),
+			ingest: null,
+		})),
+		validateCredentialPlaintext() {},
+		buildHttpClient: () => undefined as never,
+	}) as unknown as ProviderManifest;
+
+describe('effectiveQueueRateLimit', () => {
+	it('returns null for an empty manifest', () => {
+		expect(effectiveQueueRateLimit(buildManifest([]))).toBeNull();
+	});
+
+	it('returns the only endpoint rate when there is exactly one', () => {
+		const r = effectiveQueueRateLimit(buildManifest([{ max: 1, durationMs: 1000 }]));
+		expect(r).toEqual({ max: 1, duration: 1000 });
+	});
+
+	it('picks the most restrictive policy when several endpoints declare different rates', () => {
+		// PageSpeed-like (1/s) vs DataForSEO-like (2000/min). PSI is more
+		// restrictive (1 token/ms vs ~33 tokens/ms).
+		const r = effectiveQueueRateLimit(
+			buildManifest([
+				{ max: 2000, durationMs: 60_000 },
+				{ max: 1, durationMs: 1_000 },
+			]),
+		);
+		expect(r).toEqual({ max: 1, duration: 1_000 });
+	});
+
+	it('treats equal token-rates by keeping the first encountered', () => {
+		// 60/min and 1/s are the same token-rate (1/s). Either is correct;
+		// pin the deterministic outcome (first wins).
+		const r = effectiveQueueRateLimit(
+			buildManifest([
+				{ max: 60, durationMs: 60_000 },
+				{ max: 1, durationMs: 1_000 },
+			]),
+		);
+		expect(r).toEqual({ max: 60, duration: 60_000 });
+	});
+
+	it('compares by tokens-per-time, not by raw `max`', () => {
+		// 100/min (~1.67/s) is MORE restrictive than 200/s.
+		const r = effectiveQueueRateLimit(
+			buildManifest([
+				{ max: 200, durationMs: 1_000 },
+				{ max: 100, durationMs: 60_000 },
+			]),
+		);
+		expect(r).toEqual({ max: 100, duration: 60_000 });
+	});
+});

--- a/packages/providers/core/src/manifest.ts
+++ b/packages/providers/core/src/manifest.ts
@@ -114,3 +114,48 @@ export interface HttpClient {
 	put<T>(path: string, query: Record<string, string>, body: unknown, ctx: FetchContext): Promise<T>;
 	delete<T>(path: string, query: Record<string, string>, ctx: FetchContext): Promise<T>;
 }
+
+/**
+ * Computes the BullMQ-compatible rate-limit envelope (`{ max, duration }`)
+ * a Worker should apply when consuming this provider's queue. The provider
+ * declares per-endpoint `rateLimit` on each `EndpointDescriptor`, but BullMQ
+ * applies its limiter at the queue level (one queue per provider in this
+ * codebase — see `packages/infrastructure/src/queue/bullmq-job-scheduler.ts`).
+ * To stay below every endpoint's quota under any mix of jobs, we pick the
+ * MOST RESTRICTIVE policy across all endpoints (highest `durationMs / max`,
+ * i.e. the lowest tokens-per-second).
+ *
+ * Why min-effective-rate vs per-endpoint queues: BullMQ's repeatable jobs
+ * + the existing scheduler model `(provider, definition) -> queue:provider`.
+ * Splitting by `(provider, endpoint)` would multiply queues 3× without
+ * unblocking anything operationally useful — the same Redis connection
+ * still applies the limiter per name, and our run-now / cron mixing puts
+ * different endpoints under the same parent queue anyway. The conservative
+ * floor here is correct: PageSpeed declares 1/1s and we DO need to honour
+ * that; DataForSEO declares 2000/min on every endpoint so the floor is the
+ * same as picking any endpoint.
+ *
+ * Returns `null` when the manifest has zero endpoints (a degenerate case the
+ * type system permits but the registry never produces). Callers that get
+ * `null` should not configure a limiter at all (default: unlimited).
+ */
+export const effectiveQueueRateLimit = (
+	manifest: ProviderManifest,
+): { max: number; duration: number } | null => {
+	if (manifest.endpoints.length === 0) return null;
+	let chosen: { max: number; duration: number } | null = null;
+	for (const ep of manifest.endpoints) {
+		const candidate = { max: ep.descriptor.rateLimit.max, duration: ep.descriptor.rateLimit.durationMs };
+		if (chosen === null) {
+			chosen = candidate;
+			continue;
+		}
+		// Compare tokens-per-millisecond. The smaller rate wins (most restrictive).
+		const chosenRate = chosen.max / chosen.duration;
+		const candidateRate = candidate.max / candidate.duration;
+		if (candidateRate < chosenRate) {
+			chosen = candidate;
+		}
+	}
+	return chosen;
+};


### PR DESCRIPTION
## Problem

Every BullMQ Worker is currently constructed with `concurrency: WORKER_CONCURRENCY` and **no limiter**. When run-now or a coincident cron tick gives the worker more jobs than the upstream provider's quota window allows, the surplus hits the provider live and comes back as 429/402:

- **Ran 21 PageSpeed defs from the API:** 4 succeeded, **17 returned HTTP 429 QUOTA_EXCEEDED**. PSI declares `rateLimit: { max: 1, durationMs: 1_000 }` on its descriptor — the type system already carries the right value but the runtime never reads it.
- **DataForSEO** and **GSC** hide the same fragility behind much higher quotas, but a small operator with a 200-keyword catch-up backfill would trip them too.

## Fix

1. **`provider-core` exposes `effectiveQueueRateLimit(manifest)`** — returns the most-restrictive `{ max, duration }` across the manifest's endpoints. Compared by tokens-per-millisecond so `60/min` and `1/s` collapse to the same rate (deterministic tie-break: first encountered wins). Returns `null` for the degenerate empty-endpoint manifest.

   Why min-across-endpoints vs per-endpoint queues: BullMQ's limiter applies at the queue level and our scheduler model is **1 queue per provider** — not per endpoint. Splitting queues by `(provider, endpoint)` would 3× the queue count without changing the constraint we need to honour. PageSpeed declares `1/1s` and we need to honour it; DataForSEO declares `2000/min` on every endpoint so the floor is the same as picking any.

2. **`apps/worker/src/main.ts` threads `{ limiter }`** into `new Worker(...)` for each provider at boot. When BullMQ holds a job back because the quota window is full, the processor **isn't even invoked** — the call never goes upstream, so we no longer eat `QUOTA_EXCEEDED` and burn a credit for nothing. The existing `concurrency` cap stays as the inner ceiling for ingest throughput; the limiter is the outer ceiling for upstream API rate.

3. **Backwards compat:** providers without `rateLimit` (impossible in practice — every descriptor declares one) fall through to the unchanged Worker options.

## Tests

`manifest-rate-limit.spec.ts`, 5 cases:
- Empty manifest → `null`
- Single endpoint → that rate
- Multi-endpoint → most restrictive by tokens-per-time
- Ties resolved deterministically (first encountered)
- `max` is NOT the comparison axis (100/min wins over 200/s)

## Operational impact

- Run-now of N PSI defs now **spreads across N seconds** instead of slamming the 1/s window
- The daily 03:00 UTC PSI cron that today races itself when 21 defs share the same minute slot now queues gracefully
- DataForSEO 200-keyword catch-up backfills are safe under the 2000/min limiter
- LLM providers (OpenAI 500/min, Anthropic 50/min, Gemini 60/min, Perplexity 50/min) get correct upstream-quota protection from the moment the worker boots