### PR TITLE
fix(provider-connectivity): PATCH systemParams + group ingest preconditions (#149, #150)

### DIFF
--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -429,7 +429,13 @@ export function buildOpenApiDocument(): unknown {
 	registry.registerPath({
 		method: 'patch',
 		path: '/api/v1/providers/{providerId}/job-definitions/{definitionId}',
-		summary: 'Update cron / params / enabled on an existing job definition',
+		summary: 'Update cron / params / enabled / systemParams on an existing job definition',
+		description:
+			'Body fields:\n' +
+			'- `cron`, `params`, `enabled` — same semantics as on create.\n' +
+			'- `systemParams` — patch for the orchestration bag stamped at scheduling time (`targetDomain`, `ourDomain`, `competitorDomain`, `scope`, …). Merged ON TOP of the existing def; the entity-bound whitelist (`organizationId`, `projectId`, `gscPropertyId`, `ga4PropertyId`, `trackedKeywordId`, `trackedPageId`, `wikipediaArticleId`, `bingPropertyId`, `clarityProjectId`, `monitoredDomainId`, `metaPixelId`, `metaAdAccountId`) cannot be overwritten via PATCH and is preserved from the existing def.\n\n' +
+			'Unknown fields are rejected (400) — the schema is `.strict()` so a stale client sending e.g. `organizationId` at the top level surfaces immediately instead of being silently dropped (#149).\n\n' +
+			'The GET response carries `params` with both user surface AND stamped systemParams merged together (storage model). To inspect which orchestration keys are present, read `params.<key>` directly.',
 		tags: ['provider-connectivity'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {

--- a/apps/worker/src/processors/ingest-router.spec.ts
+++ b/apps/worker/src/processors/ingest-router.spec.ts
@@ -94,6 +94,113 @@ describe('IngestRouter.dispatch', () => {
 		).rejects.toBeInstanceOf(NotFoundError);
 	});
 
+	// ===== #150: validate ALL required systemParams in one pass =====
+
+	it('lists every missing systemParam in a single error (additionalSystemParamKeys, #150)', async () => {
+		const { acl, ingest } = buildEntry();
+		const entries = new Map<RouterKey, IngestRouterEntry>([
+			[
+				'dataforseo|dataforseo-labs-domain-intersection',
+				{
+					systemParamKey: 'ourDomain',
+					additionalSystemParamKeys: ['competitorDomain'],
+					acl,
+					ingest,
+				},
+			],
+		]);
+		const router = new IngestRouter(entries);
+
+		await expect(
+			router.dispatch({
+				providerId: 'dataforseo',
+				endpointId: 'dataforseo-labs-domain-intersection',
+				fetchResult: {},
+				rawPayloadId: 'rp-1',
+				// Both keys missing — pre-#150 the operator saw `ourDomain`,
+				// fixed it, hit `competitorDomain` on the next run.
+				definition: { params: {}, projectId: 'p-1' } as never,
+				dateBucket: '2026-05-06',
+			}),
+		).rejects.toThrow(/systemParams: ourDomain, competitorDomain/);
+	});
+
+	it('still throws when only an additionalSystemParamKey is missing', async () => {
+		const { acl, ingest } = buildEntry();
+		const entries = new Map<RouterKey, IngestRouterEntry>([
+			[
+				'dataforseo|dataforseo-labs-domain-intersection',
+				{
+					systemParamKey: 'ourDomain',
+					additionalSystemParamKeys: ['competitorDomain'],
+					acl,
+					ingest,
+				},
+			],
+		]);
+		const router = new IngestRouter(entries);
+
+		await expect(
+			router.dispatch({
+				providerId: 'dataforseo',
+				endpointId: 'dataforseo-labs-domain-intersection',
+				fetchResult: {},
+				rawPayloadId: 'rp-1',
+				definition: { params: { ourDomain: 'patroltech.online' }, projectId: 'p-1' } as never,
+				dateBucket: '2026-05-06',
+			}),
+		).rejects.toThrow(/systemParams: competitorDomain/);
+	});
+
+	it('passes when both primary and additional systemParams are present', async () => {
+		const { acl, execute, ingest } = buildEntry();
+		const entries = new Map<RouterKey, IngestRouterEntry>([
+			[
+				'dataforseo|dataforseo-labs-domain-intersection',
+				{
+					systemParamKey: 'ourDomain',
+					additionalSystemParamKeys: ['competitorDomain'],
+					acl,
+					ingest,
+				},
+			],
+		]);
+		const router = new IngestRouter(entries);
+
+		await router.dispatch({
+			providerId: 'dataforseo',
+			endpointId: 'dataforseo-labs-domain-intersection',
+			fetchResult: { ok: true },
+			rawPayloadId: 'rp-1',
+			definition: {
+				params: { ourDomain: 'patroltech.online', competitorDomain: 'silvertraconline.com' },
+				projectId: 'p-1',
+			} as never,
+			dateBucket: '2026-05-06',
+		});
+
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('treats empty-string systemParam values as missing', async () => {
+		const { acl, ingest } = buildEntry();
+		const entries = new Map<RouterKey, IngestRouterEntry>([
+			['fake|fake-endpoint', { systemParamKey: 'fakeId', acl, ingest }],
+		]);
+		const router = new IngestRouter(entries);
+
+		await expect(
+			router.dispatch({
+				providerId: 'fake',
+				endpointId: 'fake-endpoint',
+				fetchResult: {},
+				rawPayloadId: 'rp-1',
+				definition: { params: { fakeId: '   ' }, projectId: 'p-1' } as never,
+				dateBucket: '2026-05-06',
+			}),
+		).rejects.toThrow(/systemParams: fakeId/);
+	});
+
 	it('preserves params.projectId when already present (does not overwrite with definition.projectId)', async () => {
 		const { acl, execute, ingest } = buildEntry();
 		const entries = new Map<RouterKey, IngestRouterEntry>([

--- a/apps/worker/src/processors/ingest-router.ts
+++ b/apps/worker/src/processors/ingest-router.ts
@@ -8,6 +8,12 @@ type ProviderEndpointKey = `${string}|${string}`;
 
 export interface IngestRouterEntry {
 	readonly systemParamKey: string;
+	/**
+	 * Extra systemParams the ACL/handler reads beyond `systemParamKey`.
+	 * Validated together with the primary key so a single dispatch
+	 * surfaces ALL missing keys in one error (#150).
+	 */
+	readonly additionalSystemParamKeys?: readonly string[];
 	readonly acl: (response: unknown, ctx: AclContext) => unknown[];
 	readonly ingest: IngestUseCase;
 }
@@ -49,11 +55,29 @@ export class IngestRouter {
 		if (!entry) return false;
 
 		const params = input.definition.params as Record<string, unknown>;
-		const systemParamValue = params[entry.systemParamKey];
-		if (!systemParamValue) {
+		// #150 — validate the primary `systemParamKey` AND any
+		// `additionalSystemParamKeys` declared on the binding in one pass,
+		// then surface ALL missing keys in a single error. Pre-#150 the
+		// router checked only the primary; the ACL then re-threw on its
+		// extras one at a time, costing the operator a fresh `run-now`
+		// per missing key (e.g. domain-intersection: ourDomain → fix → re-run
+		// → competitorDomain → fix → re-run).
+		const requiredKeys = entry.additionalSystemParamKeys
+			? [entry.systemParamKey, ...entry.additionalSystemParamKeys]
+			: [entry.systemParamKey];
+		const missingKeys = requiredKeys.filter((k) => {
+			const v = params[k];
+			// Treat empty string the same as missing — DataForSEO Labs ACLs
+			// already reject `''` and `'   '`, so accepting them here would
+			// just defer the failure to the ACL with a less helpful message.
+			return v === undefined || v === null || (typeof v === 'string' && v.trim() === '');
+		});
+		if (missingKeys.length > 0) {
+			const list = missingKeys.join(', ');
+			const subject = missingKeys.length === 1 ? 'this' : 'these';
 			throw new NotFoundError(
-				`${input.providerId}/${input.endpointId} processor reached without ${entry.systemParamKey} in systemParams. ` +
-					`Auto-Schedule handler should have set this. See ADR 0001.`,
+				`${input.providerId}/${input.endpointId} processor reached without systemParams: ${list}. ` +
+					`Auto-Schedule handler should have set ${subject}. See ADR 0001.`,
 			);
 		}
 
@@ -99,6 +123,7 @@ export function buildIngestRouter(
 			const key: ProviderEndpointKey = `${manifest.id}|${endpoint.descriptor.id}`;
 			entries.set(key, {
 				systemParamKey: endpoint.ingest.systemParamKey,
+				additionalSystemParamKeys: endpoint.ingest.additionalSystemParamKeys,
 				acl: endpoint.ingest.acl as (response: unknown, ctx: AclContext) => unknown[],
 				ingest: useCase,
 			});

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.spec.ts
@@ -316,3 +316,123 @@ describe('UpdateJobDefinitionUseCase — preserves systemParams (bug #51)', () =
 		expect(view.params[key]).toBe('preserved-value');
 	});
 });
+
+// ===== #149: PATCH accepts and persists `systemParams` =====
+
+describe('UpdateJobDefinitionUseCase — systemParams patch (#149)', () => {
+	const aDefMissingTargetDomain = (): PC2.ProviderJobDefinition =>
+		PC2.ProviderJobDefinition.schedule({
+			id: 'def-149' as PC2.ProviderJobDefinitionId,
+			projectId: 'proj-1' as never,
+			providerId: PC2.ProviderId.create('dataforseo'),
+			endpointId: PC2.EndpointId.create('dataforseo-labs-ranked-keywords'),
+			params: {
+				// User-supplied params (validated via paramsSchema upstream)
+				locationCode: 2724,
+				languageCode: 'es',
+				// Sacred whitelist key already stamped by the scheduler use case
+				organizationId: 'org-1',
+				projectId: 'proj-1',
+				// `targetDomain` is missing — that's the operator's bug we're repairing
+			},
+			cron: PC2.CronExpression.create('0 5 * * *'),
+			credentialOverrideId: null,
+			now: new Date('2026-05-09T00:00:00Z'),
+		});
+
+	it('persists a new orchestration key supplied via systemParams', async () => {
+		const def = aDefMissingTargetDomain();
+		const repo = {
+			save: vi.fn(),
+			findById: vi.fn().mockResolvedValue(def),
+			delete: vi.fn(),
+			listForProject: vi.fn(),
+			findByProjectEndpointAndSystemParam: vi.fn(),
+			findFor: vi.fn(),
+		} as unknown as PC2.JobDefinitionRepository;
+		const scheduler = {
+			register: vi.fn(),
+			unregister: vi.fn(),
+			enqueueOnce: vi.fn(),
+		} satisfies PC2.JobScheduler;
+
+		const uc = new UpdateJobDefUC2(repo, scheduler);
+		const view = await uc.execute({
+			definitionId: 'def-149',
+			systemParams: { targetDomain: 'patroltech.online' },
+		});
+
+		expect(view.params.targetDomain).toBe('patroltech.online');
+		// Pre-existing keys survive the patch
+		expect(view.params.locationCode).toBe(2724);
+		expect(view.params.organizationId).toBe('org-1');
+	});
+
+	it('blocks user-supplied systemParams from overwriting sacred whitelist keys', async () => {
+		const def = aDefMissingTargetDomain();
+		const repo = {
+			save: vi.fn(),
+			findById: vi.fn().mockResolvedValue(def),
+			delete: vi.fn(),
+			listForProject: vi.fn(),
+			findByProjectEndpointAndSystemParam: vi.fn(),
+			findFor: vi.fn(),
+		} as unknown as PC2.JobDefinitionRepository;
+		const scheduler = {
+			register: vi.fn(),
+			unregister: vi.fn(),
+			enqueueOnce: vi.fn(),
+		} satisfies PC2.JobScheduler;
+
+		const uc = new UpdateJobDefUC2(repo, scheduler);
+		const view = await uc.execute({
+			definitionId: 'def-149',
+			systemParams: {
+				organizationId: 'EVIL-ORG',
+				projectId: 'EVIL-PROJ',
+				targetDomain: 'attacker.com',
+			},
+		});
+
+		expect(view.params.organizationId).toBe('org-1');
+		expect(view.params.projectId).toBe('proj-1');
+		// Non-whitelisted orchestration keys still take effect
+		expect(view.params.targetDomain).toBe('attacker.com');
+	});
+
+	it('applies both `params` and `systemParams` in one PATCH call', async () => {
+		const def = aDefMissingTargetDomain();
+		const repo = {
+			save: vi.fn(),
+			findById: vi.fn().mockResolvedValue(def),
+			delete: vi.fn(),
+			listForProject: vi.fn(),
+			findByProjectEndpointAndSystemParam: vi.fn(),
+			findFor: vi.fn(),
+		} as unknown as PC2.JobDefinitionRepository;
+		const scheduler = {
+			register: vi.fn(),
+			unregister: vi.fn(),
+			enqueueOnce: vi.fn(),
+		} satisfies PC2.JobScheduler;
+
+		const uc = new UpdateJobDefUC2(repo, scheduler);
+		const view = await uc.execute({
+			definitionId: 'def-149',
+			// `params` REPLACE semantics (with whitelist preservation)
+			params: { locationCode: 2840, languageCode: 'en' },
+			// `systemParams` MERGE semantics (overlay)
+			systemParams: { targetDomain: 'patroltech.online', country: 'US' },
+		});
+
+		// `params` replaced the user surface
+		expect(view.params.locationCode).toBe(2840);
+		expect(view.params.languageCode).toBe('en');
+		// `systemParams` overlaid the orchestration keys
+		expect(view.params.targetDomain).toBe('patroltech.online');
+		expect(view.params.country).toBe('US');
+		// Whitelist survived both phases
+		expect(view.params.organizationId).toBe('org-1');
+		expect(view.params.projectId).toBe('proj-1');
+	});
+});

--- a/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
+++ b/packages/application/src/provider-connectivity/use-cases/manage-job-definition.use-cases.ts
@@ -51,6 +51,14 @@ export interface UpdateJobDefinitionCommand {
 	cron?: string;
 	params?: Record<string, unknown>;
 	enabled?: boolean;
+	/**
+	 * Patch for the orchestration bag the auto-schedule handler stamps
+	 * (`targetDomain`, `ourDomain`, `competitorDomain`, `scope`, …). Merged
+	 * ON TOP of the existing def's `params` (replaces overlapping keys),
+	 * but the entity-bound whitelist is still preserved so a user PATCH
+	 * cannot tamper with `organizationId`, `gscPropertyId`, etc. (#149).
+	 */
+	systemParams?: Record<string, unknown>;
 }
 
 /**
@@ -106,6 +114,31 @@ function mergeUserParamsPreservingSystem(
 	return { ...userPatch, ...preserved };
 }
 
+/**
+ * Overlay a `systemParams` PATCH onto the existing def's params. Used by
+ * #149 so the operator can fix orchestration keys (`targetDomain`,
+ * `ourDomain`, `competitorDomain`, `scope`, …) on a misconfigured def
+ * without rebuilding the whole schedule.
+ *
+ * Unlike `mergeUserParamsPreservingSystem` which has REPLACE semantics on
+ * the user surface, this one has MERGE semantics — only the keys the
+ * caller supplies change; everything else (including unrelated user
+ * params and stamped orchestration keys not being patched) survives.
+ *
+ * The whitelist is still applied so a malicious patch can't overwrite
+ * `organizationId` / `gscPropertyId` / etc.
+ */
+function applySystemParamsPatch(
+	existing: Record<string, unknown>,
+	systemPatch: Record<string, unknown>,
+): Record<string, unknown> {
+	const merged: Record<string, unknown> = { ...existing, ...systemPatch };
+	for (const key of SYSTEM_PARAM_KEYS) {
+		if (existing[key] !== undefined) merged[key] = existing[key];
+	}
+	return merged;
+}
+
 export class UpdateJobDefinitionUseCase {
 	constructor(
 		private readonly definitions: ProviderConnectivity.JobDefinitionRepository,
@@ -138,6 +171,15 @@ export class UpdateJobDefinitionUseCase {
 			// downstream code requires extending this list, which forces a
 			// review of every PATCH call site.
 			def.updateParams(mergeUserParamsPreservingSystem(def.params, cmd.params));
+		}
+		if (cmd.systemParams !== undefined) {
+			// #149 — pre-fix, the schema dropped `systemParams` silently and
+			// the operator had no way to repair an ACL/router precondition
+			// failure caused by a missing orchestration key. Now the patch
+			// is overlaid on the existing params (post-`params`-replace if
+			// both were sent), with the entity-bound whitelist still
+			// protecting sacred keys.
+			def.updateParams(applySystemParamsPatch(def.params, cmd.systemParams));
 		}
 		if (cmd.enabled === true) def.enable();
 		if (cmd.enabled === false) def.disable();

--- a/packages/contracts/src/provider-connectivity/index.ts
+++ b/packages/contracts/src/provider-connectivity/index.ts
@@ -72,10 +72,32 @@ export const UpdateJobDefinitionRequest = z
 		cron: z.string().min(5).max(80).optional(),
 		params: z.record(z.string(), z.unknown()).optional(),
 		enabled: z.boolean().optional(),
+		/**
+		 * Patch the orchestration bag (`targetDomain`, `ourDomain`,
+		 * `competitorDomain`, `scope`, …) — keys the auto-schedule handler
+		 * stamps but the operator may need to fix on a misconfigured def
+		 * (#149). Merged ON TOP of the existing params; the use case still
+		 * preserves the entity-bound system keys (organizationId,
+		 * gscPropertyId, …) from the existing def via the same whitelist
+		 * used for `params` patches.
+		 */
+		systemParams: z.record(z.string(), z.unknown()).optional(),
 	})
-	.refine((v) => v.cron !== undefined || v.params !== undefined || v.enabled !== undefined, {
-		message: 'At least one of cron, params, enabled must be provided',
-	});
+	// `.strict()` rejects unknown fields with 400 instead of silently dropping
+	// them — pre-#149 the schema accepted arbitrary keys (including `systemParams`
+	// itself) and the use case never saw them, leaving the operator with a 200
+	// OK response and a still-broken schedule.
+	.strict()
+	.refine(
+		(v) =>
+			v.cron !== undefined ||
+			v.params !== undefined ||
+			v.enabled !== undefined ||
+			v.systemParams !== undefined,
+		{
+			message: 'At least one of cron, params, enabled, systemParams must be provided',
+		},
+	);
 export type UpdateJobDefinitionRequest = z.infer<typeof UpdateJobDefinitionRequest>;
 
 export const JobRunDto = z.object({

--- a/packages/providers/core/src/manifest.ts
+++ b/packages/providers/core/src/manifest.ts
@@ -94,6 +94,21 @@ export interface EndpointManifest<TParams = unknown, TResponse = unknown> {
 export interface IngestBinding<TResponse = unknown> {
 	readonly useCaseKey: string;
 	readonly systemParamKey: string;
+	/**
+	 * Extra systemParams the ACL/handler reads beyond the primary
+	 * `systemParamKey`. The IngestRouter validates ALL listed keys at
+	 * dispatch time and surfaces the missing set in a single
+	 * `INGEST_PRECONDITION_FAILED` error so the operator can fix the
+	 * schedule in one trip instead of discovering each missing key
+	 * across separate runs (#150).
+	 *
+	 * Use this for unconditional requirements (e.g. domain-intersection
+	 * always needs both `ourDomain` and `competitorDomain`). Bindings
+	 * whose ACL is polymorphic on a systemParam (e.g. needs
+	 * `competitorDomain` only when `scope === 'competitor'`) should NOT
+	 * declare those keys here — the ACL keeps its conditional check.
+	 */
+	readonly additionalSystemParamKeys?: readonly string[];
 	readonly acl: (response: TResponse, ctx: AclContext) => unknown[];
 }
 

--- a/packages/providers/dataforseo/src/acl/domain-intersection-to-domain.acl.ts
+++ b/packages/providers/dataforseo/src/acl/domain-intersection-to-domain.acl.ts
@@ -27,10 +27,11 @@ export interface DomainIntersectionRow {
  * ready for the competitor-intelligence ingest use case.
  *
  * Both `ourDomain` and `competitorDomain` come from `ctx.systemParams`. The
- * `IngestBinding` schema only models a single `systemParamKey`, so we pin
- * `ourDomain` as the binding's declared key (used by the router's
- * precondition guard) and read `competitorDomain` directly here — both are
- * required for the ACL to project rows correctly.
+ * binding pins `ourDomain` as the primary `systemParamKey` and lists
+ * `competitorDomain` under `additionalSystemParamKeys` so the IngestRouter
+ * surfaces both in a single precondition error (#150). The throws below
+ * are defence-in-depth — they catch ACL invocations from a code path that
+ * bypasses the router (none today, but cheaper than reasoning about it).
  *
  * Mapping convention (consistent with the endpoint's targets-order swap, see
  * `buildDomainIntersectionBody`):

--- a/packages/providers/dataforseo/src/manifest.ts
+++ b/packages/providers/dataforseo/src/manifest.ts
@@ -121,14 +121,15 @@ const rankTrackingRankedKeywordsIngest: IngestBinding<RankedKeywordsResponse> = 
  * `IngestDomainIntersectionUseCase`, which persists into the
  * `competitor_keyword_gaps` hypertable.
  *
- * `IngestBinding` only supports a single `systemParamKey`, so we declare
- * `ourDomain` (the precondition the router asserts before dispatch). The ACL
- * additionally reads `competitorDomain` directly from `ctx.systemParams` —
- * both are required for the row mapping to be meaningful.
+ * `ourDomain` is the binding's primary `systemParamKey`; `competitorDomain`
+ * is unconditionally required by the ACL too, so it's listed in
+ * `additionalSystemParamKeys` for the IngestRouter precondition (#150) —
+ * both missing keys surface in a single error instead of cascading.
  */
 const competitorIntelligenceDomainIntersectionIngest: IngestBinding<DomainIntersectionResponse> = {
 	useCaseKey: 'competitor-intelligence:ingest-domain-intersection',
 	systemParamKey: 'ourDomain',
+	additionalSystemParamKeys: ['competitorDomain'],
 	acl: normaliseDomainIntersectionResponse,
 };
 


### PR DESCRIPTION
## Summary

Closes #149 and #150 — two operator-DX bugs around `JobDefinition` schedules.

### #149 — PATCH `/job-definitions/{id}` silently dropped `systemParams`

The Zod schema for `UpdateJobDefinitionRequest` only declared `cron`, `params`, `enabled`. Unknown keys (including `systemParams`) were stripped silently, so the operator got a 200 OK but the schedule kept failing `INGEST_PRECONDITION_FAILED` because the orchestration key (e.g. `targetDomain`, `ourDomain`) never reached the def.

- `UpdateJobDefinitionRequest` now declares `systemParams: z.record(...)` and uses `.strict()` — unknown top-level fields surface as 400 instead of silent drop.
- `UpdateJobDefinitionUseCase` accepts `cmd.systemParams` and overlays it on `def.params` (MERGE semantics, complementary to the existing `params` REPLACE semantics). The entity-bound whitelist (`organizationId`, `projectId`, `gscPropertyId`, …) is still preserved — a PATCH cannot overwrite sacred keys.
- OpenAPI PATCH description rewritten to document the patch shape, whitelist behaviour, and the storage model (`systemParams` are stored merged into `params`; the GET response surfaces them under `params.<key>`).

### #150 — `INGEST_PRECONDITION_FAILED` cascaded one missing key at a time

`domain-intersection` requires both `ourDomain` and `competitorDomain`, but the IngestRouter only validated the binding's single `systemParamKey`. The ACL re-threw on its extras one at a time, so the operator paid two `run-now` round-trips to discover both missing keys.

- `IngestBinding` carries optional `additionalSystemParamKeys: readonly string[]`.
- IngestRouter validates ALL listed keys in one pass and groups the missing set in a single error: `... processor reached without systemParams: ourDomain, competitorDomain. Auto-Schedule handler should have set these.`
- DataForSEO's `domain-intersection` manifest declares `additionalSystemParamKeys: ['competitorDomain']`. The ACL throws stay in place as defence-in-depth for any future caller that bypasses the router.
- Empty-string values are now treated as missing (the ACLs already rejected them; this just shifts the better message earlier).

### Out of scope (deliberately)

- `on-page-instant-pages` is polymorphic on `systemParams.scope` (`'competitor'` requires extras; `'own'` doesn't). It can't declare `additionalSystemParamKeys` unconditionally without breaking own-domain schedules. Left to the ACL's conditional check.
- `ranked-keywords` only requires `targetDomain`, which is already the primary `systemParamKey`.

## Test plan

- [x] `pnpm typecheck` — 27/27 packages green.
- [x] `pnpm lint` — Biome clean (no fixes applied).
- [x] `pnpm test` — full suite green (402 tests in `application`, all 27 packages pass).
- New tests:
  - `UpdateJobDefinitionUseCase` — persists `systemParams` patch, blocks whitelist overwrites, applies `params + systemParams` together (3 cases).
  - `IngestRouter.dispatch` — groups missing keys into one error, single-additional missing surfaces, both present passes through, empty-string is treated as missing (4 cases).

## Notes for review

- The `.strict()` change is a minor breaking change for any client that was sending unknown top-level fields to PATCH (the issue's reproduction had `organizationId` as a junk top-level key). Pre-fix those were silently dropped; now they 400. This is the explicit improvement #2 from the issue ("Mejor: rechazar 400 campos desconocidos").
- The third point of #149 ("incluir systemParams en GET") is addressed via doc-only changes — the storage model merges them into `params` and re-deriving the split from origin is brittle. The OpenAPI description now spells this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #149
Closes #150

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYdYFQYi8yfacjJaD9vaqB)_