### PR TITLE
feat(cockpit): Sprint 2 — AI SoV sparkline + Cannibalization widget

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -622,6 +622,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.QueryAiSearchSov, aisi.QueryAiSearchSov),
 		value(Tokens.QueryAiSearchCitations, aisi.QueryAiSearchCitations),
 		value(Tokens.QueryPromptSovDaily, aisi.QueryPromptSovDaily),
+		value(Tokens.QueryProjectSovDaily, aisi.QueryProjectSovDaily),
 		value(Tokens.QueryCompetitiveMatrix, aisi.QueryCompetitiveMatrix),
 		value(Tokens.QueryAiSearchAlerts, aisi.QueryAiSearchAlerts),
 	];

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -182,6 +182,7 @@ export const Tokens = {
 	QueryAiSearchSov: Symbol('QueryAiSearchSovUseCase'),
 	QueryAiSearchCitations: Symbol('QueryAiSearchCitationsUseCase'),
 	QueryPromptSovDaily: Symbol('QueryPromptSovDailyUseCase'),
+	QueryProjectSovDaily: Symbol('QueryProjectSovDailyUseCase'),
 	QueryCompetitiveMatrix: Symbol('QueryCompetitiveMatrixUseCase'),
 	QueryAiSearchAlerts: Symbol('QueryAiSearchAlertsUseCase'),
 

--- a/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
+++ b/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
@@ -41,6 +41,8 @@ export class AiSearchInsightsController {
 		private readonly queryCitations: AiUseCases.QueryAiSearchCitationsUseCase,
 		@Inject(Tokens.QueryPromptSovDaily)
 		private readonly querySovDaily: AiUseCases.QueryPromptSovDailyUseCase,
+		@Inject(Tokens.QueryProjectSovDaily)
+		private readonly queryProjectSovDaily: AiUseCases.QueryProjectSovDailyUseCase,
 		@Inject(Tokens.QueryCompetitiveMatrix)
 		private readonly queryMatrix: AiUseCases.QueryCompetitiveMatrixUseCase,
 		@Inject(Tokens.QueryAiSearchAlerts)
@@ -224,6 +226,22 @@ export class AiSearchInsightsController {
 		await this.requireProjectAccess(principal, projectId);
 		const items = await this.queryAlerts.execute({ projectId });
 		return { items: items.map((i) => ({ ...i, details: { ...i.details } })) };
+	}
+
+	@Get('projects/:projectId/ai-search/sov-daily')
+	async projectSovDaily(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Query(new ZodValidationPipe(AiSearchInsightsContracts.AiSearchSovDailyQuery))
+		query: AiSearchInsightsContracts.AiSearchSovDailyQuery,
+	): Promise<AiSearchInsightsContracts.AiSearchSovDailyResponse> {
+		await this.requireProjectAccess(principal, projectId);
+		const items = await this.queryProjectSovDaily.execute({
+			projectId,
+			from: query.from ? new Date(query.from) : undefined,
+			to: query.to ? new Date(query.to) : undefined,
+		});
+		return { items: items.map((i) => ({ ...i })) };
 	}
 
 	@Get('projects/:projectId/brand-prompts/:promptId/sov-daily')

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -967,6 +967,29 @@ export function buildOpenApiDocument(): unknown {
 
 	registry.registerPath({
 		method: 'get',
+		path: '/api/v1/projects/{projectId}/ai-search/sov-daily',
+		summary: 'AI Brand Radar — project-wide daily SoV curve (cockpit sparkline)',
+		description:
+			'Aggregates own-brand mention rate across every BrandPrompt and capture in the window, returning one point per day. Powers the Decision Cockpit AI SoV sparkline (issue #117 Sprint 2).',
+		tags: ['ai-search-insights'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: {
+			params: z.object({ projectId: z.string().uuid() }),
+			query: AiSearchInsightsContracts.AiSearchSovDailyQuery,
+		},
+		responses: {
+			200: {
+				description: 'Daily points (one per day in the window)',
+				content: {
+					'application/json': { schema: AiSearchInsightsContracts.AiSearchSovDailyResponse },
+				},
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'get',
 		path: '/api/v1/projects/{projectId}/brand-prompts/{promptId}/sov-daily',
 		summary: 'AI Brand Radar — daily SoV curve for a single BrandPrompt (sparkline data)',
 		tags: ['ai-search-insights'],

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -550,8 +550,17 @@ const en = {
 			},
 			aiRadar: {
 				title: 'AI Brand Radar SoV',
-				hint: 'Share of voice across ChatGPT / Claude / Perplexity / Gemini.',
+				hint: 'Project-wide own-brand mention rate over the last 28 days.',
 				description: 'See LLM mentions, citations, and competitor SoV trends.',
+				windowHint: 'last {{days}} days',
+				sparklineAria: 'Daily own-brand mention rate sparkline',
+				empty: 'No AI captures yet',
+				emptyDescription: 'Add a brand prompt and connect an LLM provider to start capturing.',
+			},
+			cannibalization: {
+				title: 'Cannibalization',
+				hint: 'Pairs of pages competing for the same keyword.',
+				description: 'See where multiple pages rank for the same query and split clicks.',
 			},
 			lostOpportunity: {
 				title: 'Lost Opportunity Score',
@@ -595,6 +604,7 @@ const en = {
 				forecast90d: 'Forecast 90 days organic traffic',
 				competitorActivity: 'Competitor Activity Radar (Wayback CDX + backlinks)',
 				contentGap: 'Content Gap Map (keywords-for-site without tracked URL)',
+				searchDemand: 'Search Demand Trend (DataForSEO history + Google Trends)',
 			},
 		},
 		ctrAnomaliesPage: {
@@ -1238,8 +1248,17 @@ const es = {
 			},
 			aiRadar: {
 				title: 'AI Brand Radar SoV',
-				hint: 'Share of voice en ChatGPT / Claude / Perplexity / Gemini.',
+				hint: 'Mention rate propio del proyecto en los últimos 28 días.',
 				description: 'Ve menciones de LLM, citas y tendencias SoV de competidores.',
+				windowHint: 'últimos {{days}} días',
+				sparklineAria: 'Sparkline diaria del mention rate de marca propia',
+				empty: 'Aún no hay capturas de AI',
+				emptyDescription: 'Añade un brand prompt y conecta un proveedor LLM para empezar a capturar.',
+			},
+			cannibalization: {
+				title: 'Canibalización',
+				hint: 'Pares de páginas compitiendo por la misma keyword.',
+				description: 'Ve dónde varias páginas posicionan para la misma query y se reparten clicks.',
 			},
 			lostOpportunity: {
 				title: 'Lost Opportunity Score',
@@ -1284,6 +1303,7 @@ const es = {
 				forecast90d: 'Forecast 90 días tráfico orgánico',
 				competitorActivity: 'Competitor Activity Radar (Wayback CDX + backlinks)',
 				contentGap: 'Content Gap Map (keywords-for-site sin URL trackeada)',
+				searchDemand: 'Search Demand Trend (DataForSEO history + Google Trends)',
 			},
 		},
 		ctrAnomaliesPage: {

--- a/apps/web/src/pages/cockpit.page.tsx
+++ b/apps/web/src/pages/cockpit.page.tsx
@@ -7,6 +7,7 @@ import {
 	CardTitle,
 	EmptyState,
 	KpiCard,
+	Sparkline,
 	Spinner,
 } from '@rankpulse/ui';
 import { useQuery } from '@tanstack/react-query';
@@ -18,6 +19,7 @@ import {
 	CheckCircle2,
 	ChevronRight,
 	Compass,
+	Layers,
 	Map as MapIcon,
 	MousePointerClick,
 	Sparkles,
@@ -76,6 +78,10 @@ export const CockpitPage = () => {
 		queryKey: ['project', projectId, 'cockpit', 'brand-decay'],
 		queryFn: () => api.cockpit.brandDecay(projectId),
 	});
+	const aiSovDailyQuery = useQuery({
+		queryKey: ['project', projectId, 'ai-search', 'sov-daily'],
+		queryFn: () => api.aiSearch.projectSovDaily(projectId),
+	});
 
 	const cockpitMetrics = useMemo(() => {
 		const rows = serpMapQuery.data?.rows ?? [];
@@ -119,6 +125,9 @@ export const CockpitPage = () => {
 	const totalLostClicks = lostOpportunity?.totalLostClicks ?? 0;
 	const ctrAnomalyCount = ctrAnomalies?.anomalies.length ?? 0;
 	const noBrandDelta = brandDecay?.nonBranded.deltaPct ?? null;
+	const sovDailyPoints = aiSovDailyQuery.data?.items ?? [];
+	const sovValues = sovDailyPoints.map((p) => p.mentionRate * 100);
+	const latestSovPct = sovValues.length === 0 ? null : (sovValues[sovValues.length - 1] ?? null);
 
 	return (
 		<AppShell>
@@ -383,7 +392,44 @@ export const CockpitPage = () => {
 						href={{ to: '/projects/$id/ai-radar', params: { id: projectId } }}
 						cta={t('cockpit:openDetail')}
 					>
-						<p className="text-sm text-muted-foreground">{t('cockpit:widgets.aiRadar.description')}</p>
+						{aiSovDailyQuery.isLoading ? (
+							<Spinner size="sm" />
+						) : sovValues.length === 0 ? (
+							<EmptyState
+								title={t('cockpit:widgets.aiRadar.empty')}
+								description={t('cockpit:widgets.aiRadar.emptyDescription')}
+							/>
+						) : (
+							<div className="flex flex-col gap-2">
+								<div className="flex items-baseline justify-between gap-2">
+									<span className="font-mono text-2xl font-semibold">
+										{latestSovPct === null ? '—' : `${latestSovPct.toFixed(0)}%`}
+									</span>
+									<span className="text-xs text-muted-foreground">
+										{t('cockpit:widgets.aiRadar.windowHint', { days: sovValues.length })}
+									</span>
+								</div>
+								<Sparkline
+									values={sovValues}
+									stroke="#a855f7"
+									fill="#a855f7"
+									aria-label={t('cockpit:widgets.aiRadar.sparklineAria')}
+								/>
+								<p className="text-xs text-muted-foreground">{t('cockpit:widgets.aiRadar.description')}</p>
+							</div>
+						)}
+					</WidgetCard>
+
+					<WidgetCard
+						title={t('cockpit:widgets.cannibalization.title')}
+						hint={t('cockpit:widgets.cannibalization.hint')}
+						icon={<Layers size={14} className="text-cyan-600" />}
+						href={{ to: '/projects/$id/cannibalization', params: { id: projectId } }}
+						cta={t('cockpit:openDetail')}
+					>
+						<p className="text-sm text-muted-foreground">
+							{t('cockpit:widgets.cannibalization.description')}
+						</p>
 					</WidgetCard>
 				</div>
 
@@ -432,10 +478,11 @@ export const CockpitPage = () => {
 					<CardContent>
 						<ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
 							{[
-								{ icon: <Compass size={14} />, label: t('cockpit:upcoming.items.pageExperience') },
-								{ icon: <TrendingUp size={14} />, label: t('cockpit:upcoming.items.forecast90d') },
 								{ icon: <Users size={14} />, label: t('cockpit:upcoming.items.competitorActivity') },
+								{ icon: <Compass size={14} />, label: t('cockpit:upcoming.items.pageExperience') },
 								{ icon: <BarChart3 size={14} />, label: t('cockpit:upcoming.items.contentGap') },
+								{ icon: <TrendingUp size={14} />, label: t('cockpit:upcoming.items.searchDemand') },
+								{ icon: <TrendingUp size={14} />, label: t('cockpit:upcoming.items.forecast90d') },
 							].map((item) => (
 								<li
 									key={item.label}

--- a/packages/application/src/ai-search-insights/index.ts
+++ b/packages/application/src/ai-search-insights/index.ts
@@ -9,6 +9,7 @@ export * from './use-cases/query-ai-search-presence.use-case.js';
 export * from './use-cases/query-ai-search-sov.use-case.js';
 export * from './use-cases/query-competitive-matrix.use-case.js';
 export * from './use-cases/query-llm-answers.use-case.js';
+export * from './use-cases/query-project-sov-daily.use-case.js';
 export * from './use-cases/query-prompt-sov-daily.use-case.js';
 export * from './use-cases/record-llm-answer.use-case.js';
 export * from './use-cases/register-brand-prompt.use-case.js';

--- a/packages/application/src/ai-search-insights/module.ts
+++ b/packages/application/src/ai-search-insights/module.ts
@@ -15,6 +15,7 @@ import { QueryAiSearchPresenceUseCase } from './use-cases/query-ai-search-presen
 import { QueryAiSearchSovUseCase } from './use-cases/query-ai-search-sov.use-case.js';
 import { QueryCompetitiveMatrixUseCase } from './use-cases/query-competitive-matrix.use-case.js';
 import { QueryLlmAnswersUseCase } from './use-cases/query-llm-answers.use-case.js';
+import { QueryProjectSovDailyUseCase } from './use-cases/query-project-sov-daily.use-case.js';
 import { QueryPromptSovDailyUseCase } from './use-cases/query-prompt-sov-daily.use-case.js';
 import { RecordLlmAnswerUseCase } from './use-cases/record-llm-answer.use-case.js';
 import { RegisterBrandPromptUseCase } from './use-cases/register-brand-prompt.use-case.js';
@@ -57,6 +58,7 @@ export const aiSearchInsightsModule: ContextModule = {
 				QueryAiSearchSov: new QueryAiSearchSovUseCase(d.llmAnswerReadModel),
 				QueryAiSearchCitations: new QueryAiSearchCitationsUseCase(d.llmAnswerReadModel),
 				QueryPromptSovDaily: new QueryPromptSovDailyUseCase(d.llmAnswerReadModel),
+				QueryProjectSovDaily: new QueryProjectSovDailyUseCase(d.llmAnswerReadModel),
 				QueryCompetitiveMatrix: new QueryCompetitiveMatrixUseCase(d.llmAnswerReadModel),
 				QueryAiSearchAlerts: new QueryAiSearchAlertsUseCase(d.llmAnswerReadModel),
 			},

--- a/packages/application/src/ai-search-insights/use-cases/query-project-sov-daily.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-project-sov-daily.use-case.spec.ts
@@ -1,0 +1,118 @@
+import { AiSearchInsights, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { InMemoryLlmAnswerReadModel } from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryProjectSovDailyUseCase } from './query-project-sov-daily.use-case.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const OTHER_PROJECT_ID = '22222222-2222-2222-2222-222222222222' as Uuid as ProjectManagement.ProjectId;
+const PROMPT_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as AiSearchInsights.BrandPromptId;
+const PROMPT_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid as AiSearchInsights.BrandPromptId;
+
+describe('QueryProjectSovDailyUseCase', () => {
+	let readModel: InMemoryLlmAnswerReadModel;
+	let useCase: QueryProjectSovDailyUseCase;
+
+	beforeEach(() => {
+		readModel = new InMemoryLlmAnswerReadModel();
+		useCase = new QueryProjectSovDailyUseCase(readModel);
+	});
+
+	it('aggregates across every prompt in the project for one bucket per UTC day', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_A,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_B,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.ANTHROPIC,
+				country: 'US',
+				language: 'en',
+				mentions: [],
+				citations: [],
+				capturedAt: new Date('2026-05-01T20:00:00Z'),
+			},
+			{
+				id: 'a3',
+				brandPromptId: PROMPT_B,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 2, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-02T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(2);
+		const day1 = result.find((p) => p.day === '2026-05-01');
+		expect(day1?.totalAnswers).toBe(2);
+		expect(day1?.answersWithOwnMention).toBe(1);
+		expect(day1?.mentionRate).toBe(0.5);
+		const day2 = result.find((p) => p.day === '2026-05-02');
+		expect(day2?.mentionRate).toBe(1);
+	});
+
+	it('returns mentionRate=0 when there are no captures in the window', async () => {
+		readModel.setRows([]);
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+		expect(result).toEqual([]);
+	});
+
+	it('scopes to the requested project (does not bleed in across-project rows)', async () => {
+		readModel.setRows([
+			{
+				id: 'a1',
+				brandPromptId: PROMPT_A,
+				projectId: PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+			{
+				id: 'a2',
+				brandPromptId: PROMPT_B,
+				projectId: OTHER_PROJECT_ID,
+				aiProvider: AiSearchInsights.AiProviderNames.OPENAI,
+				country: 'US',
+				language: 'en',
+				mentions: [{ brand: 'OurBrand', isOwnBrand: true, position: 1, citedUrl: null }],
+				citations: [],
+				capturedAt: new Date('2026-05-01T10:00:00Z'),
+			},
+		]);
+
+		const result = await useCase.execute({
+			projectId: PROJECT_ID,
+			from: new Date('2026-04-01T00:00:00Z'),
+			to: new Date('2026-05-31T00:00:00Z'),
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.totalAnswers).toBe(1);
+	});
+});

--- a/packages/application/src/ai-search-insights/use-cases/query-project-sov-daily.use-case.ts
+++ b/packages/application/src/ai-search-insights/use-cases/query-project-sov-daily.use-case.ts
@@ -1,0 +1,41 @@
+import type { AiSearchInsights, ProjectManagement } from '@rankpulse/domain';
+import { normaliseDashboardWindow } from './window-guards.js';
+
+export interface QueryProjectSovDailyQuery {
+	projectId: string;
+	from?: Date;
+	to?: Date;
+}
+
+export interface AiSearchProjectSovDailyPointDto {
+	day: string;
+	totalAnswers: number;
+	answersWithOwnMention: number;
+	mentionRate: number;
+}
+
+const DEFAULT_WINDOW_DAYS = 28;
+
+/**
+ * Project-wide daily own-brand mention rate (issue #117 Sprint 2). Aggregates
+ * across every BrandPrompt and capture in the window, returning one point per
+ * day. Same shape as `QueryPromptSovDailyUseCase` so the SPA reuses the
+ * sparkline renderer.
+ */
+export class QueryProjectSovDailyUseCase {
+	constructor(private readonly readModel: AiSearchInsights.LlmAnswerReadModel) {}
+
+	async execute(query: QueryProjectSovDailyQuery): Promise<readonly AiSearchProjectSovDailyPointDto[]> {
+		const { from, to } = normaliseDashboardWindow(query, DEFAULT_WINDOW_DAYS);
+		const points = await this.readModel.sovDailyForProject(query.projectId as ProjectManagement.ProjectId, {
+			from,
+			to,
+		});
+		return points.map((p) => ({
+			day: p.day,
+			totalAnswers: p.totalAnswers,
+			answersWithOwnMention: p.answersWithOwnMention,
+			mentionRate: p.totalAnswers === 0 ? 0 : p.answersWithOwnMention / p.totalAnswers,
+		}));
+	}
+}

--- a/packages/domain/src/ai-search-insights/ports/llm-answer-read-model.ts
+++ b/packages/domain/src/ai-search-insights/ports/llm-answer-read-model.ts
@@ -109,6 +109,16 @@ export interface LlmAnswerReadModel {
 		brandPromptId: BrandPromptId,
 		filter: AiSearchReadModelFilter,
 	): Promise<readonly AiSearchSovDailyPoint[]>;
+	/**
+	 * Project-wide own-brand mention rate per day, aggregating across every
+	 * BrandPrompt and capture in the window. Powers the Decision Cockpit
+	 * SoV sparkline (issue #117 Sprint 2) — same shape as `sovDailyForPrompt`
+	 * so the SPA can reuse the same series renderer.
+	 */
+	sovDailyForProject(
+		projectId: ProjectId,
+		filter: AiSearchReadModelFilter,
+	): Promise<readonly AiSearchSovDailyPoint[]>;
 	competitiveMatrixForProject(
 		projectId: ProjectId,
 		filter: AiSearchReadModelFilter,

--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -298,6 +298,47 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 		}));
 	}
 
+	async sovDailyForProject(
+		projectId: ProjectManagement.ProjectId,
+		filter: AiSearchInsights.AiSearchReadModelFilter,
+	): Promise<readonly AiSearchInsights.AiSearchSovDailyPoint[]> {
+		const fromIso = filter.from.toISOString();
+		const toIso = filter.to.toISOString();
+		const rows = await this.db.execute(sql<{
+			day: string;
+			total_answers: number;
+			answers_with_own_mention: number;
+		}>`
+			WITH base AS (
+				SELECT
+					captured_at,
+					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
+				FROM llm_answers
+				WHERE project_id = ${projectId}
+				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
+			)
+			SELECT
+				to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+				COUNT(*)::int AS total_answers,
+				COUNT(*) FILTER (
+					WHERE jsonb_path_exists(mentions, '$[*] ? (@.isOwnBrand == true)')
+				)::int AS answers_with_own_mention
+			FROM base
+			GROUP BY day
+			ORDER BY day
+		`);
+		const list = unwrap<{
+			day: string;
+			total_answers: number;
+			answers_with_own_mention: number;
+		}>(rows);
+		return list.map((r) => ({
+			day: r.day,
+			totalAnswers: Number(r.total_answers ?? 0),
+			answersWithOwnMention: Number(r.answers_with_own_mention ?? 0),
+		}));
+	}
+
 	async competitiveMatrixForProject(
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,

--- a/packages/sdk/src/resources/ai-search.ts
+++ b/packages/sdk/src/resources/ai-search.ts
@@ -90,6 +90,15 @@ export class AiSearchResource {
 		);
 	}
 
+	projectSovDaily(
+		projectId: string,
+		query?: AiSearchInsightsContracts.AiSearchSovDailyQuery,
+	): Promise<AiSearchInsightsContracts.AiSearchSovDailyResponse> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/ai-search/sov-daily`, {
+			query: query ?? {},
+		});
+	}
+
 	competitiveMatrix(
 		projectId: string,
 		query?: AiSearchInsightsContracts.CompetitiveMatrixQuery,

--- a/packages/testing/src/in-memory/in-memory-llm-answer-read-model.ts
+++ b/packages/testing/src/in-memory/in-memory-llm-answer-read-model.ts
@@ -200,6 +200,26 @@ export class InMemoryLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRea
 			.map(([day, v]) => ({ day, totalAnswers: v.total, answersWithOwnMention: v.withOwn }));
 	}
 
+	async sovDailyForProject(
+		projectId: ProjectManagement.ProjectId,
+		filter: AiSearchInsights.AiSearchReadModelFilter,
+	): Promise<readonly AiSearchInsights.AiSearchSovDailyPoint[]> {
+		const within = this.rows.filter(
+			(r) => r.projectId === projectId && r.capturedAt >= filter.from && r.capturedAt <= filter.to,
+		);
+		const buckets = new Map<string, { total: number; withOwn: number }>();
+		for (const r of within) {
+			const day = r.capturedAt.toISOString().slice(0, 10);
+			const cell = buckets.get(day) ?? { total: 0, withOwn: 0 };
+			cell.total += 1;
+			if (r.mentions.some((m) => m.isOwnBrand)) cell.withOwn += 1;
+			buckets.set(day, cell);
+		}
+		return [...buckets.entries()]
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([day, v]) => ({ day, totalAnswers: v.total, answersWithOwnMention: v.withOwn }));
+	}
+
 	async competitiveMatrixForProject(
 		projectId: ProjectManagement.ProjectId,
 		filter: AiSearchInsights.AiSearchReadModelFilter,


### PR DESCRIPTION
## Summary

**Closes #117 Sprint 2 partial** — 2/3 widgets shipped:

| Widget | Backend | UI |
|---|---|---|
| **AI Brand Radar SoV sparkline** | new `QueryProjectSovDailyUseCase` + `sovDailyForProject` read-model + endpoint `/api/v1/projects/:id/ai-search/sov-daily` + SDK | Cockpit AI Radar card upgraded with `<Sparkline>` + current mention rate + 28-day window hint |
| **Cannibalization** | n/a — page already exists, this PR is link-only | New Cockpit card linking to `/projects/:id/cannibalization` |

**Deferred to its own sub-issue**: Competitor Activity Radar (Wayback CDX + backlinks). Needs two new provider integrations — too big for this PR.

## Architecture

```
Domain (ai-search-insights)
  ports/llm-answer-read-model.ts  + sovDailyForProject(projectId, filter)

Infrastructure
  drizzle-llm-answer-read-model.ts → SQL: WHERE project_id = ?, GROUP BY day,
                                      counts answers and answers-with-own-mention

Application
  use-cases/query-project-sov-daily.use-case.ts  — wraps the read model with
                                                    dashboard window guard

API
  ai-search-insights.controller.ts → @Get('projects/:projectId/ai-search/sov-daily')

SDK
  client.aiSearch.projectSovDaily(projectId, query?)

Frontend
  cockpit.page.tsx → upgrades AI Radar widget (now shows sparkline) + adds
                     Cannibalization card linking to existing page
```

## Test plan

- [x] `pnpm typecheck` — 26 packages pass
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 357 application tests pass (3 new for `QueryProjectSovDailyUseCase`)
- [x] `pnpm build` — 23 packages compile

## #117 progress

- Sprint 1 complete (4/4) — merged in #126
- Sprint 2: 2/3 (this PR). Competitor Activity Radar deferred.
- Sprints 3-4: pending sub-issues.

After this merges, **6/12 cockpit widgets are live**.

https://claude.ai/code/session_01EEavBjA8d68ckE2zE49aZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEavBjA8d68ckE2zE49aZY)_