### PR TITLE
fix(cockpit): exclude observations from unlinked GSC properties

### DIFF
--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
@@ -37,6 +37,15 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					     ELSE 0 END AS weighted_position
 				FROM gsc_observations
 				WHERE project_id = ${projectId}
+					-- Exclude observations from unlinked properties so the cockpit
+					-- only surfaces data from currently-active GSC properties.
+					-- Bug A of #164: unlinking a property left historical rows
+					-- in gsc_observations contributing to the cockpit until they
+					-- aged out of the window. This subquery makes unlink immediate.
+					AND gsc_property_id IN (
+						SELECT id FROM gsc_properties
+						WHERE project_id = ${projectId} AND unlinked_at IS NULL
+					)
 					AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 					AND query <> ''
 				GROUP BY query, page
@@ -89,6 +98,9 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 				SUM(impressions)::bigint AS impressions
 			FROM gsc_observations
 			WHERE project_id = ${projectId}
+				AND gsc_property_id IN (
+					SELECT id FROM gsc_properties WHERE project_id = ${projectId} AND unlinked_at IS NULL
+				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 				AND query <> ''
 			GROUP BY week_start, query
@@ -128,6 +140,9 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 				SUM(impressions)::bigint AS impressions
 			FROM gsc_observations
 			WHERE project_id = ${projectId}
+				AND gsc_property_id IN (
+					SELECT id FROM gsc_properties WHERE project_id = ${projectId} AND unlinked_at IS NULL
+				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 			GROUP BY day
 			ORDER BY day ASC


### PR DESCRIPTION
## Closes #164 (definitivamente)

Post-PR #166 + cleanup operativo: `sc-domain:patroltech.online` unlinked en PT EN/FR/MX. Pero el cockpit SEGUÍA mostrando los mismos queries de PT ES en los 4 proyectos.

**Causa**: el unlink solo evita FUTURAS ingestas (ya estaba bien en `IngestGscRowsUseCase` desde el día 1 con `!property.isActive()` short-circuit). Pero las observations HISTÓRICAS (insertadas cuando la property estaba activa) persisten en `gsc_observations` con su `project_id` original, contribuyendo al cockpit hasta envejecer (~30 días).

## Fix

Las 3 queries del cockpit (`aggregateByQuery`, `weeklyClicksByQuery`, `dailyTotalsForProject`) añaden filtro subquery:
```sql
AND gsc_property_id IN (
    SELECT id FROM gsc_properties
    WHERE project_id = X AND unlinked_at IS NULL
)
```

Unlink ahora es inmediato a nivel de read-time, sin necesidad de migración de datos.

## Coste

`gsc_properties` tiene ~10 rows por project. Índice `gsc_properties_project_idx` cubre el WHERE. Sub-milisegundo extra por query.

## Verificación manual post-deploy

```
PT EN cockpit BEFORE: "patrol texh" pos 17  (de PT ES, vía patroltech.online linked)
PT EN cockpit AFTER:  solo queries de guardtour.app
```