### PR TITLE
fix(competitor-intelligence): swap targets order so /keyword-gaps actually returns rows

### DIFF
--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.spec.ts
@@ -77,7 +77,7 @@ describe('CompetitorAdded → schedules', () => {
 
 		// domain-intersection params pair OUR primary × the competitor
 		expect(di?.paramsBuilder(event)).toMatchObject({
-			targets: ['patroltech.online', 'silvertraconline.com'],
+			targets: ['silvertraconline.com', 'patroltech.online'],
 			locationCode: 2724,
 			languageCode: 'es',
 		});

--- a/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
+++ b/packages/application/src/competitor-intelligence/event-handlers/auto-schedule.config.ts
@@ -128,6 +128,12 @@ const buildCompetitorAddedSpecs = async (
 		});
 
 		// 2. domain-intersection — pairs OUR primary domain × this competitor.
+		// DataForSEO `one_intersect` returns keywords where target[0] ranks
+		// and target[1] does NOT. We want "keywords where competitor ranks
+		// and WE don't" (the gap to fagocitar), so the order is
+		// [competitorDomain, ourDomain] — NOT the other way around. Until
+		// PR fixing this, the read model was empty because we asked for
+		// keywords where our (new, near-empty) domains rank.
 		specs.push({
 			providerId: DOMAIN_INTERSECTION_DEFAULTS.providerId,
 			endpointId: DOMAIN_INTERSECTION_DEFAULTS.endpointId,
@@ -138,7 +144,7 @@ const buildCompetitorAddedSpecs = async (
 			// looks up `params[systemParamKey]` via a string `equals` match.
 			systemParamKey: 'intersectionScheduleKey',
 			paramsBuilder: () => ({
-				targets: [ourDomain, competitorDomain],
+				targets: [competitorDomain, ourDomain],
 				locationCode,
 				languageCode,
 				limit: DOMAIN_INTERSECTION_DEFAULTS.limit,


### PR DESCRIPTION
## Causa raíz

PR #155 (auto-schedule del competitor-intelligence) montó los specs de `domain-intersection` con `targets: [ourDomain, competitorDomain]`. El endpoint DataForSEO `domain_intersection/live` con `intersection_mode: 'one_intersect'` devuelve keywords donde `targets[0]` rankea y `targets[1]` NO. La intención de `/keyword-gaps` es lo INVERSO: keywords donde el COMPETIDOR rankea y NOSOTROS no.

Con el orden invertido el API devolvía "keywords donde nuestros dominios nuevos (casi vacíos) rankean y el competidor no" — el conjunto vacío.

Confirmado en producción: tras runs `succeeded` con `rawPayloadId` poblado, `/projects/{id}/keyword-gaps?ourDomain=X&competitorDomain=Y` devolvía `{rows: []}` en los 4 PT projects.

## Fix

```ts
// antes (PR #155)
targets: [ourDomain, competitorDomain],

// ahora
targets: [competitorDomain, ourDomain],
```

Más comentario inline explicando la semántica `one_intersect` para que el siguiente que pase no se equivoque. El descriptor del endpoint (`endpoints/domain-intersection.ts`) YA documentaba el orden correcto — me lo salté en PR #155.

Test spec actualizado para que el assertion refleje el nuevo orden.

## Follow-up operativo (no en este PR)

Las defs `domain-intersection` ya en producción (las creadas el día del PR #155) tienen el orden viejo baked-in en `params.targets`. Post-merge hay que:

1. Borrar via API/SQL las defs viejas: `WHERE provider_id='dataforseo' AND endpoint_id='dataforseo-labs-domain-intersection'`.
2. Re-disparar el auto-schedule re-añadiendo los competidores (o vía evento sintético).

Coste: ~30 DataForSEO calls a $0.02 = $0.60.

## Sin tests E2E

Vitest cubre el assertion del builder, pero el bug solo se ve contra DataForSEO real. La verificación post-merge es ejecutar un run-now de una def re-creada con orden correcto y confirmar que `/keyword-gaps` devuelve filas.
