### PR TITLE
fix(worker): update lastRunAt on ALL run paths (#160)

### DIFF
--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -271,6 +271,10 @@ export class ProviderFetchProcessor {
 				);
 			}
 			run.complete(existing.id, this.deps.clock.now());
+			// #160: lastRunAt must update even on cache-hit so the dashboard
+			// stops reporting these defs as "never run".
+			definition.markRan(this.deps.clock.now());
+			await this.deps.jobDefRepo.save(definition);
 			await this.deps.jobRunRepo.save(run);
 			return;
 		}
@@ -506,6 +510,7 @@ export class ProviderFetchProcessor {
 				// (the `if (!definition.enabled) skip` branch above). The
 				// operator must explicitly re-enable after topping up credit.
 				definition.disable();
+				definition.markRan(this.deps.clock.now());
 				await this.deps.jobDefRepo.save(definition);
 				run.fail({ code: 'QUOTA_EXCEEDED', message, retryable: false }, this.deps.clock.now());
 				await this.deps.jobRunRepo.save(run);
@@ -527,6 +532,8 @@ export class ProviderFetchProcessor {
 				// dashboard can separate it from real upstream fetch
 				// failures, and do NOT re-throw.
 				run.fail({ code: 'INGEST_PRECONDITION_FAILED', message, retryable: false }, this.deps.clock.now());
+				definition.markRan(this.deps.clock.now());
+				await this.deps.jobDefRepo.save(definition);
 				await this.deps.jobRunRepo.save(run);
 				runLog.error(
 					{ err: message },
@@ -536,6 +543,8 @@ export class ProviderFetchProcessor {
 			}
 
 			run.fail({ code: 'FETCH_FAILED', message, retryable: true }, this.deps.clock.now());
+			definition.markRan(this.deps.clock.now());
+			await this.deps.jobDefRepo.save(definition);
 			await this.deps.jobRunRepo.save(run);
 			throw err;
 		}


### PR DESCRIPTION
## Closes #160

`provider-fetch.processor.ts` solo llamaba a `definition.markRan(now)` en el path happy de fetch+ingest. Las otras 4 terminaciones persistían el run pero dejaban el `lastRunAt` del def intacto:

1. **Idempotent skip (cache hit)** — el principal culpable. Cada run-now post-primera ejecución entra por aquí, persiste el run como `succeeded` con `rawPayloadId` cacheado, pero el def no se toca.
2. **QUOTA_EXCEEDED** — disable + save pero sin markRan.
3. **INGEST_PRECONDITION_FAILED** — fail + save run pero sin markRan.
4. **FETCH_FAILED** — fail + save run + throw, sin markRan.

Síntoma diagnosticado hoy: tras run-now masivo de 51 defs labs DataForSEO, el dashboard reportaba 44 como "never run" pese a tener runs `succeeded` con rawPayloadId limpio en BD.

## Semántica del campo

`lastRunAt` ahora significa "última vez que intentamos correr", no "última vez que terminó OK". Para distinguir éxito vs fracaso, consultar `runs.status` (ya está). De este modo:

- Un def que falla todos los runs muestra `lastRunAt` actualizándose y `runs[0].status = failed` — operador puede diferenciar "muerto silencioso" de "fallando ruidosamente".
- El filtro `lastRunAt IS NULL` ahora significa de verdad "nunca ran", no "primera run fue cache hit".

## Verificación post-merge

```bash
# Disparar run-now sobre cualquier def existente (cache hit guaranteed)
curl -X POST .../job-definitions/<def>/run-now -d '{"organizationId":"..."}'
sleep 5
# lastRunAt debe estar set
curl .../job-definitions/<def> | jq .lastRunAt
# → "2026-05-09T..." (no null)
```