### PR TITLE
fix(worker): replay ingest on idempotent fetch skip — recovers data after silent #147 (#151)

### DIFF
--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -247,7 +247,29 @@ export class ProviderFetchProcessor {
 		);
 		const existing = await this.deps.rawPayloadRepo.findByRequestHash(requestHash);
 		if (existing) {
-			runLog.info({ requestHash }, 'idempotent skip');
+			// Idempotent fetch skip — but the ingest pipeline still has to run.
+			// Without this, a prior run that silently dropped its rows (e.g.
+			// systemParams missing — see #147) leaves the read-model empty and
+			// every subsequent run-now hits this branch and never re-ingests
+			// because the requestHash already exists. Replaying the cached
+			// payload through the IngestRouter heals that case at zero cost
+			// (no upstream API call). #151
+			try {
+				await this.deps.ingestRouter.dispatch({
+					providerId: definition.providerId.value,
+					endpointId: definition.endpointId.value,
+					fetchResult: existing.payload,
+					rawPayloadId: existing.id,
+					definition,
+					dateBucket,
+				});
+				runLog.info({ requestHash }, 'idempotent skip — replayed ingest from cached payload');
+			} catch (err) {
+				runLog.warn(
+					{ requestHash, err: err instanceof Error ? err.message : String(err) },
+					'idempotent skip — ingest replay failed (raw payload preserved)',
+				);
+			}
 			run.complete(existing.id, this.deps.clock.now());
 			await this.deps.jobRunRepo.save(run);
 			return;


### PR DESCRIPTION
## Causa raíz #151

Después de mergear #152 (projectId fix), los 51 defs DataForSEO labs siguen devolviendo `rows: []` en los endpoints SPA (`/ranked-keywords`, `/keyword-gaps`, etc.). Diagnóstico:

- Run-now de def → `status: succeeded`, `rawPayloadId` IDÉNTICO al de la primera run de hoy, duración 17ms.
- Una llamada real a DataForSEO Labs ranked-keywords con `limit:1000` toma 5-15s, no 17ms.

El processor `provider-fetch.processor.ts:248-254` tiene un guard de idempotencia:

```ts
const existing = await this.deps.rawPayloadRepo.findByRequestHash(requestHash);
if (existing) {
    runLog.info({ requestHash }, 'idempotent skip');
    run.complete(existing.id, this.deps.clock.now());
    await this.deps.jobRunRepo.save(run);
    return;  // ← skips fetch AND ingest
}
```

El `requestHash` se calcula con `(providerId, endpointId, resolvedParams, dateBucket)`. Si ya existe un raw_payload con ese hash hoy → return.

**El problema:** la rama de skip vuelve antes de llegar al `ingestRouter.dispatch(...)` que aparece más abajo en el processor. Entonces:

- Primera run hoy: fetch OK → raw_payload guardado → ingest worker handler hizo `logger.warn + return` silencioso por #147 → tablas vacías
- Run-now después de #152 (deploy 13:35): requestHash hit → skip antes del fetch → IngestRouter NO se llama → tablas siguen vacías

Es decir, el fix de #152 se aplica solo a runs que llegan al fetch — los que tienen cache hit nunca pasan por ahí.

## Fix

En la rama de idempotent skip, llamar a `ingestRouter.dispatch` con el payload cacheado como `fetchResult`. Coste 0 (no hay llamada upstream). Errores se loggean como warning y el run completa de todos modos (mismo status code que antes).

```ts
const existing = await this.deps.rawPayloadRepo.findByRequestHash(requestHash);
if (existing) {
    try {
        await this.deps.ingestRouter.dispatch({
            providerId, endpointId,
            fetchResult: existing.payload,    // ← reuse cached
            rawPayloadId: existing.id,
            definition,
            dateBucket,
        });
        runLog.info({ requestHash }, 'idempotent skip — replayed ingest from cached payload');
    } catch (err) {
        runLog.warn({ requestHash, err: ... }, 'idempotent skip — ingest replay failed');
    }
    run.complete(existing.id, this.deps.clock.now());
    await this.deps.jobRunRepo.save(run);
    return;
}
```

## Beneficio meta

Hace el sistema **self-healing**: cualquier deploy que arregla un bug silencioso de ingest (como #147) ahora recupera datos retroactivamente al siguiente run-now, sin forzar a borrar raw_payloads ni esperar al siguiente dateBucket.

## Verificación post-merge

```bash
# 1. Disparar run-now de cualquier def cacheada
curl -X POST .../job-definitions/{def}/run-now -d '{"organizationId":"..."}'

# 2. Esperar 5s
# 3. Confirmar que la tabla read-model tiene filas
SELECT count(*) FROM ranked_keywords_observations WHERE created_at > NOW() - INTERVAL '5 minutes';

# 4. Confirmar SPA
curl .../projects/{id}/ranked-keywords?targetDomain=silvertraconline.com
# → rows: [...]
```

Cierra **#151**. Junto con #152 desbloquea finalmente los datos de:
- 16 ranked-keywords runs
- 12 domain-intersection runs
- 4 page-intersection runs
- 20 historical-serps runs

Total: 52 runs de los 51 defs PatrolTech recuperarán sus datos sin coste DataForSEO adicional.