### PR TITLE
feat(competitor-intelligence): on-page audit for competitor URLs

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -132,6 +132,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		drizzle.db,
 	);
 	const competitorKeywordGapRepo = new DrizzlePersistence.DrizzleCompetitorKeywordGapRepository(drizzle.db);
+	const competitorPageAuditRepo = new DrizzlePersistence.DrizzleCompetitorPageAuditRepository(drizzle.db);
 	const gscPropertyRepo = new DrizzlePersistence.DrizzleGscPropertyRepository(drizzle.db);
 	const gscObservationRepo = new DrizzlePersistence.DrizzleGscPerformanceObservationRepository(drizzle.db);
 	const gscCockpitReadModel = new DrizzlePersistence.DrizzleGscCockpitReadModel(drizzle.db);
@@ -330,6 +331,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		events: eventPublisher,
 		projectRepo,
 		competitorKeywordGapRepo,
+		competitorPageAuditRepo,
 		competitorIntelligenceSchemaTables: DrizzlePersistence.schema.competitorIntelligenceSchemaTables,
 	} satisfies CIUseCases.CompetitorIntelligenceDeps as unknown as SharedDeps);
 
@@ -573,8 +575,11 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 
 		// competitor-intelligence
 		value(Tokens.CompetitorKeywordGapRepository, competitorKeywordGapRepo),
+		value(Tokens.CompetitorPageAuditRepository, competitorPageAuditRepo),
 		value(Tokens.IngestDomainIntersection, ci.IngestDomainIntersection),
 		value(Tokens.QueryKeywordGaps, ci.QueryKeywordGaps),
+		value(Tokens.IngestCompetitorPageAudit, ci.IngestCompetitorPageAudit),
+		value(Tokens.QueryCompetitorPageAudits, ci.QueryCompetitorPageAudits),
 
 		// search-console-insights
 		value(Tokens.GscPropertyRepository, gscPropertyRepo),

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -90,10 +90,13 @@ export const Tokens = {
 
 	// Competitor-Intelligence ports
 	CompetitorKeywordGapRepository: Symbol('CompetitorKeywordGapRepository'),
+	CompetitorPageAuditRepository: Symbol('CompetitorPageAuditRepository'),
 
 	// Competitor-Intelligence use cases
 	IngestDomainIntersection: Symbol('IngestDomainIntersectionUseCase'),
 	QueryKeywordGaps: Symbol('QueryKeywordGapsUseCase'),
+	IngestCompetitorPageAudit: Symbol('IngestCompetitorPageAuditUseCase'),
+	QueryCompetitorPageAudits: Symbol('QueryCompetitorPageAuditsUseCase'),
 
 	// Search-Console-Insights ports
 	GscPropertyRepository: Symbol('GscPropertyRepository'),

--- a/apps/api/src/modules/competitor-intelligence/competitor-intelligence.controller.ts
+++ b/apps/api/src/modules/competitor-intelligence/competitor-intelligence.controller.ts
@@ -16,6 +16,8 @@ export class CompetitorIntelligenceController {
 	constructor(
 		@Inject(Tokens.QueryKeywordGaps)
 		private readonly queryKeywordGaps: CIUseCases.QueryKeywordGapsUseCase,
+		@Inject(Tokens.QueryCompetitorPageAudits)
+		private readonly queryCompetitorPageAudits: CIUseCases.QueryCompetitorPageAuditsUseCase,
 		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
 		@Inject(Tokens.MembershipRepository) memberships: IdentityAccess.MembershipRepository,
 	) {
@@ -40,6 +42,26 @@ export class CompetitorIntelligenceController {
 			competitorDomain: q.competitorDomain,
 			limit: q.limit,
 			minVolume: q.minVolume,
+		});
+	}
+
+	@Get('projects/:projectId/competitor-page-audits')
+	async competitorPageAudits(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Query(new ZodValidationPipe(CompetitorIntelligenceContracts.CompetitorPageAuditsQuery))
+		q: CompetitorIntelligenceContracts.CompetitorPageAuditsQuery,
+	): Promise<CompetitorIntelligenceContracts.CompetitorPageAuditsResponse> {
+		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${projectId} not found`);
+		}
+		await this.orgMembership.require(principal, project.organizationId);
+		return this.queryCompetitorPageAudits.execute({
+			projectId,
+			competitorDomain: q.competitorDomain,
+			url: q.url,
+			limit: q.limit,
 		});
 	}
 }

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -604,6 +604,29 @@ export function buildOpenApiDocument(): unknown {
 
 	registry.registerPath({
 		method: 'get',
+		path: '/api/v1/projects/{projectId}/competitor-page-audits',
+		summary: 'Latest on-page audits for a competitor (issue #131)',
+		description:
+			'Returns competitor URL audits sourced from DataForSEO `on_page/instant_pages`. The endpoint manifest carries an ACL polymorphic on `systemParams.scope`: when a `JobDefinition` is registered with `scope: "competitor"`, the ACL emits ONE row per fetch into the `competitor_page_audits` hypertable; other scopes (`"own"`, absent) are ignored by this BC and a future web-performance binding can attach for own-domain audits without restructuring the manifest entry.\n\nThe table is "fat" by design — every metric column is nullable so partial fetches still produce a row, and the `raw_payloads` row holds the full DataForSEO response so the ACL is re-runnable for backfills if columns are added later.\n\n- Without `url`: returns one row per audited URL within the competitor (the latest audit for each), ordered by `observedAt` DESC.\n- With `url`: returns the single most recent audit for that exact URL.\n\nAuto-registration of competitor URLs from `ranked_keywords` top-N is OUT OF SCOPE today; an operator schedules each URL manually with `systemParams: { scope: "competitor", competitorDomain, projectId, url }`.',
+		tags: ['competitor-intelligence'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: {
+			params: z.object({ projectId: z.string().uuid() }),
+			query: CompetitorIntelligenceContracts.CompetitorPageAuditsQuery,
+		},
+		responses: {
+			200: {
+				description: 'Latest on-page audit snapshot(s) for the competitor',
+				content: {
+					'application/json': { schema: CompetitorIntelligenceContracts.CompetitorPageAuditsResponse },
+				},
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'get',
 		path: '/api/v1/projects/{projectId}/serp-map/suggestions',
 		summary: 'SERP-derived competitor suggestions (external domains in top-10)',
 		description:

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -50,6 +50,7 @@ async function bootstrap(): Promise<void> {
 		drizzle.db,
 	);
 	const competitorKeywordGapRepo = new DrizzlePersistence.DrizzleCompetitorKeywordGapRepository(drizzle.db);
+	const competitorPageAuditRepo = new DrizzlePersistence.DrizzleCompetitorPageAuditRepository(drizzle.db);
 	const projectRepo = new DrizzlePersistence.DrizzleProjectRepository(drizzle.db);
 	const competitorRepo = new DrizzlePersistence.DrizzleCompetitorRepository(drizzle.db);
 	const competitorSuggestionRepo = new DrizzlePersistence.DrizzleCompetitorSuggestionRepository(drizzle.db);
@@ -140,6 +141,12 @@ async function bootstrap(): Promise<void> {
 		competitorKeywordGapRepo,
 		SystemIdGenerator,
 	);
+	const ingestCompetitorPageAuditUseCase =
+		new CompetitorIntelligenceUseCases.IngestCompetitorPageAuditUseCase(
+			projectRepo,
+			competitorPageAuditRepo,
+			SystemIdGenerator,
+		);
 	const ingestGscRowsUseCase = new SearchConsoleInsightsUseCases.IngestGscRowsUseCase(
 		gscPropertyRepo,
 		gscObservationRepo,
@@ -455,6 +462,34 @@ async function bootstrap(): Promise<void> {
 					language,
 					rawPayloadId,
 					rows: rows as Parameters<typeof ingestDomainIntersectionUseCase.execute>[0]['rows'],
+				});
+			},
+		},
+		'competitor-intelligence:ingest-competitor-page-audit': {
+			async execute({ rawPayloadId, rows, systemParams }) {
+				const projectId = systemParams.projectId as string | undefined;
+				const competitorDomain = systemParams.competitorDomain as string | undefined;
+				const url = systemParams.url as string | undefined;
+				if (!projectId || !competitorDomain || !url) {
+					logger.warn(
+						{ systemParams },
+						'competitor-intelligence:ingest-competitor-page-audit skipped: missing projectId, competitorDomain, or url in systemParams',
+					);
+					return;
+				}
+				const audit = rows[0] as
+					| Parameters<typeof ingestCompetitorPageAuditUseCase.execute>[0]['audit']
+					| undefined;
+				if (!audit) {
+					// ACL returns [] when scope !== 'competitor'; treat as a no-op.
+					return;
+				}
+				await ingestCompetitorPageAuditUseCase.execute({
+					projectId,
+					competitorDomain,
+					url,
+					rawPayloadId,
+					audit,
 				});
 			},
 		},

--- a/packages/application/src/competitor-intelligence/index.ts
+++ b/packages/application/src/competitor-intelligence/index.ts
@@ -1,3 +1,5 @@
 export * from './module.js';
+export * from './use-cases/ingest-competitor-page-audit.use-case.js';
 export * from './use-cases/ingest-domain-intersection.use-case.js';
+export * from './use-cases/query-competitor-page-audits.use-case.js';
 export * from './use-cases/query-keyword-gaps.use-case.js';

--- a/packages/application/src/competitor-intelligence/module.ts
+++ b/packages/application/src/competitor-intelligence/module.ts
@@ -5,7 +5,9 @@ import type {
 } from '@rankpulse/domain';
 import type { Clock, IdGenerator } from '@rankpulse/shared';
 import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { IngestCompetitorPageAuditUseCase } from './use-cases/ingest-competitor-page-audit.use-case.js';
 import { IngestDomainIntersectionUseCase } from './use-cases/ingest-domain-intersection.use-case.js';
+import { QueryCompetitorPageAuditsUseCase } from './use-cases/query-competitor-page-audits.use-case.js';
 import { QueryKeywordGapsUseCase } from './use-cases/query-keyword-gaps.use-case.js';
 
 export interface CompetitorIntelligenceDeps {
@@ -14,6 +16,7 @@ export interface CompetitorIntelligenceDeps {
 	readonly events: SharedKernel.EventPublisher;
 	readonly projectRepo: PMDomain.ProjectRepository;
 	readonly competitorKeywordGapRepo: CIDomain.CompetitorKeywordGapRepository;
+	readonly competitorPageAuditRepo: CIDomain.CompetitorPageAuditRepository;
 	readonly competitorIntelligenceSchemaTables: readonly unknown[];
 }
 
@@ -26,10 +29,20 @@ export const competitorIntelligenceModule: ContextModule = {
 			d.competitorKeywordGapRepo,
 			d.ids,
 		);
+		const ingestCompetitorPageAudit = new IngestCompetitorPageAuditUseCase(
+			d.projectRepo,
+			d.competitorPageAuditRepo,
+			d.ids,
+		);
 		return {
 			useCases: {
 				IngestDomainIntersection: ingestDomainIntersection,
 				QueryKeywordGaps: new QueryKeywordGapsUseCase(d.projectRepo, d.competitorKeywordGapRepo),
+				IngestCompetitorPageAudit: ingestCompetitorPageAudit,
+				QueryCompetitorPageAudits: new QueryCompetitorPageAuditsUseCase(
+					d.projectRepo,
+					d.competitorPageAuditRepo,
+				),
 			},
 			ingestUseCases: {
 				// Issue #128: typed ingest path. The router's generic envelope
@@ -46,6 +59,25 @@ export const competitorIntelligenceModule: ContextModule = {
 							language: (systemParams.language as string | undefined) ?? '',
 							rawPayloadId,
 							rows: rows as Parameters<typeof ingestDomainIntersection.execute>[0]['rows'],
+						});
+					},
+				},
+				// Issue #131: typed ingest path for competitor on-page audits. The
+				// ACL emits ONE row when systemParams.scope === 'competitor'; the
+				// router pumps it through the use case which persists the fat
+				// snapshot in `competitor_page_audits`.
+				'competitor-intelligence:ingest-competitor-page-audit': {
+					async execute({ rawPayloadId, rows, systemParams }) {
+						const audit = rows[0] as
+							| Parameters<typeof ingestCompetitorPageAudit.execute>[0]['audit']
+							| undefined;
+						if (!audit) return;
+						await ingestCompetitorPageAudit.execute({
+							projectId: systemParams.projectId as string,
+							competitorDomain: systemParams.competitorDomain as string,
+							url: systemParams.url as string,
+							rawPayloadId,
+							audit,
 						});
 					},
 				},

--- a/packages/application/src/competitor-intelligence/use-cases/ingest-competitor-page-audit.use-case.spec.ts
+++ b/packages/application/src/competitor-intelligence/use-cases/ingest-competitor-page-audit.use-case.spec.ts
@@ -1,0 +1,94 @@
+import type { IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { FixedIdGenerator, type Uuid } from '@rankpulse/shared';
+import {
+	aProject,
+	InMemoryCompetitorPageAuditRepository,
+	InMemoryProjectRepository,
+} from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IngestCompetitorPageAuditUseCase } from './ingest-competitor-page-audit.use-case.js';
+
+const orgId = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+
+const auditFields = (): Parameters<IngestCompetitorPageAuditUseCase['execute']>[0]['audit'] => ({
+	statusCode: 200,
+	statusMessage: 'OK',
+	fetchTimeMs: 432,
+	pageSizeBytes: 89_000,
+	title: 'Competitor landing',
+	metaDescription: 'Best app',
+	h1: 'Welcome',
+	h2Count: 4,
+	h3Count: 7,
+	wordCount: 1250,
+	plainTextSizeBytes: 8_500,
+	internalLinksCount: 33,
+	externalLinksCount: 5,
+	hasSchemaOrg: true,
+	schemaTypes: ['Organization', 'WebSite'],
+	canonicalUrl: 'https://rondacontrol.es/landing',
+	redirectUrl: null,
+	lcpMs: 2_100,
+	cls: 0.05,
+	ttfbMs: 180,
+	domSize: 850,
+	isAmp: false,
+	isJavascript: true,
+	isHttps: true,
+	hreflangCount: 2,
+	ogTagsCount: 6,
+	observedAtProvider: new Date('2026-05-09T05:55:00Z'),
+});
+
+describe('IngestCompetitorPageAuditUseCase', () => {
+	let projects: InMemoryProjectRepository;
+	let audits: InMemoryCompetitorPageAuditRepository;
+	let project: ProjectManagement.Project;
+	let useCase: IngestCompetitorPageAuditUseCase;
+
+	const ids = (n: number): FixedIdGenerator =>
+		new FixedIdGenerator(
+			Array.from({ length: n }, (_, i) => `dddddddd-dddd-dddd-dddd-${String(i).padStart(12, '0')}` as Uuid),
+		);
+
+	beforeEach(async () => {
+		projects = new InMemoryProjectRepository();
+		audits = new InMemoryCompetitorPageAuditRepository();
+		project = aProject({ organizationId: orgId });
+		await projects.save(project);
+		useCase = new IngestCompetitorPageAuditUseCase(projects, audits, ids(10));
+	});
+
+	it('persists exactly one fat audit row stamped with sourceProvider=dataforseo', async () => {
+		const result = await useCase.execute({
+			projectId: project.id,
+			competitorDomain: 'rondacontrol.es',
+			url: 'https://rondacontrol.es/landing',
+			rawPayloadId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+			observedAt: new Date('2026-05-09T06:00:00Z'),
+			audit: auditFields(),
+		});
+		expect(result.ingested).toBe(1);
+		expect(audits.rows).toHaveLength(1);
+		const row = audits.rows[0];
+		expect(row?.competitorDomain).toBe('rondacontrol.es');
+		expect(row?.url).toBe('https://rondacontrol.es/landing');
+		expect(row?.sourceProvider).toBe('dataforseo');
+		expect(row?.statusCode).toBe(200);
+		expect(row?.lcpMs).toBe(2_100);
+		expect(row?.schemaTypes).toEqual(['Organization', 'WebSite']);
+		expect(row?.observedAtProvider).toEqual(new Date('2026-05-09T05:55:00Z'));
+	});
+
+	it('throws NotFoundError when the project does not exist', async () => {
+		await expect(
+			useCase.execute({
+				projectId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+				competitorDomain: 'rondacontrol.es',
+				url: 'https://rondacontrol.es/landing',
+				rawPayloadId: null,
+				audit: auditFields(),
+			}),
+		).rejects.toMatchObject({ code: 'NOT_FOUND' });
+	});
+});

--- a/packages/application/src/competitor-intelligence/use-cases/ingest-competitor-page-audit.use-case.ts
+++ b/packages/application/src/competitor-intelligence/use-cases/ingest-competitor-page-audit.use-case.ts
@@ -1,0 +1,110 @@
+import { CompetitorIntelligence, type ProjectManagement } from '@rankpulse/domain';
+import { type IdGenerator, NotFoundError } from '@rankpulse/shared';
+
+export interface CompetitorPageAuditFields {
+	statusCode: number | null;
+	statusMessage: string | null;
+	fetchTimeMs: number | null;
+	pageSizeBytes: number | null;
+	title: string | null;
+	metaDescription: string | null;
+	h1: string | null;
+	h2Count: number | null;
+	h3Count: number | null;
+	wordCount: number | null;
+	plainTextSizeBytes: number | null;
+	internalLinksCount: number | null;
+	externalLinksCount: number | null;
+	hasSchemaOrg: boolean | null;
+	schemaTypes: readonly string[];
+	canonicalUrl: string | null;
+	redirectUrl: string | null;
+	lcpMs: number | null;
+	cls: number | null;
+	ttfbMs: number | null;
+	domSize: number | null;
+	isAmp: boolean | null;
+	isJavascript: boolean | null;
+	isHttps: boolean | null;
+	hreflangCount: number | null;
+	ogTagsCount: number | null;
+	observedAtProvider: Date | null;
+}
+
+export interface IngestCompetitorPageAuditCommand {
+	projectId: string;
+	competitorDomain: string;
+	url: string;
+	audit: CompetitorPageAuditFields;
+	rawPayloadId: string | null;
+	observedAt?: Date;
+}
+
+export interface IngestCompetitorPageAuditResult {
+	ingested: number;
+}
+
+const SOURCE_PROVIDER = 'dataforseo';
+
+/**
+ * Issue #131: persists a single fat-row snapshot of a competitor URL audit
+ * (DataForSEO `on_page/instant_pages`) into `competitor_page_audits`. Mirrors
+ * the passive-observation ingest pattern of `IngestDomainIntersectionUseCase`
+ * (#128): no domain events, the natural-key PK absorbs idempotent re-runs.
+ *
+ * One audit per fetch — `saveAll([single])` keeps the repository contract
+ * uniform with the keyword-gap path.
+ */
+export class IngestCompetitorPageAuditUseCase {
+	constructor(
+		private readonly projects: ProjectManagement.ProjectRepository,
+		private readonly audits: CompetitorIntelligence.CompetitorPageAuditRepository,
+		private readonly ids: IdGenerator,
+	) {}
+
+	async execute(cmd: IngestCompetitorPageAuditCommand): Promise<IngestCompetitorPageAuditResult> {
+		const project = await this.projects.findById(cmd.projectId as ProjectManagement.ProjectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${cmd.projectId} not found`);
+		}
+		const observedAt = cmd.observedAt ?? new Date();
+		const audit = CompetitorIntelligence.CompetitorPageAudit.record({
+			id: this.ids.generate() as CompetitorIntelligence.CompetitorPageAuditId,
+			observedAt,
+			projectId: project.id,
+			competitorDomain: cmd.competitorDomain,
+			url: cmd.url,
+			statusCode: cmd.audit.statusCode,
+			statusMessage: cmd.audit.statusMessage,
+			fetchTimeMs: cmd.audit.fetchTimeMs,
+			pageSizeBytes: cmd.audit.pageSizeBytes,
+			title: cmd.audit.title,
+			metaDescription: cmd.audit.metaDescription,
+			h1: cmd.audit.h1,
+			h2Count: cmd.audit.h2Count,
+			h3Count: cmd.audit.h3Count,
+			wordCount: cmd.audit.wordCount,
+			plainTextSizeBytes: cmd.audit.plainTextSizeBytes,
+			internalLinksCount: cmd.audit.internalLinksCount,
+			externalLinksCount: cmd.audit.externalLinksCount,
+			hasSchemaOrg: cmd.audit.hasSchemaOrg,
+			schemaTypes: cmd.audit.schemaTypes,
+			canonicalUrl: cmd.audit.canonicalUrl,
+			redirectUrl: cmd.audit.redirectUrl,
+			lcpMs: cmd.audit.lcpMs,
+			cls: cmd.audit.cls,
+			ttfbMs: cmd.audit.ttfbMs,
+			domSize: cmd.audit.domSize,
+			isAmp: cmd.audit.isAmp,
+			isJavascript: cmd.audit.isJavascript,
+			isHttps: cmd.audit.isHttps,
+			hreflangCount: cmd.audit.hreflangCount,
+			ogTagsCount: cmd.audit.ogTagsCount,
+			sourceProvider: SOURCE_PROVIDER,
+			rawPayloadId: cmd.rawPayloadId,
+			observedAtProvider: cmd.audit.observedAtProvider,
+		});
+		const { inserted } = await this.audits.saveAll([audit]);
+		return { ingested: inserted };
+	}
+}

--- a/packages/application/src/competitor-intelligence/use-cases/query-competitor-page-audits.use-case.spec.ts
+++ b/packages/application/src/competitor-intelligence/use-cases/query-competitor-page-audits.use-case.spec.ts
@@ -1,0 +1,141 @@
+import { CompetitorIntelligence, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import {
+	aProject,
+	InMemoryCompetitorPageAuditRepository,
+	InMemoryProjectRepository,
+} from '@rankpulse/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryCompetitorPageAuditsUseCase } from './query-competitor-page-audits.use-case.js';
+
+const orgId = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
+
+const buildAudit = (
+	overrides: Partial<{
+		projectId: ProjectManagement.ProjectId;
+		url: string;
+		observedAt: Date;
+		title: string | null;
+	}>,
+): CompetitorIntelligence.CompetitorPageAudit =>
+	CompetitorIntelligence.CompetitorPageAudit.record({
+		id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as CompetitorIntelligence.CompetitorPageAuditId,
+		observedAt: overrides.observedAt ?? new Date('2026-05-09T06:00:00Z'),
+		projectId: overrides.projectId ?? ('p' as Uuid as ProjectManagement.ProjectId),
+		competitorDomain: 'rondacontrol.es',
+		url: overrides.url ?? 'https://rondacontrol.es/landing',
+		statusCode: 200,
+		statusMessage: 'OK',
+		fetchTimeMs: 432,
+		pageSizeBytes: 89_000,
+		title: overrides.title ?? 'Competitor landing',
+		metaDescription: null,
+		h1: 'Welcome',
+		h2Count: 4,
+		h3Count: 7,
+		wordCount: 1250,
+		plainTextSizeBytes: 8_500,
+		internalLinksCount: 33,
+		externalLinksCount: 5,
+		hasSchemaOrg: true,
+		schemaTypes: ['Organization'],
+		canonicalUrl: null,
+		redirectUrl: null,
+		lcpMs: 2_100,
+		cls: 0.05,
+		ttfbMs: 180,
+		domSize: 850,
+		isAmp: false,
+		isJavascript: true,
+		isHttps: true,
+		hreflangCount: 2,
+		ogTagsCount: 6,
+		sourceProvider: 'dataforseo',
+		rawPayloadId: null,
+		observedAtProvider: null,
+	});
+
+describe('QueryCompetitorPageAuditsUseCase', () => {
+	let projects: InMemoryProjectRepository;
+	let audits: InMemoryCompetitorPageAuditRepository;
+	let project: ProjectManagement.Project;
+	let useCase: QueryCompetitorPageAuditsUseCase;
+
+	beforeEach(async () => {
+		projects = new InMemoryProjectRepository();
+		audits = new InMemoryCompetitorPageAuditRepository();
+		project = aProject({ organizationId: orgId });
+		await projects.save(project);
+		useCase = new QueryCompetitorPageAuditsUseCase(projects, audits);
+	});
+
+	it('returns the latest audit per URL when no url filter is supplied', async () => {
+		await audits.saveAll([
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/a',
+				observedAt: new Date('2026-05-08T06:00:00Z'),
+				title: 'a-old',
+			}),
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/a',
+				observedAt: new Date('2026-05-09T06:00:00Z'),
+				title: 'a-new',
+			}),
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/b',
+				observedAt: new Date('2026-05-09T05:00:00Z'),
+				title: 'b',
+			}),
+		]);
+		const result = await useCase.execute({
+			projectId: project.id,
+			competitorDomain: 'rondacontrol.es',
+		});
+		expect(result.rows).toHaveLength(2);
+		const byUrl = new Map(result.rows.map((r) => [r.url, r] as const));
+		expect(byUrl.get('https://rondacontrol.es/a')?.title).toBe('a-new');
+		expect(byUrl.get('https://rondacontrol.es/b')?.title).toBe('b');
+	});
+
+	it('returns the single latest audit for a specific URL when url is supplied', async () => {
+		await audits.saveAll([
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/a',
+				observedAt: new Date('2026-05-08T06:00:00Z'),
+				title: 'a-old',
+			}),
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/a',
+				observedAt: new Date('2026-05-09T06:00:00Z'),
+				title: 'a-new',
+			}),
+			buildAudit({
+				projectId: project.id,
+				url: 'https://rondacontrol.es/b',
+				observedAt: new Date('2026-05-09T05:00:00Z'),
+				title: 'b',
+			}),
+		]);
+		const result = await useCase.execute({
+			projectId: project.id,
+			competitorDomain: 'rondacontrol.es',
+			url: 'https://rondacontrol.es/a',
+		});
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.title).toBe('a-new');
+	});
+
+	it('throws NotFoundError when the project does not exist', async () => {
+		await expect(
+			useCase.execute({
+				projectId: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+				competitorDomain: 'rondacontrol.es',
+			}),
+		).rejects.toMatchObject({ code: 'NOT_FOUND' });
+	});
+});

--- a/packages/application/src/competitor-intelligence/use-cases/query-competitor-page-audits.use-case.ts
+++ b/packages/application/src/competitor-intelligence/use-cases/query-competitor-page-audits.use-case.ts
@@ -1,0 +1,106 @@
+import type { CompetitorIntelligence, ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryCompetitorPageAuditsCommand {
+	projectId: string;
+	competitorDomain: string;
+	url?: string;
+	limit?: number;
+}
+
+export interface CompetitorPageAuditEntryDto {
+	observedAt: string;
+	competitorDomain: string;
+	url: string;
+	statusCode: number | null;
+	statusMessage: string | null;
+	fetchTimeMs: number | null;
+	pageSizeBytes: number | null;
+	title: string | null;
+	metaDescription: string | null;
+	h1: string | null;
+	h2Count: number | null;
+	h3Count: number | null;
+	wordCount: number | null;
+	plainTextSizeBytes: number | null;
+	internalLinksCount: number | null;
+	externalLinksCount: number | null;
+	hasSchemaOrg: boolean | null;
+	schemaTypes: string[];
+	canonicalUrl: string | null;
+	redirectUrl: string | null;
+	lcpMs: number | null;
+	cls: number | null;
+	ttfbMs: number | null;
+	domSize: number | null;
+	isAmp: boolean | null;
+	isJavascript: boolean | null;
+	isHttps: boolean | null;
+	hreflangCount: number | null;
+	ogTagsCount: number | null;
+	sourceProvider: string;
+	observedAtProvider: string | null;
+}
+
+export interface CompetitorPageAuditsResponseDto {
+	rows: CompetitorPageAuditEntryDto[];
+}
+
+/**
+ * Issue #131: read-side projection over `competitor_page_audits`.
+ * - With `url` provided, returns the single latest audit for that URL.
+ * - Without `url`, returns the latest audit per URL across the competitor.
+ * Project existence is validated up-front so the controller doesn't need a
+ * separate 404 check.
+ */
+export class QueryCompetitorPageAuditsUseCase {
+	constructor(
+		private readonly projects: ProjectManagement.ProjectRepository,
+		private readonly audits: CompetitorIntelligence.CompetitorPageAuditRepository,
+	) {}
+
+	async execute(cmd: QueryCompetitorPageAuditsCommand): Promise<CompetitorPageAuditsResponseDto> {
+		const project = await this.projects.findById(cmd.projectId as ProjectManagement.ProjectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${cmd.projectId} not found`);
+		}
+		const audits = await this.audits.listLatestForCompetitor(project.id, cmd.competitorDomain, {
+			url: cmd.url,
+			limit: cmd.limit,
+		});
+		const rows: CompetitorPageAuditEntryDto[] = audits.map((a) => ({
+			observedAt: a.observedAt.toISOString(),
+			competitorDomain: a.competitorDomain,
+			url: a.url,
+			statusCode: a.statusCode,
+			statusMessage: a.statusMessage,
+			fetchTimeMs: a.fetchTimeMs,
+			pageSizeBytes: a.pageSizeBytes,
+			title: a.title,
+			metaDescription: a.metaDescription,
+			h1: a.h1,
+			h2Count: a.h2Count,
+			h3Count: a.h3Count,
+			wordCount: a.wordCount,
+			plainTextSizeBytes: a.plainTextSizeBytes,
+			internalLinksCount: a.internalLinksCount,
+			externalLinksCount: a.externalLinksCount,
+			hasSchemaOrg: a.hasSchemaOrg,
+			schemaTypes: [...a.schemaTypes],
+			canonicalUrl: a.canonicalUrl,
+			redirectUrl: a.redirectUrl,
+			lcpMs: a.lcpMs,
+			cls: a.cls,
+			ttfbMs: a.ttfbMs,
+			domSize: a.domSize,
+			isAmp: a.isAmp,
+			isJavascript: a.isJavascript,
+			isHttps: a.isHttps,
+			hreflangCount: a.hreflangCount,
+			ogTagsCount: a.ogTagsCount,
+			sourceProvider: a.sourceProvider,
+			observedAtProvider: a.observedAtProvider ? a.observedAtProvider.toISOString() : null,
+		}));
+		return { rows };
+	}
+}

--- a/packages/contracts/src/competitor-intelligence/index.ts
+++ b/packages/contracts/src/competitor-intelligence/index.ts
@@ -26,3 +26,52 @@ export const KeywordGapsResponse = z.object({
 	rows: z.array(KeywordGapsResponseEntry),
 });
 export type KeywordGapsResponse = z.infer<typeof KeywordGapsResponse>;
+
+// --- Competitor Page Audits (issue #131) ---
+
+export const CompetitorPageAuditsQuery = z.object({
+	competitorDomain: z.string().min(3).max(253),
+	url: z.string().url().optional(),
+	limit: z.coerce.number().int().min(1).max(1000).optional(),
+});
+export type CompetitorPageAuditsQuery = z.infer<typeof CompetitorPageAuditsQuery>;
+
+export const CompetitorPageAuditDto = z.object({
+	observedAt: z.string().datetime(),
+	competitorDomain: z.string(),
+	url: z.string(),
+	statusCode: z.number().int().nullable(),
+	statusMessage: z.string().nullable(),
+	fetchTimeMs: z.number().int().nullable(),
+	pageSizeBytes: z.number().int().nullable(),
+	title: z.string().nullable(),
+	metaDescription: z.string().nullable(),
+	h1: z.string().nullable(),
+	h2Count: z.number().int().nullable(),
+	h3Count: z.number().int().nullable(),
+	wordCount: z.number().int().nullable(),
+	plainTextSizeBytes: z.number().int().nullable(),
+	internalLinksCount: z.number().int().nullable(),
+	externalLinksCount: z.number().int().nullable(),
+	hasSchemaOrg: z.boolean().nullable(),
+	schemaTypes: z.array(z.string()),
+	canonicalUrl: z.string().nullable(),
+	redirectUrl: z.string().nullable(),
+	lcpMs: z.number().int().nullable(),
+	cls: z.number().nullable(),
+	ttfbMs: z.number().int().nullable(),
+	domSize: z.number().int().nullable(),
+	isAmp: z.boolean().nullable(),
+	isJavascript: z.boolean().nullable(),
+	isHttps: z.boolean().nullable(),
+	hreflangCount: z.number().int().nullable(),
+	ogTagsCount: z.number().int().nullable(),
+	sourceProvider: z.string(),
+	observedAtProvider: z.string().datetime().nullable(),
+});
+export type CompetitorPageAuditDto = z.infer<typeof CompetitorPageAuditDto>;
+
+export const CompetitorPageAuditsResponse = z.object({
+	rows: z.array(CompetitorPageAuditDto),
+});
+export type CompetitorPageAuditsResponse = z.infer<typeof CompetitorPageAuditsResponse>;

--- a/packages/domain/src/competitor-intelligence/entities/competitor-page-audit.ts
+++ b/packages/domain/src/competitor-intelligence/entities/competitor-page-audit.ts
@@ -1,0 +1,172 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import { AggregateRoot } from '../../shared-kernel/aggregate-root.js';
+import type { CompetitorPageAuditId } from '../value-objects/identifiers.js';
+
+export interface CompetitorPageAuditProps {
+	id: CompetitorPageAuditId;
+	observedAt: Date;
+	projectId: ProjectId;
+	competitorDomain: string;
+	url: string;
+	statusCode: number | null;
+	statusMessage: string | null;
+	fetchTimeMs: number | null;
+	pageSizeBytes: number | null;
+	title: string | null;
+	metaDescription: string | null;
+	h1: string | null;
+	h2Count: number | null;
+	h3Count: number | null;
+	wordCount: number | null;
+	plainTextSizeBytes: number | null;
+	internalLinksCount: number | null;
+	externalLinksCount: number | null;
+	hasSchemaOrg: boolean | null;
+	schemaTypes: readonly string[];
+	canonicalUrl: string | null;
+	redirectUrl: string | null;
+	lcpMs: number | null;
+	cls: number | null;
+	ttfbMs: number | null;
+	domSize: number | null;
+	isAmp: boolean | null;
+	isJavascript: boolean | null;
+	isHttps: boolean | null;
+	hreflangCount: number | null;
+	ogTagsCount: number | null;
+	sourceProvider: string;
+	rawPayloadId: string | null;
+	observedAtProvider: Date | null;
+}
+
+/**
+ * Issue #131: a fat snapshot of a competitor URL's on-page audit produced by
+ * DataForSEO's `on_page/instant_pages` endpoint. Persisted in the
+ * `competitor_page_audits` hypertable (chunk 30d, retention 13mo).
+ *
+ * Passive read-model — no domain events. Auto-registration of competitor URLs
+ * (e.g. from `ranked_keywords` top-N) is OUT OF SCOPE for #131; today the
+ * operator creates a `JobDefinition` manually with
+ * `systemParams: { scope: 'competitor', competitorDomain, projectId, url }`
+ * so the ACL polymorphic guard can route the row into this aggregate.
+ *
+ * The "fat" projection mirrors as much of the DataForSEO response as we can
+ * extract; the `raw_payloads` row holds the full payload so the ACL is
+ * re-runnable for backfills if we add columns later.
+ */
+export class CompetitorPageAudit extends AggregateRoot {
+	private constructor(private readonly props: CompetitorPageAuditProps) {
+		super();
+	}
+
+	static record(input: CompetitorPageAuditProps): CompetitorPageAudit {
+		return new CompetitorPageAudit({ ...input, schemaTypes: [...input.schemaTypes] });
+	}
+
+	static rehydrate(props: CompetitorPageAuditProps): CompetitorPageAudit {
+		return new CompetitorPageAudit({ ...props, schemaTypes: [...props.schemaTypes] });
+	}
+
+	get id(): CompetitorPageAuditId {
+		return this.props.id;
+	}
+	get observedAt(): Date {
+		return this.props.observedAt;
+	}
+	get projectId(): ProjectId {
+		return this.props.projectId;
+	}
+	get competitorDomain(): string {
+		return this.props.competitorDomain;
+	}
+	get url(): string {
+		return this.props.url;
+	}
+	get statusCode(): number | null {
+		return this.props.statusCode;
+	}
+	get statusMessage(): string | null {
+		return this.props.statusMessage;
+	}
+	get fetchTimeMs(): number | null {
+		return this.props.fetchTimeMs;
+	}
+	get pageSizeBytes(): number | null {
+		return this.props.pageSizeBytes;
+	}
+	get title(): string | null {
+		return this.props.title;
+	}
+	get metaDescription(): string | null {
+		return this.props.metaDescription;
+	}
+	get h1(): string | null {
+		return this.props.h1;
+	}
+	get h2Count(): number | null {
+		return this.props.h2Count;
+	}
+	get h3Count(): number | null {
+		return this.props.h3Count;
+	}
+	get wordCount(): number | null {
+		return this.props.wordCount;
+	}
+	get plainTextSizeBytes(): number | null {
+		return this.props.plainTextSizeBytes;
+	}
+	get internalLinksCount(): number | null {
+		return this.props.internalLinksCount;
+	}
+	get externalLinksCount(): number | null {
+		return this.props.externalLinksCount;
+	}
+	get hasSchemaOrg(): boolean | null {
+		return this.props.hasSchemaOrg;
+	}
+	get schemaTypes(): readonly string[] {
+		return this.props.schemaTypes;
+	}
+	get canonicalUrl(): string | null {
+		return this.props.canonicalUrl;
+	}
+	get redirectUrl(): string | null {
+		return this.props.redirectUrl;
+	}
+	get lcpMs(): number | null {
+		return this.props.lcpMs;
+	}
+	get cls(): number | null {
+		return this.props.cls;
+	}
+	get ttfbMs(): number | null {
+		return this.props.ttfbMs;
+	}
+	get domSize(): number | null {
+		return this.props.domSize;
+	}
+	get isAmp(): boolean | null {
+		return this.props.isAmp;
+	}
+	get isJavascript(): boolean | null {
+		return this.props.isJavascript;
+	}
+	get isHttps(): boolean | null {
+		return this.props.isHttps;
+	}
+	get hreflangCount(): number | null {
+		return this.props.hreflangCount;
+	}
+	get ogTagsCount(): number | null {
+		return this.props.ogTagsCount;
+	}
+	get sourceProvider(): string {
+		return this.props.sourceProvider;
+	}
+	get rawPayloadId(): string | null {
+		return this.props.rawPayloadId;
+	}
+	get observedAtProvider(): Date | null {
+		return this.props.observedAtProvider;
+	}
+}

--- a/packages/domain/src/competitor-intelligence/index.ts
+++ b/packages/domain/src/competitor-intelligence/index.ts
@@ -1,6 +1,8 @@
 // Entities
 export * from './entities/competitor-keyword-gap.js';
+export * from './entities/competitor-page-audit.js';
 // Ports
 export * from './ports/competitor-keyword-gap-repository.js';
+export * from './ports/competitor-page-audit-repository.js';
 // Value objects
 export * from './value-objects/identifiers.js';

--- a/packages/domain/src/competitor-intelligence/ports/competitor-page-audit-repository.ts
+++ b/packages/domain/src/competitor-intelligence/ports/competitor-page-audit-repository.ts
@@ -1,0 +1,37 @@
+import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
+import type { CompetitorPageAudit } from '../entities/competitor-page-audit.js';
+
+export interface ListCompetitorPageAuditsOptions {
+	/**
+	 * If supplied, returns the single most recent audit for that exact URL
+	 * within the (project, competitorDomain) tuple. If omitted, returns the
+	 * latest audit per URL across the competitor (one row per URL, picking the
+	 * most recent observation for each).
+	 */
+	url?: string;
+	/** Caps row count when listing latest-per-url. Defaults to 500. */
+	limit?: number;
+}
+
+export interface CompetitorPageAuditRepository {
+	/**
+	 * Bulk insert with `onConflictDoNothing` against the natural key
+	 * `(observed_at, project_id, competitor_domain, url)`. `inserted` reports
+	 * rows attempted (Drizzle on postgres-js does not surface affected counts
+	 * on `onConflictDoNothing`), matching the `CompetitorKeywordGapRepository`
+	 * convention.
+	 */
+	saveAll(audits: readonly CompetitorPageAudit[]): Promise<{ inserted: number }>;
+
+	/**
+	 * Latest snapshot for a competitor's audited pages within the project.
+	 * - With `opts.url`: returns at most one row — the latest audit for that URL.
+	 * - Without `opts.url`: returns the latest audit per URL (one row per URL),
+	 *   ordered by observed_at DESC.
+	 */
+	listLatestForCompetitor(
+		projectId: ProjectId,
+		competitorDomain: string,
+		opts?: ListCompetitorPageAuditsOptions,
+	): Promise<readonly CompetitorPageAudit[]>;
+}

--- a/packages/domain/src/competitor-intelligence/value-objects/identifiers.ts
+++ b/packages/domain/src/competitor-intelligence/value-objects/identifiers.ts
@@ -1,3 +1,5 @@
 import type { Uuid } from '@rankpulse/shared';
 
 export type CompetitorKeywordGapId = Uuid & { readonly __kind: 'CompetitorKeywordGapId' };
+
+export type CompetitorPageAuditId = Uuid & { readonly __kind: 'CompetitorPageAuditId' };

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -6,6 +6,7 @@ export { ProjectBrandWatchlistResolver } from './repositories/ai-search-insights
 export { DrizzleBingPropertyRepository } from './repositories/bing-webmaster-insights/bing-property.repository.js';
 export { DrizzleBingTrafficObservationRepository } from './repositories/bing-webmaster-insights/bing-traffic-observation.repository.js';
 export { DrizzleCompetitorKeywordGapRepository } from './repositories/competitor-intelligence/competitor-keyword-gap.repository.js';
+export { DrizzleCompetitorPageAuditRepository } from './repositories/competitor-intelligence/competitor-page-audit.repository.js';
 export { DrizzleWikipediaArticleRepository } from './repositories/entity-awareness/wikipedia-article.repository.js';
 export { DrizzleWikipediaPageviewObservationRepository } from './repositories/entity-awareness/wikipedia-pageview-observation.repository.js';
 export { DrizzleClarityProjectRepository } from './repositories/experience-analytics/clarity-project.repository.js';

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0020_competitor_page_audits.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0020_competitor_page_audits.sql
@@ -1,0 +1,69 @@
+CREATE TABLE IF NOT EXISTS "competitor_page_audits" (
+	"observed_at" timestamp with time zone NOT NULL,
+	"project_id" uuid NOT NULL,
+	"competitor_domain" text NOT NULL,
+	"url" text NOT NULL,
+	"status_code" smallint,
+	"status_message" text,
+	"fetch_time_ms" integer,
+	"page_size_bytes" integer,
+	"title" text,
+	"meta_description" text,
+	"h1" text,
+	"h2_count" smallint,
+	"h3_count" smallint,
+	"word_count" integer,
+	"plain_text_size_bytes" integer,
+	"internal_links_count" integer,
+	"external_links_count" integer,
+	"has_schema_org" boolean,
+	"schema_types" jsonb,
+	"canonical_url" text,
+	"redirect_url" text,
+	"lcp_ms" integer,
+	"cls" double precision,
+	"ttfb_ms" integer,
+	"dom_size" integer,
+	"is_amp" boolean,
+	"is_javascript" boolean,
+	"is_https" boolean,
+	"hreflang_count" smallint,
+	"og_tags_count" smallint,
+	"source_provider" text NOT NULL,
+	"raw_payload_id" uuid,
+	"observed_at_provider" timestamp with time zone,
+	CONSTRAINT "competitor_page_audits_pk" PRIMARY KEY("observed_at","project_id","competitor_domain","url")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	ALTER TABLE "competitor_page_audits"
+		ADD CONSTRAINT "competitor_page_audits_project_id_fk"
+		FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+	WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "competitor_page_audits_pair_idx" ON "competitor_page_audits" USING btree ("project_id","competitor_domain","observed_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "competitor_page_audits_domain_idx" ON "competitor_page_audits" USING btree ("competitor_domain","observed_at");--> statement-breakpoint
+
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+		PERFORM create_hypertable(
+			'competitor_page_audits',
+			'observed_at',
+			chunk_time_interval => INTERVAL '30 days',
+			if_not_exists => TRUE,
+			migrate_data => TRUE
+		);
+		-- Issue #131 acceptance: 13-month rolling window matches the rest of
+		-- the competitor-intelligence BC (#128) and rank-tracking (#127), so
+		-- YoY trend deltas always have both endpoints available.
+		PERFORM add_retention_policy(
+			'competitor_page_audits',
+			INTERVAL '13 months',
+			if_not_exists => TRUE
+		);
+	END IF;
+END
+$$;

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
 			"when": 1779100000000,
 			"tag": "0019_competitor_activity",
 			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1779200000000,
+			"tag": "0020_competitor_page_audits",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/infrastructure/src/persistence/drizzle/repositories/competitor-intelligence/competitor-page-audit.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/competitor-intelligence/competitor-page-audit.repository.ts
@@ -1,0 +1,150 @@
+import { CompetitorIntelligence, type ProjectManagement } from '@rankpulse/domain';
+import { and, desc, eq } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+import { type CompetitorPageAuditRow, competitorPageAudits } from '../../schema/index.js';
+
+/**
+ * Issue #131: persists fat competitor URL audits and exposes the latest
+ * snapshot for either:
+ *   - a specific URL (returns at most one row), or
+ *   - the entire competitor (returns one row per URL — DISTINCT ON (url)
+ *     ORDER BY url, observed_at DESC).
+ *
+ * The natural-key PK on the hypertable absorbs idempotent re-runs at the
+ * same `observedAt`; `saveAll` reports `inserted = audits.length` because
+ * postgres-js doesn't surface row counts under `onConflictDoNothing` — same
+ * convention as `DrizzleCompetitorKeywordGapRepository`.
+ */
+export class DrizzleCompetitorPageAuditRepository
+	implements CompetitorIntelligence.CompetitorPageAuditRepository
+{
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async saveAll(
+		audits: readonly CompetitorIntelligence.CompetitorPageAudit[],
+	): Promise<{ inserted: number }> {
+		if (audits.length === 0) return { inserted: 0 };
+		await this.db
+			.insert(competitorPageAudits)
+			.values(
+				audits.map((a) => ({
+					observedAt: a.observedAt,
+					projectId: a.projectId,
+					competitorDomain: a.competitorDomain,
+					url: a.url,
+					statusCode: a.statusCode,
+					statusMessage: a.statusMessage,
+					fetchTimeMs: a.fetchTimeMs,
+					pageSizeBytes: a.pageSizeBytes,
+					title: a.title,
+					metaDescription: a.metaDescription,
+					h1: a.h1,
+					h2Count: a.h2Count,
+					h3Count: a.h3Count,
+					wordCount: a.wordCount,
+					plainTextSizeBytes: a.plainTextSizeBytes,
+					internalLinksCount: a.internalLinksCount,
+					externalLinksCount: a.externalLinksCount,
+					hasSchemaOrg: a.hasSchemaOrg,
+					schemaTypes: [...a.schemaTypes],
+					canonicalUrl: a.canonicalUrl,
+					redirectUrl: a.redirectUrl,
+					lcpMs: a.lcpMs,
+					cls: a.cls,
+					ttfbMs: a.ttfbMs,
+					domSize: a.domSize,
+					isAmp: a.isAmp,
+					isJavascript: a.isJavascript,
+					isHttps: a.isHttps,
+					hreflangCount: a.hreflangCount,
+					ogTagsCount: a.ogTagsCount,
+					sourceProvider: a.sourceProvider,
+					rawPayloadId: a.rawPayloadId,
+					observedAtProvider: a.observedAtProvider,
+				})),
+			)
+			.onConflictDoNothing();
+		return { inserted: audits.length };
+	}
+
+	async listLatestForCompetitor(
+		projectId: ProjectManagement.ProjectId,
+		competitorDomain: string,
+		opts: CompetitorIntelligence.ListCompetitorPageAuditsOptions = {},
+	): Promise<readonly CompetitorIntelligence.CompetitorPageAudit[]> {
+		const limit = opts.limit ?? 500;
+		if (opts.url != null) {
+			const rows = await this.db
+				.select()
+				.from(competitorPageAudits)
+				.where(
+					and(
+						eq(competitorPageAudits.projectId, projectId),
+						eq(competitorPageAudits.competitorDomain, competitorDomain),
+						eq(competitorPageAudits.url, opts.url),
+					),
+				)
+				.orderBy(desc(competitorPageAudits.observedAt))
+				.limit(1);
+			return rows.map((r) => this.rehydrate(r));
+		}
+		// Postgres-only: DISTINCT ON (url) ... ORDER BY url, observed_at DESC
+		// keeps the projection to one row per URL — the most recent audit. The
+		// outer `.sort` after fetch re-orders by recency so the API surface
+		// returns "freshest first" rather than alphabetical-by-url.
+		const rows = await this.db
+			.selectDistinctOn([competitorPageAudits.url])
+			.from(competitorPageAudits)
+			.where(
+				and(
+					eq(competitorPageAudits.projectId, projectId),
+					eq(competitorPageAudits.competitorDomain, competitorDomain),
+				),
+			)
+			.orderBy(competitorPageAudits.url, desc(competitorPageAudits.observedAt))
+			.limit(limit);
+		return rows
+			.slice()
+			.sort((a, b) => b.observedAt.getTime() - a.observedAt.getTime())
+			.map((r) => this.rehydrate(r));
+	}
+
+	private rehydrate(r: CompetitorPageAuditRow): CompetitorIntelligence.CompetitorPageAudit {
+		return CompetitorIntelligence.CompetitorPageAudit.rehydrate({
+			id: `${r.observedAt.toISOString()}#${r.projectId}#${r.competitorDomain}#${r.url}` as CompetitorIntelligence.CompetitorPageAuditId,
+			observedAt: r.observedAt,
+			projectId: r.projectId as ProjectManagement.ProjectId,
+			competitorDomain: r.competitorDomain,
+			url: r.url,
+			statusCode: r.statusCode,
+			statusMessage: r.statusMessage,
+			fetchTimeMs: r.fetchTimeMs,
+			pageSizeBytes: r.pageSizeBytes,
+			title: r.title,
+			metaDescription: r.metaDescription,
+			h1: r.h1,
+			h2Count: r.h2Count,
+			h3Count: r.h3Count,
+			wordCount: r.wordCount,
+			plainTextSizeBytes: r.plainTextSizeBytes,
+			internalLinksCount: r.internalLinksCount,
+			externalLinksCount: r.externalLinksCount,
+			hasSchemaOrg: r.hasSchemaOrg,
+			schemaTypes: r.schemaTypes ?? [],
+			canonicalUrl: r.canonicalUrl,
+			redirectUrl: r.redirectUrl,
+			lcpMs: r.lcpMs,
+			cls: r.cls,
+			ttfbMs: r.ttfbMs,
+			domSize: r.domSize,
+			isAmp: r.isAmp,
+			isJavascript: r.isJavascript,
+			isHttps: r.isHttps,
+			hreflangCount: r.hreflangCount,
+			ogTagsCount: r.ogTagsCount,
+			sourceProvider: r.sourceProvider,
+			rawPayloadId: r.rawPayloadId,
+			observedAtProvider: r.observedAtProvider,
+		});
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/schema/competitor-intelligence.ts
+++ b/packages/infrastructure/src/persistence/drizzle/schema/competitor-intelligence.ts
@@ -1,7 +1,9 @@
 import {
+	boolean,
 	doublePrecision,
 	index,
 	integer,
+	jsonb,
 	pgTable,
 	primaryKey,
 	smallint,
@@ -54,4 +56,63 @@ export const competitorKeywordGaps = pgTable(
 
 export type CompetitorKeywordGapRow = typeof competitorKeywordGaps.$inferSelect;
 
-export const competitorIntelligenceSchemaTables = [competitorKeywordGaps] as const;
+/**
+ * Issue #131: fat snapshot of a competitor URL on-page audit (DataForSEO
+ * `on_page/instant_pages`). Promoted to a TimescaleDB hypertable by migration
+ * `0020` with chunk-time = 30 days and a 13-month retention policy.
+ *
+ * `raw_payloads` stores the full DataForSEO response so the ACL can be
+ * re-run for backfills if we add columns later — only PK + sourceProvider
+ * are required here; every other column is nullable on purpose.
+ */
+export const competitorPageAudits = pgTable(
+	'competitor_page_audits',
+	{
+		observedAt: timestamp('observed_at', { withTimezone: true }).notNull(),
+		projectId: uuid('project_id')
+			.notNull()
+			.references(() => projects.id, { onDelete: 'cascade' }),
+		competitorDomain: text('competitor_domain').notNull(),
+		url: text('url').notNull(),
+		statusCode: smallint('status_code'),
+		statusMessage: text('status_message'),
+		fetchTimeMs: integer('fetch_time_ms'),
+		pageSizeBytes: integer('page_size_bytes'),
+		title: text('title'),
+		metaDescription: text('meta_description'),
+		h1: text('h1'),
+		h2Count: smallint('h2_count'),
+		h3Count: smallint('h3_count'),
+		wordCount: integer('word_count'),
+		plainTextSizeBytes: integer('plain_text_size_bytes'),
+		internalLinksCount: integer('internal_links_count'),
+		externalLinksCount: integer('external_links_count'),
+		hasSchemaOrg: boolean('has_schema_org'),
+		schemaTypes: jsonb('schema_types').$type<string[]>(),
+		canonicalUrl: text('canonical_url'),
+		redirectUrl: text('redirect_url'),
+		lcpMs: integer('lcp_ms'),
+		cls: doublePrecision('cls'),
+		ttfbMs: integer('ttfb_ms'),
+		domSize: integer('dom_size'),
+		isAmp: boolean('is_amp'),
+		isJavascript: boolean('is_javascript'),
+		isHttps: boolean('is_https'),
+		hreflangCount: smallint('hreflang_count'),
+		ogTagsCount: smallint('og_tags_count'),
+		sourceProvider: text('source_provider').notNull(),
+		rawPayloadId: uuid('raw_payload_id'),
+		observedAtProvider: timestamp('observed_at_provider', { withTimezone: true }),
+	},
+	(t) => ({
+		pk: primaryKey({
+			columns: [t.observedAt, t.projectId, t.competitorDomain, t.url],
+		}),
+		pairIdx: index('competitor_page_audits_pair_idx').on(t.projectId, t.competitorDomain, t.observedAt),
+		domainIdx: index('competitor_page_audits_domain_idx').on(t.competitorDomain, t.observedAt),
+	}),
+);
+
+export type CompetitorPageAuditRow = typeof competitorPageAudits.$inferSelect;
+
+export const competitorIntelligenceSchemaTables = [competitorKeywordGaps, competitorPageAudits] as const;

--- a/packages/providers/dataforseo/src/acl/on-page-instant-to-competitor-audit.acl.spec.ts
+++ b/packages/providers/dataforseo/src/acl/on-page-instant-to-competitor-audit.acl.spec.ts
@@ -1,0 +1,195 @@
+import type { AclContext } from '@rankpulse/provider-core';
+import { describe, expect, it } from 'vitest';
+import type { OnPageInstantResponse } from '../endpoints/on-page-instant.js';
+import { mapOnPageToCompetitorAudit } from './on-page-instant-to-competitor-audit.acl.js';
+
+const ctx = (overrides: Partial<AclContext> = {}): AclContext => ({
+	dateBucket: '2026-05-09',
+	systemParams: {
+		scope: 'competitor',
+		competitorDomain: 'rondacontrol.es',
+		projectId: 'pppppppp-pppp-pppp-pppp-pppppppppppp',
+		url: 'https://rondacontrol.es/landing',
+	},
+	endpointParams: { url: 'https://rondacontrol.es/landing' },
+	...overrides,
+});
+
+// The helper's `OnPageInstantResponse` only types the most-used fields; the
+// fixture exercises the wider documented shape (schema_org, htags, content,
+// page_timing, …) that the ACL reads via the `ExtraOnPageFields` cast. We
+// build it as `unknown` and assert at the call site.
+const fixture = {
+	status_code: 20000,
+	status_message: 'Ok.',
+	tasks: [
+		{
+			status_code: 20000,
+			status_message: 'Ok.',
+			// `time` is read defensively — typing it as a non-declared property
+			// here exercises the cast in the ACL.
+			...{ time: '2026-05-09 05:55:00 +00:00' },
+			result: [
+				{
+					items: [
+						{
+							url: 'https://rondacontrol.es/landing',
+							status_code: 200,
+							meta: {
+								title: 'Competitor landing',
+								description: 'Best app',
+								canonical: 'https://rondacontrol.es/landing',
+								htags: { h1: ['Welcome'], h2: ['a', 'b', 'c'], h3: ['x', 'y'] },
+								internal_links_count: 33,
+								external_links_count: 5,
+								hreflang_languages: ['es', 'en'],
+								og_tags: { 'og:title': 't', 'og:image': 'i' },
+							},
+							page_timing: {
+								largest_contentful_paint: 2_100,
+								duration_time: 432,
+								ttfb: 180,
+							},
+							content: { plain_text_word_count: 1250, plain_text_size: 8_500 },
+							checks: {
+								is_https: true,
+								is_javascript: true,
+								has_amp: false,
+								cumulative_layout_shift: 0.05,
+							},
+							schema_org: [{ '@type': 'Organization' }, { '@type': 'WebSite' }],
+							size: 89_000,
+							dom_size: 850,
+							status_message: 'OK',
+						},
+					],
+				},
+			],
+		},
+	],
+} as unknown as OnPageInstantResponse;
+
+describe('mapOnPageToCompetitorAudit', () => {
+	it('returns ONE fat row when scope is "competitor"', () => {
+		const rows = mapOnPageToCompetitorAudit(fixture, ctx());
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			statusCode: 200,
+			statusMessage: 'OK',
+			title: 'Competitor landing',
+			metaDescription: 'Best app',
+			h1: 'Welcome',
+			h2Count: 3,
+			h3Count: 2,
+			wordCount: 1250,
+			plainTextSizeBytes: 8_500,
+			internalLinksCount: 33,
+			externalLinksCount: 5,
+			hasSchemaOrg: true,
+			schemaTypes: ['Organization', 'WebSite'],
+			canonicalUrl: 'https://rondacontrol.es/landing',
+			lcpMs: 2_100,
+			cls: 0.05,
+			ttfbMs: 180,
+			domSize: 850,
+			isAmp: false,
+			isJavascript: true,
+			isHttps: true,
+			hreflangCount: 2,
+			ogTagsCount: 2,
+			pageSizeBytes: 89_000,
+			fetchTimeMs: 432,
+			redirectUrl: null,
+		});
+		expect(rows[0]?.observedAtProvider).toBeInstanceOf(Date);
+	});
+
+	it('returns [] when scope is not "competitor" (own / absent)', () => {
+		expect(mapOnPageToCompetitorAudit(fixture, ctx({ systemParams: { scope: 'own' } }))).toEqual([]);
+		expect(mapOnPageToCompetitorAudit(fixture, ctx({ systemParams: { url: 'https://x.com' } }))).toEqual([]);
+	});
+
+	it('throws when systemParams.competitorDomain is missing under scope=competitor', () => {
+		expect(() =>
+			mapOnPageToCompetitorAudit(
+				fixture,
+				ctx({
+					systemParams: {
+						scope: 'competitor',
+						projectId: 'pppppppp-pppp-pppp-pppp-pppppppppppp',
+						url: 'https://x',
+					},
+				}),
+			),
+		).toThrow(/competitorDomain/);
+	});
+
+	it('throws when systemParams.projectId is missing under scope=competitor', () => {
+		expect(() =>
+			mapOnPageToCompetitorAudit(
+				fixture,
+				ctx({
+					systemParams: {
+						scope: 'competitor',
+						competitorDomain: 'x.es',
+						url: 'https://x',
+					},
+				}),
+			),
+		).toThrow(/projectId/);
+	});
+
+	it('throws when systemParams.url is missing under scope=competitor', () => {
+		expect(() =>
+			mapOnPageToCompetitorAudit(
+				fixture,
+				ctx({
+					systemParams: {
+						scope: 'competitor',
+						competitorDomain: 'x.es',
+						projectId: 'pppppppp-pppp-pppp-pppp-pppppppppppp',
+					},
+				}),
+			),
+		).toThrow(/url/);
+	});
+
+	it('handles a payload missing the optional fields without throwing', () => {
+		const minimal: OnPageInstantResponse = {
+			status_code: 20000,
+			status_message: 'Ok.',
+			tasks: [
+				{
+					status_code: 20000,
+					status_message: 'Ok.',
+					result: [{ items: [{ url: 'https://x', status_code: 301 }] }],
+				},
+			],
+		};
+		const rows = mapOnPageToCompetitorAudit(minimal, ctx());
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			statusCode: 301,
+			title: null,
+			metaDescription: null,
+			h1: null,
+			h2Count: null,
+			schemaTypes: [],
+			hasSchemaOrg: false,
+			lcpMs: null,
+			cls: null,
+		});
+	});
+
+	it('emits a status-only row when DataForSEO returns no items', () => {
+		const empty: OnPageInstantResponse = {
+			status_code: 20000,
+			status_message: 'Ok.',
+			tasks: [{ status_code: 20000, status_message: 'Ok.', result: [{ items: [] }] }],
+		};
+		const rows = mapOnPageToCompetitorAudit(empty, ctx());
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.statusCode).toBeNull();
+		expect(rows[0]?.title).toBeNull();
+	});
+});

--- a/packages/providers/dataforseo/src/acl/on-page-instant-to-competitor-audit.acl.ts
+++ b/packages/providers/dataforseo/src/acl/on-page-instant-to-competitor-audit.acl.ts
@@ -1,0 +1,272 @@
+import type { AclContext } from '@rankpulse/provider-core';
+import { InvalidInputError } from '@rankpulse/shared';
+import type { OnPageInstantResponse, OnPagePageMetrics } from '../endpoints/on-page-instant.js';
+
+/**
+ * Anti-Corruption Layer output: a fat row mirroring the
+ * `competitor_page_audits` hypertable. Every metric column is nullable on
+ * purpose — DataForSEO frequently omits fields when they don't apply (e.g.
+ * `lcp_ms` for non-rendered fetches), and the use case persists what is
+ * available without rejecting the row.
+ */
+export interface CompetitorPageAuditAclRow {
+	statusCode: number | null;
+	statusMessage: string | null;
+	fetchTimeMs: number | null;
+	pageSizeBytes: number | null;
+	title: string | null;
+	metaDescription: string | null;
+	h1: string | null;
+	h2Count: number | null;
+	h3Count: number | null;
+	wordCount: number | null;
+	plainTextSizeBytes: number | null;
+	internalLinksCount: number | null;
+	externalLinksCount: number | null;
+	hasSchemaOrg: boolean | null;
+	schemaTypes: string[];
+	canonicalUrl: string | null;
+	redirectUrl: string | null;
+	lcpMs: number | null;
+	cls: number | null;
+	ttfbMs: number | null;
+	domSize: number | null;
+	isAmp: boolean | null;
+	isJavascript: boolean | null;
+	isHttps: boolean | null;
+	hreflangCount: number | null;
+	ogTagsCount: number | null;
+	observedAtProvider: Date | null;
+}
+
+/**
+ * DataForSEO's `on_page/instant_pages` response is shared between two
+ * scopes: own-domain audits (web-performance BC, future) and competitor
+ * audits (this BC, issue #131). The endpoint manifest carries a single
+ * `IngestBinding`, so the ACL acts as a polymorphic switch keyed off
+ * `ctx.systemParams.scope`:
+ *
+ *   - `scope === 'competitor'`  → emit ONE fat row per fetch (this ACL).
+ *   - anything else (incl. absent or `'own'`) → return `[]` so the row
+ *     never reaches the use case. The raw payload is still stored upstream
+ *     by the processor, so a future web-performance binding could hook into
+ *     a separate manifest entry without restructuring this one.
+ *
+ * `competitorDomain`, `projectId` and `url` are required when scope is
+ * `'competitor'`. The `IngestBinding`'s `systemParamKey` declares `url`
+ * (the router's hard precondition), but the row mapping needs all three —
+ * we throw a clear `InvalidInputError` if any is missing so a misconfigured
+ * schedule fails loudly instead of silently inserting a partial row.
+ */
+export const mapOnPageToCompetitorAudit = (
+	response: OnPageInstantResponse,
+	ctx: AclContext,
+): CompetitorPageAuditAclRow[] => {
+	const scope = ctx.systemParams.scope;
+	if (scope !== 'competitor') {
+		// Not a competitor-scoped fetch — nothing to ingest into this BC.
+		return [];
+	}
+	const competitorDomain = ctx.systemParams.competitorDomain;
+	const projectId = ctx.systemParams.projectId;
+	const url = ctx.systemParams.url;
+	if (typeof competitorDomain !== 'string' || competitorDomain.trim() === '') {
+		throw new InvalidInputError(
+			'on-page-instant ACL (competitor scope) requires `systemParams.competitorDomain`. ' +
+				'A schedule without it is misconfigured.',
+		);
+	}
+	if (typeof projectId !== 'string' || projectId.trim() === '') {
+		throw new InvalidInputError(
+			'on-page-instant ACL (competitor scope) requires `systemParams.projectId`. ' +
+				'A schedule without it is misconfigured.',
+		);
+	}
+	if (typeof url !== 'string' || url.trim() === '') {
+		throw new InvalidInputError(
+			'on-page-instant ACL (competitor scope) requires `systemParams.url`. ' +
+				'A schedule without it is misconfigured.',
+		);
+	}
+
+	const task = response.tasks?.[0];
+	const item = task?.result?.[0]?.items?.[0];
+	// `time` is documented on every DataForSEO task envelope but isn't typed
+	// in the helper's response interface today. Read it defensively for the
+	// clock-skew column (`observedAtProvider`).
+	const observedAtProviderRaw = (task as { time?: string } | undefined)?.time;
+	if (!item) {
+		// DataForSEO returned an empty result set (e.g. fetch failed before any
+		// metrics were captured). Emit a status-only row so operators still see
+		// "we tried at T". Most fields fall through as null.
+		return [
+			{
+				statusCode: null,
+				statusMessage: null,
+				fetchTimeMs: null,
+				pageSizeBytes: null,
+				title: null,
+				metaDescription: null,
+				h1: null,
+				h2Count: null,
+				h3Count: null,
+				wordCount: null,
+				plainTextSizeBytes: null,
+				internalLinksCount: null,
+				externalLinksCount: null,
+				hasSchemaOrg: null,
+				schemaTypes: [],
+				canonicalUrl: null,
+				redirectUrl: null,
+				lcpMs: null,
+				cls: null,
+				ttfbMs: null,
+				domSize: null,
+				isAmp: null,
+				isJavascript: null,
+				isHttps: null,
+				hreflangCount: null,
+				ogTagsCount: null,
+				observedAtProvider: parseProviderTime(observedAtProviderRaw),
+			},
+		];
+	}
+
+	return [projectItem(item, observedAtProviderRaw)];
+};
+
+// TODO(claude #131): the field paths below mirror the publicly documented
+// DataForSEO `on_page/instant_pages` response shape, but the helper's TS
+// interface only types the most-used keys. The remaining paths are read
+// defensively via `(item as ExtraFields)?.x?.y`. If any path turns out to be
+// wrong post-merge, the raw_payload is preserved so the ACL can be re-run.
+interface ExtraOnPageFields {
+	page_timing?: {
+		time_to_interactive?: number;
+		largest_contentful_paint?: number;
+		dom_complete?: number;
+		time_to_secure_connection?: number;
+		waiting_time?: number;
+		download_time?: number;
+		duration_time?: number;
+		fetch_start?: number;
+		fetch_end?: number;
+		ttfb?: number;
+	};
+	meta?: {
+		title?: string;
+		description?: string;
+		canonical?: string;
+		htags?: { h1?: string[]; h2?: string[]; h3?: string[] };
+		internal_links_count?: number;
+		external_links_count?: number;
+		images_count?: number;
+		scripts_count?: number;
+		stylesheets_count?: number;
+		content?: { plain_text_word_count?: number; plain_text_size?: number };
+		social_media_tags?: Record<string, string>;
+		hreflang_languages?: string[];
+		og_tags?: Record<string, string>;
+	};
+	content?: {
+		plain_text_word_count?: number;
+		plain_text_size?: number;
+	};
+	checks?: Record<string, boolean | undefined> & {
+		is_https?: boolean;
+		canonical?: boolean;
+		has_amp?: boolean;
+		is_javascript?: boolean;
+		cumulative_layout_shift?: number;
+	};
+	cumulative_layout_shift?: number;
+	largest_contentful_paint?: number;
+	total_dom_size?: number;
+	dom_size?: number;
+	size?: number;
+	media_type?: string;
+	server?: string;
+	url_redirect?: string;
+	location?: string;
+	fetch_time?: string;
+	status_message?: string;
+	is_javascript?: boolean;
+	is_amp?: boolean;
+	schema_org?: Array<{ '@type'?: string; type?: string }>;
+}
+
+const projectItem = (
+	rawItem: OnPagePageMetrics,
+	providerTime: string | undefined,
+): CompetitorPageAuditAclRow => {
+	const item = rawItem as OnPagePageMetrics & ExtraOnPageFields;
+	const meta = item.meta;
+	const htags = meta?.htags;
+	const content = item.content ?? meta?.content;
+	const timing = item.page_timing;
+	const schemaOrg = Array.isArray(item.schema_org) ? item.schema_org : [];
+	const schemaTypeSet = new Set<string>();
+	for (const entry of schemaOrg) {
+		const t = entry?.['@type'] ?? entry?.type;
+		if (typeof t === 'string' && t.trim() !== '') schemaTypeSet.add(t);
+	}
+	const schemaTypes = [...schemaTypeSet];
+	const checks = item.checks ?? {};
+	const statusCode = numberOrNull(item.status_code);
+	const isRedirect = typeof statusCode === 'number' && statusCode >= 300 && statusCode < 400;
+	const url = item.url ?? '';
+	const isHttps =
+		typeof checks.is_https === 'boolean'
+			? checks.is_https
+			: url.length > 0
+				? url.startsWith('https://')
+				: null;
+
+	return {
+		statusCode,
+		statusMessage: typeof item.status_message === 'string' ? item.status_message : null,
+		fetchTimeMs: numberOrNull(timing?.duration_time ?? timing?.dom_complete),
+		pageSizeBytes: numberOrNull(item.size),
+		title: nonEmptyString(meta?.title),
+		metaDescription: nonEmptyString(meta?.description),
+		h1: nonEmptyString(htags?.h1?.[0]),
+		h2Count: arrayLengthOrNull(htags?.h2),
+		h3Count: arrayLengthOrNull(htags?.h3),
+		wordCount: numberOrNull(content?.plain_text_word_count),
+		plainTextSizeBytes: numberOrNull(content?.plain_text_size),
+		internalLinksCount: numberOrNull(meta?.internal_links_count),
+		externalLinksCount: numberOrNull(meta?.external_links_count),
+		hasSchemaOrg: schemaTypes.length > 0,
+		schemaTypes,
+		canonicalUrl: nonEmptyString(meta?.canonical),
+		redirectUrl: isRedirect ? nonEmptyString(item.url_redirect ?? item.location) : null,
+		lcpMs: numberOrNull(timing?.largest_contentful_paint ?? item.largest_contentful_paint),
+		cls: numberOrNull(checks.cumulative_layout_shift ?? item.cumulative_layout_shift),
+		ttfbMs: numberOrNull(timing?.ttfb ?? timing?.waiting_time),
+		domSize: numberOrNull(item.dom_size ?? item.total_dom_size),
+		isAmp: typeof checks.has_amp === 'boolean' ? checks.has_amp : booleanOrNull(item.is_amp),
+		isJavascript:
+			typeof checks.is_javascript === 'boolean' ? checks.is_javascript : booleanOrNull(item.is_javascript),
+		isHttps,
+		hreflangCount: arrayLengthOrNull(meta?.hreflang_languages),
+		ogTagsCount: meta?.og_tags ? Object.keys(meta.og_tags).length : null,
+		observedAtProvider: parseProviderTime(providerTime),
+	};
+};
+
+const numberOrNull = (v: number | null | undefined): number | null =>
+	typeof v === 'number' && Number.isFinite(v) ? v : null;
+
+const booleanOrNull = (v: boolean | null | undefined): boolean | null => (typeof v === 'boolean' ? v : null);
+
+const nonEmptyString = (v: string | null | undefined): string | null =>
+	typeof v === 'string' && v.trim() !== '' ? v : null;
+
+const arrayLengthOrNull = (v: readonly unknown[] | null | undefined): number | null =>
+	Array.isArray(v) ? v.length : null;
+
+const parseProviderTime = (raw: string | undefined): Date | null => {
+	if (typeof raw !== 'string' || raw.trim() === '') return null;
+	const t = Date.parse(raw);
+	return Number.isNaN(t) ? null : new Date(t);
+};

--- a/packages/providers/dataforseo/src/index.ts
+++ b/packages/providers/dataforseo/src/index.ts
@@ -1,5 +1,6 @@
 export * from './acl/backlinks-summary.acl.js';
 export * from './acl/domain-intersection-to-domain.acl.js';
+export * from './acl/on-page-instant-to-competitor-audit.acl.js';
 export * from './acl/ranked-keywords-to-domain.acl.js';
 export * from './acl/serp-to-ranking.acl.js';
 export * from './credential.js';

--- a/packages/providers/dataforseo/src/manifest.ts
+++ b/packages/providers/dataforseo/src/manifest.ts
@@ -7,6 +7,7 @@ import type {
 import { InvalidInputError } from '@rankpulse/shared';
 import { summariseBacklinksResponse } from './acl/backlinks-summary.acl.js';
 import { normaliseDomainIntersectionResponse } from './acl/domain-intersection-to-domain.acl.js';
+import { mapOnPageToCompetitorAudit } from './acl/on-page-instant-to-competitor-audit.acl.js';
 import { normaliseRankedKeywordsResponse } from './acl/ranked-keywords-to-domain.acl.js';
 import { parseCredential } from './credential.js';
 import {
@@ -31,7 +32,11 @@ import {
 	keywordsDataSearchVolumeDescriptor,
 } from './endpoints/keywords-data-search-volume.js';
 import { fetchKeywordsForSite, keywordsForSiteDescriptor } from './endpoints/keywords-for-site.js';
-import { fetchOnPageInstantPages, onPageInstantDescriptor } from './endpoints/on-page-instant.js';
+import {
+	fetchOnPageInstantPages,
+	type OnPageInstantResponse,
+	onPageInstantDescriptor,
+} from './endpoints/on-page-instant.js';
 import { fetchPageIntersection, pageIntersectionDescriptor } from './endpoints/page-intersection.js';
 import {
 	fetchRankedKeywords,
@@ -127,6 +132,28 @@ const competitorIntelligenceDomainIntersectionIngest: IngestBinding<DomainInters
 	acl: normaliseDomainIntersectionResponse,
 };
 
+/**
+ * Issue #131: typed ingest binding for the `on_page/instant_pages` endpoint
+ * extended to audit COMPETITOR URLs (not only own URLs). The ACL is
+ * polymorphic, gated on `ctx.systemParams.scope`:
+ *   - `scope === 'competitor'` → emit ONE fat row that flows into the
+ *     `competitor_page_audits` hypertable via
+ *     `IngestCompetitorPageAuditUseCase`.
+ *   - anything else (`'own'`, absent, …) → return `[]` so the row never
+ *     reaches the use case. The raw_payload is still stored upstream by the
+ *     processor, so a future web-performance binding for own-domain audits
+ *     can be attached without restructuring this manifest entry.
+ *
+ * `systemParamKey` is `url` (the router's hard precondition); the ACL
+ * additionally validates `competitorDomain` and `projectId` from
+ * `ctx.systemParams` and throws `InvalidInputError` on misconfiguration.
+ */
+const competitorIntelligenceCompetitorPageAuditIngest: IngestBinding<OnPageInstantResponse> = {
+	useCaseKey: 'competitor-intelligence:ingest-competitor-page-audit',
+	systemParamKey: 'url',
+	acl: mapOnPageToCompetitorAudit,
+};
+
 const endpoints: readonly EndpointManifest[] = [
 	{
 		descriptor: serpGoogleOrganicLiveDescriptor,
@@ -206,7 +233,13 @@ const endpoints: readonly EndpointManifest[] = [
 	{
 		descriptor: onPageInstantDescriptor,
 		fetch: adapt(fetchOnPageInstantPages),
-		ingest: null,
+		// Issue #131: ACL polymorphic on `systemParams.scope`. Emits a row
+		// only when `scope === 'competitor'` (routed to
+		// `IngestCompetitorPageAuditUseCase`); returns `[]` for `'own'` /
+		// absent so the binding is a no-op for other scopes. Web-performance
+		// can attach its own binding later (different `useCaseKey`) for
+		// `scope === 'own'` if/when an own-domain audit BC is wired.
+		ingest: competitorIntelligenceCompetitorPageAuditIngest as IngestBinding,
 	},
 	{
 		descriptor: backlinksSummaryDescriptor,

--- a/packages/sdk/src/resources/competitor-intelligence.ts
+++ b/packages/sdk/src/resources/competitor-intelligence.ts
@@ -17,4 +17,17 @@ export class CompetitorIntelligenceResource {
 			},
 		});
 	}
+
+	getCompetitorPageAudits(
+		projectId: string,
+		query: CompetitorIntelligenceContracts.CompetitorPageAuditsQuery,
+	): Promise<CompetitorIntelligenceContracts.CompetitorPageAuditsResponse> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/competitor-page-audits`, {
+			query: {
+				competitorDomain: query.competitorDomain,
+				url: query.url ?? null,
+				limit: query.limit ? String(query.limit) : null,
+			},
+		});
+	}
 }

--- a/packages/testing/src/in-memory/in-memory-competitor-page-audit-repository.ts
+++ b/packages/testing/src/in-memory/in-memory-competitor-page-audit-repository.ts
@@ -1,0 +1,50 @@
+import type { CompetitorIntelligence, ProjectManagement } from '@rankpulse/domain';
+
+/**
+ * Mirrors the Drizzle repo contract for `competitor_page_audits`. Rows are
+ * kept in insertion order; `listLatestForCompetitor`:
+ *   - With `opts.url`: returns the single most recent audit for that URL.
+ *   - Without `opts.url`: returns one row per URL — the most recent audit
+ *     for each — ordered by observed_at DESC.
+ */
+export class InMemoryCompetitorPageAuditRepository
+	implements CompetitorIntelligence.CompetitorPageAuditRepository
+{
+	rows: CompetitorIntelligence.CompetitorPageAudit[] = [];
+
+	async saveAll(
+		audits: readonly CompetitorIntelligence.CompetitorPageAudit[],
+	): Promise<{ inserted: number }> {
+		this.rows.push(...audits);
+		return { inserted: audits.length };
+	}
+
+	async listLatestForCompetitor(
+		projectId: ProjectManagement.ProjectId,
+		competitorDomain: string,
+		opts: CompetitorIntelligence.ListCompetitorPageAuditsOptions = {},
+	): Promise<readonly CompetitorIntelligence.CompetitorPageAudit[]> {
+		const candidates = this.rows.filter(
+			(r) => r.projectId === projectId && r.competitorDomain === competitorDomain,
+		);
+		if (candidates.length === 0) return [];
+		const limit = opts.limit ?? 500;
+		if (opts.url != null) {
+			const forUrl = candidates.filter((r) => r.url === opts.url);
+			if (forUrl.length === 0) return [];
+			const latest = forUrl.reduce((acc, r) => (r.observedAt.getTime() > acc.observedAt.getTime() ? r : acc));
+			return [latest];
+		}
+		// Latest per URL.
+		const byUrl = new Map<string, CompetitorIntelligence.CompetitorPageAudit>();
+		for (const r of candidates) {
+			const prev = byUrl.get(r.url);
+			if (!prev || r.observedAt.getTime() > prev.observedAt.getTime()) {
+				byUrl.set(r.url, r);
+			}
+		}
+		return [...byUrl.values()]
+			.sort((a, b) => b.observedAt.getTime() - a.observedAt.getTime())
+			.slice(0, limit);
+	}
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -8,6 +8,7 @@ export * from './in-memory/fake-password-hasher.js';
 export * from './in-memory/in-memory-api-token-repository.js';
 export * from './in-memory/in-memory-brand-prompt-repository.js';
 export * from './in-memory/in-memory-competitor-keyword-gap-repository.js';
+export * from './in-memory/in-memory-competitor-page-audit-repository.js';
 export * from './in-memory/in-memory-competitor-repository.js';
 export * from './in-memory/in-memory-gsc-performance-observation-repository.js';
 export * from './in-memory/in-memory-keyword-list-repository.js';


### PR DESCRIPTION
## Summary

Extends DataForSEO `on_page/instant_pages` to audit competitor URLs via a polymorphic ACL keyed off `systemParams.scope`, and persists a FAT snapshot in a new `competitor_page_audits` hypertable inside the `competitor-intelligence` BC. The fat schema captures status, on-page SEO, page metrics, Core Web Vitals, and structured-data signals — enough for the Page Audits Diff tab in #132 and for any future "compare our URL vs theirs" read model.

`Closes #131`

> Note: issue #131's body is truncated on GitHub (cuts at `extraer:\n- \``). The full agreed scope was discussed in-session and pinned as a comment on issue #131; this PR implements that.

## What landed

| Layer | Change |
|---|---|
| **Provider** | New ACL `mapOnPageToCompetitorAudit`. Reads `systemParams.scope`: emits ONE row when `scope === 'competitor'`, else returns `[]` so the row never reaches the use case. Validates `competitorDomain` + `projectId` + `url` with `InvalidInputError` if any is missing. Manifest entry for `on-page-instant` now carries an `IngestBinding`; the previous `ingest: null` is replaced — but with the polymorphism guard, future web-performance `scope === 'own'` audits can attach their own binding via a separate manifest entry without restructuring this one. |
| **Domain (extends BC)** | `CompetitorPageAudit` aggregate (passive observation, no events) + `CompetitorPageAuditRepository` port + `CompetitorPageAuditId` VO. Inline comments document the "raw_payloads holds the full response, ACL is re-runnable for backfills" architecture. |
| **Application** | `IngestCompetitorPageAuditUseCase` (validates project, persists one row) + `QueryCompetitorPageAuditsUseCase` (returns latest single audit when `url` is given, otherwise latest-per-url across the competitor). Specs cover scope-guard, missing systemParams, project-not-found, latest-per-url. |
| **Infrastructure** | Hypertable `competitor_page_audits` with **33 fat columns** (status, page metrics, on-page SEO, Core Web Vitals, structured data, audit trail). Retention 13mo, chunk 30d. PK `(observed_at, project_id, competitor_domain, url)`. Idempotent FK cascade on `project_id`. Migration **0020** (idx 19 was already taken by #135). |
| **API** | `GET /api/v1/projects/:projectId/competitor-page-audits?competitorDomain=&url=&limit=`. OpenAPI tag `competitor-intelligence`. Latest-snapshot semantics. |
| **SDK** | New `getCompetitorPageAudits` method. |

28 files changed, 1691 insertions(+), 3 deletions(-).

## Design rationale

- **Polymorphic ACL** chosen over (a) attaching ingest to a duplicated descriptor or (b) splitting the endpoint. Reasons:
  - **Escalable**: any future `scope` value (`'partner'`, `'benchmark'`) is one ACL branch away, no manifest restructuring.
  - **Reprocessable**: `raw_payloads` is preserved 100% by the upstream pipeline. If we add a new column to the table later (e.g. `mobile_score`), a script re-runs the ACL against historical raw_payloads and backfills — no re-fetch required.
  - **Backwards-safe**: the ACL emits `[]` for unknown scopes, so `web-performance` can later attach a sibling `IngestBinding` for `scope === 'own'` without breaking either path.
- **FAT table** rather than narrow + jsonb: PG TOAST handles wide rows fine, and explicit columns are cheaper to query (typed indexes, no jsonb extraction). The full raw is in `raw_payloads` for any future field we forgot.
- **Empty-result safety**: when DataForSEO returns no items the ACL still emits one status-only row (operator visibility into "we tried at T") rather than `[]`. Documented inline.
- **Auto-register out of scope**: same deferred pattern as #127/#128. Operator schedules each URL today with `systemParams: { scope: 'competitor', competitorDomain, projectId, url }`. Auto-registration from `ranked_keywords` top-N is a follow-up.

## TODO markers in code

- One `// TODO(claude #131):` in `on-page-instant-to-competitor-audit.acl.ts` flagging defensive reads of DataForSEO field paths (`page_timing.duration_time/ttfb`, `total_dom_size`, `url_redirect/location`, `schema_org` shape) because the helper's existing TS interface only types the most-used keys. The raw_payload preserves the response so the ACL is re-runnable for backfills if any path turns out wrong post-merge.

## Test plan

- [x] `pnpm --filter @rankpulse/provider-dataforseo test` — 60/60 passing (4 new for #131 ACL)
- [x] `pnpm --filter @rankpulse/domain test:unit` — 26/26
- [x] `pnpm --filter @rankpulse/application test:unit` — 386/386 (4 new specs for ingest + query)
- [x] `pnpm typecheck` — 27/27 packages
- [x] `pnpm lint` — clean (2 pre-existing warnings from #135 unrelated to this PR)
- [ ] Manual: schedule one audit for a known competitor URL once credentials are loaded → verify a row lands in `competitor_page_audits` and `GET /projects/:id/competitor-page-audits` returns it.

## Follow-ups

- #132 — Competitor Intelligence web page (now has Page Audits Diff data).
- Auto-register competitor URLs from `ranked_keywords` top-N (single follow-up that also covers #127/#128 auto-schedule deferral).
- web-performance binding for `scope === 'own'` if/when PSI tracked-pages audit migrates onto this same DataForSEO endpoint.

https://claude.ai/code/session_01Hwqfg7H4YqtaMA7Cfrg9UN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwqfg7H4YqtaMA7Cfrg9UN)_