### PR TITLE
fix(cockpit): coerce timestamptz to Date in GSC cockpit read model

### DIFF
--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.spec.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.spec.ts
@@ -1,0 +1,68 @@
+import type { ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { DrizzleDatabase } from '../../client.js';
+import { DrizzleGscCockpitReadModel } from './gsc-cockpit-read-model.js';
+
+const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+
+const stubDbReturning = (rows: unknown[]): DrizzleDatabase => {
+	const execute = vi.fn().mockResolvedValue(rows);
+	return { execute } as unknown as DrizzleDatabase;
+};
+
+describe('DrizzleGscCockpitReadModel', () => {
+	// postgres-js (3.4.x) returns timestamptz as ISO strings — not Date —
+	// for raw `db.execute()` queries. The two methods below feed those
+	// values to use cases that call `.toISOString()` / `.getTime()`, so
+	// the repo MUST coerce. Regression guard for issue #148.
+	describe('weeklyClicksByQuery', () => {
+		it('coerces string week_start columns to Date', async () => {
+			const db = stubDbReturning([
+				{ week_start: '2026-04-27 00:00:00+00', query: 'guard tour', clicks: '50', impressions: '1000' },
+				{ week_start: '2026-05-04 00:00:00+00', query: 'patroltech', clicks: '100', impressions: '500' },
+			]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const out = await repo.weeklyClicksByQuery(PROJECT_ID, 28);
+			expect(out).toHaveLength(2);
+			expect(out[0]?.weekStart).toBeInstanceOf(Date);
+			expect(out[0]?.weekStart.toISOString()).toBe('2026-04-27T00:00:00.000Z');
+			expect(out[1]?.weekStart.toISOString()).toBe('2026-05-04T00:00:00.000Z');
+			expect(out[0]?.clicks).toBe(50);
+			expect(out[1]?.impressions).toBe(500);
+		});
+
+		it('passes Date instances through unchanged', async () => {
+			const date = new Date('2026-04-27T00:00:00.000Z');
+			const db = stubDbReturning([{ week_start: date, query: 'q', clicks: 10, impressions: 100 }]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const [row] = await repo.weeklyClicksByQuery(PROJECT_ID, 28);
+			expect(row?.weekStart).toBe(date);
+		});
+	});
+
+	describe('dailyTotalsForProject', () => {
+		it('coerces string day columns to Date', async () => {
+			const db = stubDbReturning([
+				{ day: '2026-04-29 00:00:00+00', clicks: '50', impressions: '1000' },
+				{ day: '2026-05-05 00:00:00+00', clicks: '30', impressions: '800' },
+			]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const out = await repo.dailyTotalsForProject(PROJECT_ID, 90);
+			expect(out).toHaveLength(2);
+			expect(out[0]?.day).toBeInstanceOf(Date);
+			expect(out[0]?.day.toISOString()).toBe('2026-04-29T00:00:00.000Z');
+			expect(out[1]?.day.toISOString()).toBe('2026-05-05T00:00:00.000Z');
+			expect(out[0]?.clicks).toBe(50);
+			expect(out[1]?.impressions).toBe(800);
+		});
+
+		it('handles null clicks/impressions defensively', async () => {
+			const db = stubDbReturning([{ day: '2026-04-29 00:00:00+00', clicks: null, impressions: null }]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const [row] = await repo.dailyTotalsForProject(PROJECT_ID, 90);
+			expect(row?.clicks).toBe(0);
+			expect(row?.impressions).toBe(0);
+		});
+	});
+});

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
@@ -77,7 +77,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 		windowDays: number,
 	): Promise<readonly SearchConsoleInsights.WeeklyClicksByQueryRow[]> {
 		const result = await this.db.execute(sql<{
-			week_start: Date;
+			week_start: string;
 			query: string;
 			clicks: number;
 			impressions: number;
@@ -94,10 +94,15 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 			GROUP BY week_start, query
 			ORDER BY week_start ASC, clicks DESC
 		`);
-		type Row = { week_start: Date; query: string; clicks: number; impressions: number };
+		// postgres-js (3.4.x) returns timestamptz from raw `db.execute()` as
+		// the original ISO string (e.g. `"2026-04-27 00:00:00+00"`), NOT a
+		// Date object — its built-in type parsers only kick in for the
+		// schema-typed query builder. The use case calls `.toISOString()`
+		// on `weekStart`, so we coerce here at the repo boundary.
+		type Row = { week_start: string | Date; query: string; clicks: number; impressions: number };
 		const rows = unwrap<Row>(result);
 		return rows.map((r) => ({
-			weekStart: r.week_start,
+			weekStart: toDate(r.week_start),
 			query: r.query,
 			clicks: Number(r.clicks),
 			impressions: Number(r.impressions),
@@ -113,7 +118,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 		// because the forecast wants TOTAL traffic — including discover-only
 		// / opaque rows GSC returns without a query value.
 		const result = await this.db.execute(sql<{
-			day: Date;
+			day: string;
 			clicks: number;
 			impressions: number;
 		}>`
@@ -127,12 +132,17 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 			GROUP BY day
 			ORDER BY day ASC
 		`);
-		type Row = { day: Date; clicks: number | string | null; impressions: number | string | null };
+		// See `weeklyClicksByQuery` — postgres-js returns timestamptz as a
+		// raw string for `db.execute()` queries; the forecast use case calls
+		// `.getTime()` on `day` so we coerce here.
+		type Row = { day: string | Date; clicks: number | string | null; impressions: number | string | null };
 		const rows = unwrap<Row>(result);
 		return rows.map((r) => ({
-			day: r.day,
+			day: toDate(r.day),
 			clicks: Number(r.clicks ?? 0),
 			impressions: Number(r.impressions ?? 0),
 		}));
 	}
 }
+
+const toDate = (v: string | Date): Date => (v instanceof Date ? v : new Date(v));


### PR DESCRIPTION
Closes #148.

## Summary

`/cockpit/brand-decay` and `/cockpit/forecast-90d` returned **500** in production while their five sibling cockpit endpoints returned 200.

**Root cause:** `postgres-js` 3.4.x returns `timestamptz` columns from raw `db.execute(sql\`...\`)` queries as the underlying ISO string (e.g. `"2026-04-27 00:00:00+00"`), **not** a `Date`. Only the schema-typed query builder applies the date parser. The two affected use cases then call methods on the value:

| Use case | Call | Failure |
|---|---|---|
| `query-brand-decay.use-case.ts:73` | `row.weekStart.toISOString()` | `TypeError` on string |
| `query-clicks-forecast.use-case.ts:122` | `[...rows].sort((a, b) => a.day.getTime() - b.day.getTime())` | `TypeError` on string |

The five working sibling endpoints didn't surface the bug for the reporter's project because the first three return only scalar columns, `competitor-activity` uses a different read path, and `search-demand-trend` only crashes once the project has rank-tracking observations to bucket — same pattern, latent.

**Fix:** coerce `r.week_start` and `r.day` to `Date` at the repo boundary in `DrizzleGscCockpitReadModel.weeklyClicksByQuery` and `dailyTotalsForProject`. The use cases keep their `Date`-shaped domain contract; nothing downstream changes.

## Reproduction

Empirically verified against `postgres-js` + Drizzle by hand:

```text
--- weeklyClicksByQuery (BEFORE) ---
row: { type_week_start: 'string', isDate: false, value: '2026-04-27 00:00:00+00' }

--- weeklyClicksByQuery (AFTER) ---
row: { weekStart isDate=true, iso='2026-04-27T00:00:00.000Z' }
```

## Test plan

- [x] `pnpm typecheck` — green across all 27 packages
- [x] `pnpm test` — 391 + 23 unit tests pass
- [x] `pnpm exec biome check` on changed files — clean
- [x] New `gsc-cockpit-read-model.spec.ts` (4 tests) stubs `db.execute` with the string shape postgres-js actually produces, asserts `weekStart`/`day` come back as `Date`. Includes a regression guard that already-`Date` values pass through unchanged.
- [x] End-to-end manual repro against a real Postgres instance: both methods now return `Date` instances; `.toISOString()` and `.getTime()` succeed.

## Related

The same `string vs Date` mismatch exists in `aggregateMonthlyVolumeForProject` (rank-tracking) — `search-demand-trend` only avoids the crash today because the reporter's project has no ranked-keyword observations yet. Out of scope for this issue; flagging for follow-up.

https://claude.ai/code/session_019kSM3uZZpGpUvoX7bDdfER

---
_Generated by [Claude Code](https://claude.ai/code/session_019kSM3uZZpGpUvoX7bDdfER)_