### PR TITLE
fix(ingest): stamp projectId so worker handlers can scope rows (#147)

### DIFF
--- a/apps/web/src/components/competitor-intelligence/top-pages-tab.tsx
+++ b/apps/web/src/components/competitor-intelligence/top-pages-tab.tsx
@@ -105,7 +105,6 @@ export const TopPagesTab = ({ projectId, competitors }: TopPagesTabProps) => {
 		// queries reference is stable per render but `data` is what matters.
 		// Stringify the data fingerprint to avoid stale memos when one query
 		// finishes after another. Length+last-update is enough.
-		// biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
 	}, [
 		competitors,
 		queries.map((q) => q.dataUpdatedAt).join(','),

--- a/apps/web/src/pages/cockpit.page.tsx
+++ b/apps/web/src/pages/cockpit.page.tsx
@@ -1,5 +1,4 @@
 import {
-	Badge,
 	Button,
 	Card,
 	CardContent,
@@ -16,7 +15,6 @@ import {
 	Activity,
 	AlertTriangle,
 	ArrowLeft,
-	BarChart3,
 	CheckCircle2,
 	ChevronRight,
 	Compass,

--- a/apps/worker/src/processors/ingest-router.spec.ts
+++ b/apps/worker/src/processors/ingest-router.spec.ts
@@ -106,7 +106,10 @@ describe('IngestRouter.dispatch', () => {
 			endpointId: 'fake-endpoint',
 			fetchResult: {},
 			rawPayloadId: 'rp-1',
-			definition: { params: { fakeId: 'x', projectId: 'param-project' }, projectId: 'entity-project' } as never,
+			definition: {
+				params: { fakeId: 'x', projectId: 'param-project' },
+				projectId: 'entity-project',
+			} as never,
 			dateBucket: '2026-05-06',
 		});
 

--- a/apps/worker/src/processors/ingest-router.spec.ts
+++ b/apps/worker/src/processors/ingest-router.spec.ts
@@ -29,22 +29,24 @@ describe('IngestRouter.dispatch', () => {
 			endpointId: 'fake-endpoint',
 			fetchResult: { ok: true },
 			rawPayloadId: 'rp-1',
-			definition: { params: { fakeId: 'entity-1', siteUrl: 'x' } } as never,
+			definition: { params: { fakeId: 'entity-1', siteUrl: 'x' }, projectId: 'project-77' } as never,
 			dateBucket: '2026-05-06',
 		});
 
 		expect(handled).toBe(true);
+		// Router stamps `projectId` from the JobDefinition entity into the
+		// systemParams passed to ACL + ingest (defence-in-depth for #147).
 		expect(acl).toHaveBeenCalledWith(
 			{ ok: true },
 			expect.objectContaining({
 				dateBucket: '2026-05-06',
-				systemParams: { fakeId: 'entity-1', siteUrl: 'x' },
+				systemParams: { fakeId: 'entity-1', siteUrl: 'x', projectId: 'project-77' },
 			}),
 		);
 		expect(execute).toHaveBeenCalledWith({
 			rawPayloadId: 'rp-1',
 			rows: [{ row: 1 }],
-			systemParams: { fakeId: 'entity-1', siteUrl: 'x' },
+			systemParams: { fakeId: 'entity-1', siteUrl: 'x', projectId: 'project-77' },
 		});
 	});
 
@@ -90,6 +92,29 @@ describe('IngestRouter.dispatch', () => {
 				dateBucket: '2026-05-06',
 			}),
 		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('preserves params.projectId when already present (does not overwrite with definition.projectId)', async () => {
+		const { acl, execute, ingest } = buildEntry();
+		const entries = new Map<RouterKey, IngestRouterEntry>([
+			['fake|fake-endpoint', { systemParamKey: 'fakeId', acl, ingest }],
+		]);
+		const router = new IngestRouter(entries);
+
+		await router.dispatch({
+			providerId: 'fake',
+			endpointId: 'fake-endpoint',
+			fetchResult: {},
+			rawPayloadId: 'rp-1',
+			definition: { params: { fakeId: 'x', projectId: 'param-project' }, projectId: 'entity-project' } as never,
+			dateBucket: '2026-05-06',
+		});
+
+		expect(execute).toHaveBeenCalledWith(
+			expect.objectContaining({
+				systemParams: expect.objectContaining({ projectId: 'param-project' }),
+			}),
+		);
 	});
 });
 

--- a/apps/worker/src/processors/ingest-router.ts
+++ b/apps/worker/src/processors/ingest-router.ts
@@ -57,16 +57,26 @@ export class IngestRouter {
 			);
 		}
 
+		// Defence-in-depth for #147: even if the schedule path forgot to stamp
+		// `projectId` (legacy defs created before the schedule use case fix),
+		// inject it here from the entity column. Worker ingest handlers like
+		// `rank-tracking:ingest-ranked-keywords` short-circuit silently when
+		// `systemParams.projectId` is missing, so the row would be lost.
+		const systemParamsWithEntityScope: Record<string, unknown> = {
+			...params,
+			projectId: (params.projectId as string | undefined) ?? input.definition.projectId,
+		};
+
 		const rows = entry.acl(input.fetchResult, {
 			dateBucket: input.dateBucket,
-			systemParams: params,
+			systemParams: systemParamsWithEntityScope,
 			endpointParams: params,
 		});
 
 		await entry.ingest.execute({
 			rawPayloadId: input.rawPayloadId,
 			rows,
-			systemParams: params,
+			systemParams: systemParamsWithEntityScope,
 		});
 		return true;
 	}

--- a/packages/application/src/project-management/use-cases/record-competitor-backlinks-profile.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/record-competitor-backlinks-profile.use-case.spec.ts
@@ -4,7 +4,6 @@ import { InMemoryCompetitorRepository } from '@rankpulse/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { RecordCompetitorBacklinksProfileUseCase } from './record-competitor-backlinks-profile.use-case.js';
 
-const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
 const COMP_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ProjectManagement.CompetitorId;
 const OBS_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd' as Uuid;

--- a/packages/application/src/project-management/use-cases/record-competitor-backlinks-profile.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/record-competitor-backlinks-profile.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { type IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ProjectManagement } from '@rankpulse/domain';
 import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
 import { InMemoryCompetitorRepository } from '@rankpulse/testing';
 import { beforeEach, describe, expect, it } from 'vitest';

--- a/packages/application/src/project-management/use-cases/record-competitor-wayback-snapshot.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/record-competitor-wayback-snapshot.use-case.spec.ts
@@ -4,7 +4,6 @@ import { InMemoryCompetitorRepository } from '@rankpulse/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { RecordCompetitorWaybackSnapshotUseCase } from './record-competitor-wayback-snapshot.use-case.js';
 
-const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
 const COMP_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ProjectManagement.CompetitorId;
 const OBS_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd' as Uuid;

--- a/packages/application/src/project-management/use-cases/record-competitor-wayback-snapshot.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/record-competitor-wayback-snapshot.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { type IdentityAccess, ProjectManagement } from '@rankpulse/domain';
+import { ProjectManagement } from '@rankpulse/domain';
 import { FakeClock, FixedIdGenerator, NotFoundError, type Uuid } from '@rankpulse/shared';
 import { InMemoryCompetitorRepository } from '@rankpulse/testing';
 import { beforeEach, describe, expect, it } from 'vitest';

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
@@ -129,6 +129,9 @@ describe('ScheduleEndpointFetchUseCase', () => {
 			keyword: 'k',
 			organizationId: ORG_ID,
 			trackedKeywordId: TRACKED_KW_ID,
+			// #147: projectId is unconditionally stamped so the worker IngestRouter
+			// can scope persisted rows even when the caller did not pass it.
+			projectId: PROJECT_ID,
 		});
 	});
 

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
@@ -77,7 +77,17 @@ export class ScheduleEndpointFetchUseCase {
 			if (existing) return { definitionId: existing.id };
 		}
 
-		const finalParams: Record<string, unknown> = { ...validatedParams, ...(cmd.systemParams ?? {}) };
+		// `projectId` is stamped here unconditionally so the worker IngestRouter
+		// path can scope persisted rows to the right project even when the
+		// caller (auto-schedule handler or direct API) did not include it in
+		// `cmd.systemParams`. Centralising this avoids the silent skip
+		// (`logger.warn + return`) the worker handlers do when the systemParam
+		// is missing — see #147.
+		const finalParams: Record<string, unknown> = {
+			...validatedParams,
+			...(cmd.systemParams ?? {}),
+			projectId: projectId as unknown as string,
+		};
 
 		const id = this.ids.generate() as ProviderConnectivity.ProviderJobDefinitionId;
 		const definition = ProviderConnectivity.ProviderJobDefinition.schedule({


### PR DESCRIPTION
## Causa raíz #147

Los runs DataForSEO labs (ranked-keywords, domain-intersection, page-intersection, historical-serps) terminan `status: succeeded` con `rawPayloadId` poblado pero **0 filas en las tablas read-model**. Investigación de código revela:

1. Worker handler `rank-tracking:ingest-ranked-keywords` (apps/worker/src/main.ts:420) hace:
```ts
const projectId = systemParams.projectId as string | undefined;
if (!projectId || !targetDomain) {
  logger.warn(..., 'skipped: missing projectId or targetDomain');
  return; // ← silencioso
}
```
2. `ScheduleEndpointFetchUseCase` mergea `validatedParams + systemParams` en `definition.params` pero **nunca stampa `projectId`**.
3. La ruta manual del controller (`POST /endpoints/:id/schedule`) fuerza `organizationId` desde el proyecto pero **no `projectId`**.
4. Auto-schedule core (`packages/application/src/_core/auto-schedule.ts`) lee `event.projectId` para llamar al use case, pero el `systemParamsBuilder` de cada contexto solo stampa la FK (gscPropertyId, ga4PropertyId, etc.), no el projectId.

Resultado: las 51 job-defs PatrolTech que activé hoy con `systemParams.targetDomain` correctos pasan el guard de IngestRouter, llaman al ACL OK, llegan al worker handler — y el handler hace `return` silencioso porque `systemParams.projectId` no existe. El run se marca succeeded, no se loguea error visible al operador.

Cierra **#147** y debería desbloquear datos también para los endpoints SPA `/keyword-gaps`, `/ranked-keywords`, `/competitor-page-audits`, y los widgets Cockpit que dependen de estas tablas.

Probable también que **#151** (runs <0.5s) sea consecuencia: si el handler hace `return` antes de la persistencia, no hay JSON parse de un payload de 1MB → todo el job se cierra en milisegundos. Hay que verificar logs PM2 post-deploy para confirmar.

## Fix dos capas

**1. `ScheduleEndpointFetchUseCase.execute`**
```ts
const finalParams: Record<string, unknown> = {
  ...validatedParams,
  ...(cmd.systemParams ?? {}),
  projectId: projectId as unknown as string,  // ← NEW
};
```
Cualquier def nueva (auto-schedule + manual API) hereda projectId.

**2. `IngestRouter.dispatch` (defence-in-depth)**
```ts
const systemParamsWithEntityScope = {
  ...params,
  projectId: (params.projectId as string | undefined) ?? input.definition.projectId,
};
```
Cubre las 51 defs ya en BD sin migración destructiva. Si `params.projectId` ya existe, no lo sobreescribe.

## Tests

- `ingest-router.spec.ts`: el happy path ahora valida que projectId del entity se stamps en systemParams pasados a ACL/ingest. Test nuevo verifica que `params.projectId` no se sobreescribe cuando ya existe.
- `schedule-endpoint-fetch.use-case.spec.ts`: el `toMatchObject` valida que projectId queda persistido en `repo.saved[0].params`.

## Verificación post-merge

```bash
# 1. Disparar run-now contra una def existente
curl -X POST .../job-definitions/{any-ranked-keywords-def}/run-now -d '{"organizationId":"..."}'

# 2. Esperar 30s
# 3. Confirmar que la tabla tiene filas
SELECT count(*) FROM ranked_keywords_observations WHERE created_at > NOW() - INTERVAL '5 minutes';

# 4. Confirmar SPA
curl .../projects/{id}/ranked-keywords?targetDomain=silvertraconline.com
# → rows: [...]
```

## Bugs detectados como follow-up (no incluidos aquí)

- **#149** PATCH /job-definitions silently drops systemParams (workaround: usar POST /schedule con systemParams en body)
- **#150** processor errors deberían listar todos los systemParams requeridos en un solo error en lugar de descubrirlos uno a uno
- **#142** auto-schedule en Competitor add — sigue pendiente, este PR mitiga pero no reemplaza