### PR TITLE
fix(ai-search): cast project_id and brand_prompt_id to uuid in raw SQL

### DIFF
--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -51,7 +51,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions,
 					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
 				FROM llm_answers
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			)
 			SELECT
@@ -112,7 +112,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions,
 					CASE WHEN jsonb_typeof(citations) = 'array' THEN citations ELSE '[]'::jsonb END AS citations
 				FROM llm_answers
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			),
 			totals AS (
@@ -215,7 +215,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				CROSS JOIN LATERAL jsonb_array_elements(
 					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
 				) c
-				WHERE a.project_id = ${projectId}
+				WHERE a.project_id = ${projectId}::uuid
 				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 				  AND (${aiProvider}::text IS NULL OR a.ai_provider = ${aiProvider}::text)
 			)
@@ -273,7 +273,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					captured_at,
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
 				FROM llm_answers
-				WHERE brand_prompt_id = ${brandPromptId}
+				WHERE brand_prompt_id = ${brandPromptId}::uuid
 				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			)
 			SELECT
@@ -314,7 +314,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 					captured_at,
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
 				FROM llm_answers
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 			)
 			SELECT
@@ -385,7 +385,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				SELECT ai_provider, country, language, captured_at,
 					CASE WHEN jsonb_typeof(mentions) = 'array' THEN mentions ELSE '[]'::jsonb END AS mentions
 				FROM llm_answers
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 				  AND captured_at >= ${lastWeekStartIso}
 				  AND captured_at <= ${asOfIso}
 			)
@@ -477,7 +477,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				CROSS JOIN LATERAL jsonb_array_elements(
 					CASE WHEN jsonb_typeof(a.citations) = 'array' THEN a.citations ELSE '[]'::jsonb END
 				) c
-				WHERE a.project_id = ${projectId}
+				WHERE a.project_id = ${projectId}::uuid
 				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 				  AND COALESCE((c->>'isOwnDomain')::bool, false) = true
 				GROUP BY a.ai_provider, a.country, a.language, c->>'url', c->>'domain', day
@@ -501,7 +501,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				SELECT ai_provider, country, language,
 					MAX(captured_at AT TIME ZONE 'UTC')::date AS last_capture_day
 				FROM llm_answers
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 				  AND captured_at BETWEEN ${fromIso} AND ${toIso}
 				GROUP BY ai_provider, country, language
 			),
@@ -571,7 +571,7 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 				CROSS JOIN LATERAL jsonb_array_elements(
 					CASE WHEN jsonb_typeof(a.mentions) = 'array' THEN a.mentions ELSE '[]'::jsonb END
 				) m
-				WHERE a.project_id = ${projectId}
+				WHERE a.project_id = ${projectId}::uuid
 				  AND a.captured_at BETWEEN ${fromIso} AND ${toIso}
 			),
 			own_pos AS (


### PR DESCRIPTION
## Summary

Cast `project_id` and `brand_prompt_id` to `uuid` in raw template-literal SQL inside `DrizzleLlmAnswerReadModel`, so that the predicates are type-stable and Timescale can push them down into compressed chunks.

## Problem

The `ai-search/presence`, `cited-domains`, `cited-pages`, `mentions-overview` and related endpoints return **`totalAnswers = 0`** for projects whose answer data has crossed the TimescaleDB compression threshold (`compress_after = 7 days`), even though `/ai-search/answers` correctly lists the rows.

Confirmed today on PatrolTech portfolio (`organizationId: ebc15d3c-8698-4100-b7e4-f4d8db3a614e`):

| Project | `/ai-search/answers` items | `/ai-search/presence` totalAnswers |
|---|---:|---:|
| ES (`patroltech.online`) | 50 | 14 ← only uncompressed |
| EN (`guardtour.app`) | 50 | **0** |
| MX (`controlrondas.com.mx`) | 14 | **0** |
| FR (`rondesdesecurite.fr`) | 17 | **0** |

ES still works partially because it has the most recent data; everything older than 7 days is invisible to the aggregations.

## Root cause

The `llm_answers` hypertable is compressed with `compress_segmentby = 'project_id, ai_provider'`. Drizzle's template-literal serializer sends branded uuid values as `text`, so the predicate

```sql
WHERE project_id = $1   -- $1 sent as text
```

requires postgres to apply an implicit `uuid = text` comparison. On the compressed columnstore that comparison cannot be pushed down to the segmentby metadata — the rows are filtered out before the runtime cast can recover them.

Adding `::uuid` to the parameter makes the predicate type-stable and segmentby-aware:

```sql
WHERE project_id = $1::uuid
```

Timescale can now use the chunk-level minmax for `project_id`, and compressed segments return the expected rows.

## Changes

- `packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts`
  - 8 occurrences of `WHERE project_id = ${projectId}` → `WHERE project_id = ${projectId}::uuid`
  - 1 occurrence of `WHERE brand_prompt_id = ${brandPromptId}` → `WHERE brand_prompt_id = ${brandPromptId}::uuid`

## Risk

Minimal. All call sites pass a validated uuid from the upstream domain layer, so the cast either succeeds (expected) or surfaces an early `invalid input syntax for type uuid` instead of silently returning empty aggregations.

## Verification

Manual `psql` against the production DB shows the predicate now uses `Custom Scan (DecompressChunk)` with segmentby pushdown instead of the previous Seq Scan + post-decompress filter. Once deployed, `ai-search/presence` for EN/MX/FR should return non-zero `totalAnswers`.
