### PR TITLE
fix(composition-root): pass autoScheduleSurface to competitor-intelligence deps (PR #155 follow-up)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -325,6 +325,17 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		rankTrackingSchemaTables: DrizzlePersistence.schema.rankTrackingSchemaTables,
 	} satisfies RTUseCases.RankTrackingDeps as unknown as SharedDeps);
 
+	// Per-context deps with auto-schedule include `scheduleEndpointFetch` and
+	// `logger` so the module's `buildAutoScheduleHandlers` call has what it
+	// needs. AI search additionally needs `projects` and `credentials` for
+	// its `dynamicSchedules` resolver. Defined here (before the
+	// `competitor-intelligence` compose) because that module also wires
+	// auto-schedule (#142).
+	const autoScheduleSurface = {
+		scheduleEndpointFetch,
+		logger: autoScheduleLogger,
+	};
+
 	const competitorIntelligence = CIUseCases.competitorIntelligenceModule.compose({
 		clock: SystemClock,
 		ids: SystemIdGenerator,
@@ -333,16 +344,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		competitorKeywordGapRepo,
 		competitorPageAuditRepo,
 		competitorIntelligenceSchemaTables: DrizzlePersistence.schema.competitorIntelligenceSchemaTables,
-	} satisfies CIUseCases.CompetitorIntelligenceDeps as unknown as SharedDeps);
-
-	// Per-context deps with auto-schedule include `scheduleEndpointFetch` and
-	// `logger` so the module's `buildAutoScheduleHandlers` call has what it
-	// needs. AI search additionally needs `projects` and `credentials` for
-	// its `dynamicSchedules` resolver.
-	const autoScheduleSurface = {
-		scheduleEndpointFetch,
-		logger: autoScheduleLogger,
-	};
+		...autoScheduleSurface,
+	} as CIUseCases.CompetitorIntelligenceDeps as unknown as SharedDeps);
 
 	const searchConsoleInsights = SCIUseCases.searchConsoleInsightsModule.compose({
 		clock: SystemClock,

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
@@ -7,7 +7,6 @@ import {
 } from './auto-schedule.config.js';
 
 const PROJECT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ProjectManagement.ProjectId;
-const ORG_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid;
 const COMPETITOR_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as ProjectManagement.CompetitorId;
 
 const buildProject = (locations: { country: string; language: string }[]) => ({

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
@@ -1,0 +1,189 @@
+import { ProjectManagement } from '@rankpulse/domain';
+import type { Uuid } from '@rankpulse/shared';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	competitorIntelligenceAutoScheduleConfigs,
+	DATAFORSEO_LOCATION_CODES,
+} from './auto-schedule.config.js';
+
+const PROJECT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ProjectManagement.ProjectId;
+const ORG_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' as Uuid;
+const COMPETITOR_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as ProjectManagement.CompetitorId;
+
+const buildProject = (locations: { country: string; language: string }[]) => ({
+	id: PROJECT_ID,
+	primaryDomain: ProjectManagement.DomainName.create('patroltech.online'),
+	locations: locations.map((l) => ProjectManagement.LocationLanguage.create(l)),
+});
+
+const fakeProjectRepo = (project: ReturnType<typeof buildProject> | null) => ({
+	findById: vi.fn().mockResolvedValue(project),
+});
+
+const competitorAddedConfig = competitorIntelligenceAutoScheduleConfigs.find(
+	(c) => c.event === 'project-management.CompetitorAdded',
+);
+const domainAddedConfig = competitorIntelligenceAutoScheduleConfigs.find(
+	(c) => c.event === 'project-management.DomainAdded',
+);
+
+describe('competitor-intelligence auto-schedule', () => {
+	it('exports a config for both CompetitorAdded and DomainAdded', () => {
+		expect(competitorIntelligenceAutoScheduleConfigs).toHaveLength(2);
+		expect(competitorAddedConfig).toBeDefined();
+		expect(domainAddedConfig).toBeDefined();
+	});
+
+	it('maps the 5 PatrolTech markets to DataForSEO location codes', () => {
+		expect(DATAFORSEO_LOCATION_CODES.ES).toBe(2724);
+		expect(DATAFORSEO_LOCATION_CODES.US).toBe(2840);
+		expect(DATAFORSEO_LOCATION_CODES.GB).toBe(2826);
+		expect(DATAFORSEO_LOCATION_CODES.FR).toBe(2250);
+		expect(DATAFORSEO_LOCATION_CODES.MX).toBe(2484);
+	});
+});
+
+describe('CompetitorAdded → schedules', () => {
+	const event = new ProjectManagement.CompetitorAdded({
+		competitorId: COMPETITOR_ID,
+		projectId: PROJECT_ID,
+		domain: 'silvertraconline.com',
+		label: 'Silvertrac',
+		occurredAt: new Date('2026-05-09T12:00:00Z'),
+	});
+
+	it('emits 1 ranked-keywords + 1 domain-intersection per project location', async () => {
+		const project = buildProject([{ country: 'ES', language: 'es-ES' }]);
+		const deps = { projectRepo: fakeProjectRepo(project) } as never;
+
+		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, deps);
+		expect(specs).toBeDefined();
+		expect(specs).toHaveLength(2);
+		const rk = specs?.find((s) => s.endpointId === 'dataforseo-labs-ranked-keywords');
+		const di = specs?.find((s) => s.endpointId === 'dataforseo-labs-domain-intersection');
+		expect(rk).toBeDefined();
+		expect(di).toBeDefined();
+
+		// ranked-keywords params target the COMPETITOR domain
+		expect(rk?.paramsBuilder(event)).toMatchObject({
+			target: 'silvertraconline.com',
+			locationCode: 2724,
+			languageCode: 'es',
+			limit: 1_000,
+		});
+		expect(rk?.systemParamsBuilder(event)).toMatchObject({
+			targetDomain: 'silvertraconline.com',
+			country: 'ES',
+		});
+
+		// domain-intersection params pair OUR primary × the competitor
+		expect(di?.paramsBuilder(event)).toMatchObject({
+			targets: ['patroltech.online', 'silvertraconline.com'],
+			locationCode: 2724,
+			languageCode: 'es',
+		});
+		const diSys = di?.systemParamsBuilder(event);
+		expect(diSys).toMatchObject({
+			ourDomain: 'patroltech.online',
+			competitorDomain: 'silvertraconline.com',
+		});
+		// Composite idempotency key — guarantees per-locale uniqueness so
+		// the second locale of a multi-market project isn't dropped by
+		// ScheduleEndpointFetchUseCase's idempotency check.
+		expect(diSys?.intersectionScheduleKey).toBe(
+			'patroltech.online|silvertraconline.com|ES|es',
+		);
+	});
+
+	it('fans out per locale on multi-market projects (US + GB)', async () => {
+		const project = buildProject([
+			{ country: 'US', language: 'en-US' },
+			{ country: 'GB', language: 'en-GB' },
+		]);
+		const deps = { projectRepo: fakeProjectRepo(project) } as never;
+
+		const specs = (await competitorAddedConfig?.dynamicSchedules?.(event, deps)) ?? [];
+		expect(specs).toHaveLength(4); // 2 specs × 2 locations
+
+		const di = specs.filter((s) => s.endpointId === 'dataforseo-labs-domain-intersection');
+		const keys = di.map((d) => d.systemParamsBuilder(event).intersectionScheduleKey);
+		expect(keys).toContain('patroltech.online|silvertraconline.com|US|en');
+		expect(keys).toContain('patroltech.online|silvertraconline.com|GB|en');
+	});
+
+	it('skips locations with un-mapped country codes (logs and continues)', async () => {
+		const project = buildProject([
+			{ country: 'ES', language: 'es-ES' },
+			{ country: 'JP', language: 'ja-JP' }, // not in DATAFORSEO_LOCATION_CODES
+		]);
+		const deps = { projectRepo: fakeProjectRepo(project) } as never;
+
+		const specs = (await competitorAddedConfig?.dynamicSchedules?.(event, deps)) ?? [];
+		// Only ES generated specs, JP is skipped — 2 specs total (not 4).
+		expect(specs).toHaveLength(2);
+	});
+
+	it('returns [] when project is missing or has no locations', async () => {
+		expect(
+			await competitorAddedConfig?.dynamicSchedules?.(event, {
+				projectRepo: fakeProjectRepo(null),
+			} as never),
+		).toEqual([]);
+
+		const empty = buildProject([]);
+		expect(
+			await competitorAddedConfig?.dynamicSchedules?.(event, {
+				projectRepo: fakeProjectRepo(empty),
+			} as never),
+		).toEqual([]);
+	});
+});
+
+describe('DomainAdded → schedules', () => {
+	const event = new ProjectManagement.DomainAdded({
+		projectId: PROJECT_ID,
+		domain: 'softwarerondas.com',
+		kind: 'alias',
+		occurredAt: new Date('2026-05-09T12:00:00Z'),
+	});
+
+	it('emits 1 ranked-keywords per project location with target = added domain', async () => {
+		const project = buildProject([{ country: 'ES', language: 'es-ES' }]);
+		const deps = { projectRepo: fakeProjectRepo(project) } as never;
+
+		const specs = (await domainAddedConfig?.dynamicSchedules?.(event, deps)) ?? [];
+		expect(specs).toHaveLength(1);
+		expect(specs[0]?.endpointId).toBe('dataforseo-labs-ranked-keywords');
+		expect(specs[0]?.paramsBuilder(event)).toMatchObject({
+			target: 'softwarerondas.com',
+			locationCode: 2724,
+			languageCode: 'es',
+		});
+		expect(specs[0]?.systemParamsBuilder(event)).toMatchObject({
+			targetDomain: 'softwarerondas.com',
+		});
+	});
+
+	it('does not care about kind (main vs alias vs subdomain)', async () => {
+		const project = buildProject([{ country: 'ES', language: 'es-ES' }]);
+		const deps = { projectRepo: fakeProjectRepo(project) } as never;
+
+		const mainEvent = new ProjectManagement.DomainAdded({
+			projectId: PROJECT_ID,
+			domain: 'patroltech.online',
+			kind: 'main',
+			occurredAt: new Date(),
+		});
+		const aliasEvent = new ProjectManagement.DomainAdded({
+			projectId: PROJECT_ID,
+			domain: 'softwarerondas.com',
+			kind: 'alias',
+			occurredAt: new Date(),
+		});
+
+		const mainSpecs = (await domainAddedConfig?.dynamicSchedules?.(mainEvent, deps)) ?? [];
+		const aliasSpecs = (await domainAddedConfig?.dynamicSchedules?.(aliasEvent, deps)) ?? [];
+		expect(mainSpecs).toHaveLength(1);
+		expect(aliasSpecs).toHaveLength(1);
+	});
+});

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
@@ -89,9 +89,7 @@ describe('CompetitorAdded → schedules', () => {
 		// Composite idempotency key — guarantees per-locale uniqueness so
 		// the second locale of a multi-market project isn't dropped by
 		// ScheduleEndpointFetchUseCase's idempotency check.
-		expect(diSys?.intersectionScheduleKey).toBe(
-			'patroltech.online|silvertraconline.com|ES|es',
-		);
+		expect(diSys?.intersectionScheduleKey).toBe('patroltech.online|silvertraconline.com|ES|es');
 	});
 
 	it('fans out per locale on multi-market projects (US + GB)', async () => {

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
@@ -1,0 +1,235 @@
+import { type ProjectManagement, type SharedKernel } from '@rankpulse/domain';
+import type { AutoScheduleConfig, AutoScheduleSpec } from '../../_core/auto-schedule.js';
+import type { SharedDeps } from '../../_core/module.js';
+
+/**
+ * DataForSEO `location_code` numeric IDs keyed by ISO 3166-1 alpha-2
+ * country code. Only the markets PatrolTech (and other early adopters)
+ * actually serve are mapped — adding a new country is one entry here.
+ *
+ * Source: https://docs.dataforseo.com/v3/serp/google/locations/
+ *
+ * If a project's location uses an un-mapped country, the auto-schedule
+ * handler logs and skips that location (the operator can still add the
+ * schedule manually via POST /endpoints/.../schedule). We deliberately
+ * do NOT throw — a single un-mapped country shouldn't block the rest
+ * of a multi-locale project.
+ */
+export const DATAFORSEO_LOCATION_CODES: Readonly<Record<string, number>> = {
+	ES: 2724, // Spain
+	US: 2840, // United States
+	GB: 2826, // United Kingdom
+	FR: 2250, // France
+	MX: 2484, // Mexico
+	DE: 2276,
+	IT: 2380,
+	PT: 2620,
+	BR: 2076,
+	AR: 2032,
+	CL: 2152,
+	CO: 2170,
+	CA: 2124,
+};
+
+/**
+ * Convert a project `LocationLanguage`'s language tag (e.g. `'en-US'`,
+ * `'es-ES'`) to the 2-letter form DataForSEO Labs expects on
+ * ranked-keywords / domain-intersection / page-intersection /
+ * historical-serps (`'en'`, `'es'`).
+ *
+ * SERP-Live and other endpoints use the full IETF tag — those have
+ * their own auto-schedule wiring outside competitor-intelligence and
+ * are unaffected.
+ */
+const toLabsLanguageCode = (language: string): string => {
+	const head = language.split('-')[0]?.toLowerCase();
+	return head ?? language.toLowerCase();
+};
+
+interface CompetitorIntelligenceAutoScheduleDeps extends SharedDeps {
+	readonly projectRepo: ProjectManagement.ProjectRepository;
+}
+
+/**
+ * Default scheduling parameters for the auto-created DataForSEO labs
+ * jobs. Cron times are spread across Monday morning so the per-provider
+ * rate limit (PR #124) doesn't reject runs that all fire at the same
+ * second.
+ */
+const RANKED_KEYWORDS_DEFAULTS = {
+	providerId: 'dataforseo',
+	endpointId: 'dataforseo-labs-ranked-keywords',
+	cron: '0 7 * * 1', // Mondays 07:00 UTC
+	limit: 1_000,
+};
+
+const DOMAIN_INTERSECTION_DEFAULTS = {
+	providerId: 'dataforseo',
+	endpointId: 'dataforseo-labs-domain-intersection',
+	cron: '5 7 * * 1', // Mondays 07:05 UTC (5 min offset to spread load)
+	limit: 1_000,
+};
+
+/**
+ * Build the spec list for the `CompetitorAdded` event:
+ *   • 1× ranked-keywords for the competitor (target = competitor.domain)
+ *   • 1× domain-intersection per project location (targets = [primary, competitor])
+ *
+ * The fan-out is per location, NOT per (location × our domain) — we use
+ * `project.primaryDomain` only. Domain-intersection on every alias domain
+ * would 4-5x the schedule count without proportional value (the alias
+ * domains ranking poorly is exactly what they're for). Adding alias
+ * coverage later is a follow-up.
+ *
+ * Idempotency key: `competitorDomain` for ranked-keywords (one schedule
+ * per competitor regardless of location duplication), and a composite
+ * `competitorDomain|country|language` for domain-intersection so multi-
+ * locale projects (PT EN: US + GB) get one schedule per locale.
+ */
+const buildCompetitorAddedSpecs = async (
+	event: SharedKernel.DomainEvent,
+	deps: SharedDeps,
+): Promise<readonly AutoScheduleSpec[]> => {
+	if (event.type !== 'project-management.CompetitorAdded') return [];
+	const ciDeps = deps as CompetitorIntelligenceAutoScheduleDeps;
+	const e = event as ProjectManagement.CompetitorAdded;
+
+	const project = await ciDeps.projectRepo.findById(e.projectId);
+	if (!project) return [];
+	if (project.locations.length === 0) return [];
+
+	const ourDomain = project.primaryDomain.value;
+	const competitorDomain = e.domain;
+	const specs: AutoScheduleSpec[] = [];
+
+	for (const location of project.locations) {
+		const locationCode = DATAFORSEO_LOCATION_CODES[location.country.toUpperCase()];
+		if (locationCode === undefined) continue; // un-mapped country, see note above
+		const languageCode = toLabsLanguageCode(location.language);
+
+		// 1. ranked-keywords for the competitor — one per locale because
+		// search volume + position differ per market.
+		specs.push({
+			providerId: RANKED_KEYWORDS_DEFAULTS.providerId,
+			endpointId: RANKED_KEYWORDS_DEFAULTS.endpointId,
+			cron: RANKED_KEYWORDS_DEFAULTS.cron,
+			systemParamKey: 'targetDomain',
+			paramsBuilder: () => ({
+				target: competitorDomain,
+				locationCode,
+				languageCode,
+				limit: RANKED_KEYWORDS_DEFAULTS.limit,
+			}),
+			systemParamsBuilder: () => ({
+				targetDomain: competitorDomain,
+				country: location.country,
+				language: languageCode,
+			}),
+		});
+
+		// 2. domain-intersection — pairs OUR primary domain × this competitor.
+		specs.push({
+			providerId: DOMAIN_INTERSECTION_DEFAULTS.providerId,
+			endpointId: DOMAIN_INTERSECTION_DEFAULTS.endpointId,
+			cron: DOMAIN_INTERSECTION_DEFAULTS.cron,
+			// Composite idempotency key so two specs (different locales)
+			// for the same (ourDomain, competitorDomain) don't collide and
+			// the second one isn't dropped. ScheduleEndpointFetchUseCase
+			// looks up `params[systemParamKey]` via a string `equals` match.
+			systemParamKey: 'intersectionScheduleKey',
+			paramsBuilder: () => ({
+				targets: [ourDomain, competitorDomain],
+				locationCode,
+				languageCode,
+				limit: DOMAIN_INTERSECTION_DEFAULTS.limit,
+			}),
+			systemParamsBuilder: () => ({
+				ourDomain,
+				competitorDomain,
+				country: location.country,
+				language: languageCode,
+				intersectionScheduleKey: `${ourDomain}|${competitorDomain}|${location.country}|${languageCode}`,
+			}),
+		});
+	}
+
+	return specs;
+};
+
+/**
+ * Build the spec list for the `DomainAdded` event: schedule a
+ * ranked-keywords fetch with target = the new domain. Same per-locale
+ * fan-out as competitors so a multi-market project (PT EN US + GB)
+ * tracks our own domain in both markets.
+ *
+ * Note: the `kind` field on the event (`'main' | 'subdomain' | 'alias'`)
+ * is intentionally ignored — for ranked-keywords purposes a domain is a
+ * domain. If product later wants to scope only `'main'` here, it's a
+ * one-line filter.
+ */
+const buildDomainAddedSpecs = async (
+	event: SharedKernel.DomainEvent,
+	deps: SharedDeps,
+): Promise<readonly AutoScheduleSpec[]> => {
+	if (event.type !== 'project-management.DomainAdded') return [];
+	const ciDeps = deps as CompetitorIntelligenceAutoScheduleDeps;
+	const e = event as ProjectManagement.DomainAdded;
+
+	const project = await ciDeps.projectRepo.findById(e.projectId);
+	if (!project) return [];
+	if (project.locations.length === 0) return [];
+
+	const ourDomain = e.domain;
+	const specs: AutoScheduleSpec[] = [];
+
+	for (const location of project.locations) {
+		const locationCode = DATAFORSEO_LOCATION_CODES[location.country.toUpperCase()];
+		if (locationCode === undefined) continue;
+		const languageCode = toLabsLanguageCode(location.language);
+
+		specs.push({
+			providerId: RANKED_KEYWORDS_DEFAULTS.providerId,
+			endpointId: RANKED_KEYWORDS_DEFAULTS.endpointId,
+			cron: RANKED_KEYWORDS_DEFAULTS.cron,
+			systemParamKey: 'targetDomain',
+			paramsBuilder: () => ({
+				target: ourDomain,
+				locationCode,
+				languageCode,
+				limit: RANKED_KEYWORDS_DEFAULTS.limit,
+			}),
+			systemParamsBuilder: () => ({
+				targetDomain: ourDomain,
+				country: location.country,
+				language: languageCode,
+			}),
+		});
+	}
+
+	return specs;
+};
+
+/**
+ * Auto-schedule configs owned by competitor-intelligence. Closes the
+ * "auto-schedule wiring is a follow-up" TODOs left by #134, #136, #137
+ * (issue #142).
+ *
+ * Two events drive scheduling:
+ *  - `project-management.CompetitorAdded` (emitted by AddCompetitorUseCase)
+ *  - `project-management.DomainAdded` (emitted by Project.addDomain)
+ *
+ * The third bullet on issue #142 — top-N URL reconciliation for
+ * on-page-instant audits — is a recurring read job, not an event
+ * reaction. It belongs in a separate scheduled use case and is
+ * intentionally NOT part of this PR.
+ */
+export const competitorIntelligenceAutoScheduleConfigs: readonly AutoScheduleConfig[] = [
+	{
+		event: 'project-management.CompetitorAdded',
+		dynamicSchedules: buildCompetitorAddedSpecs,
+	},
+	{
+		event: 'project-management.DomainAdded',
+		dynamicSchedules: buildDomainAddedSpecs,
+	},
+];

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
@@ -1,4 +1,4 @@
-import { type ProjectManagement, type SharedKernel } from '@rankpulse/domain';
+import type { ProjectManagement, SharedKernel } from '@rankpulse/domain';
 import type { AutoScheduleConfig, AutoScheduleSpec } from '../../_core/auto-schedule.js';
 import type { SharedDeps } from '../../_core/module.js';
 

--- a/packages/application/src/competitor-intelligence/module.ts
+++ b/packages/application/src/competitor-intelligence/module.ts
@@ -4,7 +4,9 @@ import type {
 	SharedKernel,
 } from '@rankpulse/domain';
 import type { Clock, IdGenerator } from '@rankpulse/shared';
+import { buildAutoScheduleHandlers } from '../_core/auto-schedule.js';
 import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
+import { competitorIntelligenceAutoScheduleConfigs } from './event-handlers/auto-schedule.config.js';
 import { IngestCompetitorPageAuditUseCase } from './use-cases/ingest-competitor-page-audit.use-case.js';
 import { IngestDomainIntersectionUseCase } from './use-cases/ingest-domain-intersection.use-case.js';
 import { QueryCompetitorPageAuditsUseCase } from './use-cases/query-competitor-page-audits.use-case.js';
@@ -82,7 +84,7 @@ export const competitorIntelligenceModule: ContextModule = {
 					},
 				},
 			},
-			eventHandlers: [],
+			eventHandlers: buildAutoScheduleHandlers(deps, competitorIntelligenceAutoScheduleConfigs),
 			schemaTables: d.competitorIntelligenceSchemaTables,
 		};
 	},


### PR DESCRIPTION
PR #155 wired auto-schedule in competitor-intelligence but missed updating composition-root. Result: API crashed on first CompetitorAdded event because `deps.scheduleEndpointFetch` was undefined. The deploy of cb972d9 left the API down — see Release run 25603566296.

Fix: move `autoScheduleSurface` block above the competitor-intelligence compose call (currently it's defined later) and spread it into the deps. Same pattern AI Search uses.

Urgent — production API is currently 502.