### PR TITLE
fix(ai-search): batch fixes for 4 production bugs (#169 #170 #173 #174)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -441,6 +441,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		brandWatchlistResolver,
 		mentionExtractor,
 		aiSearchInsightsSchemaTables: DrizzlePersistence.schema.aiSearchInsightsSchemaTables,
+		// #174 — needed by DeleteBrandPromptUseCase to cascade the prompt
+		// removal into its scheduled JobDefinitions (no DB-level FK exists
+		// from job defs to brand prompts; the link is via JSONB params).
+		jobDefinitionRepo: jobDefRepo,
 		...autoScheduleSurface,
 		// dynamicSchedules in `aiSearchInsightsAutoScheduleConfigs` reads
 		// project locations + connected credentials at handle-time. These

--- a/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
+++ b/apps/api/src/modules/ai-search-insights/ai-search-insights.controller.ts
@@ -82,6 +82,31 @@ export class AiSearchInsightsController {
 		return { items: items.map((i) => ({ ...i })) };
 	}
 
+	/**
+	 * #170 — detail-by-id. Returns the same DTO shape that appears inside
+	 * `items[]` of the list endpoint, so SDK consumers and integrations can
+	 * drill into a single prompt without filtering the list client-side.
+	 * `requirePrompt` already enforces the project-scoped lookup + org
+	 * membership check, so a 404 here means "not found within this project"
+	 * (covers both wrong-project and missing-prompt cases).
+	 */
+	@Get('projects/:projectId/brand-prompts/:promptId')
+	async get(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+		@Param('promptId') promptId: string,
+	): Promise<AiSearchInsightsContracts.BrandPromptDtoSchema> {
+		const prompt = await this.requirePrompt(principal, projectId, promptId);
+		return {
+			id: prompt.id,
+			projectId: prompt.projectId,
+			text: prompt.text.value,
+			kind: prompt.kind,
+			pausedAt: prompt.pausedAt?.toISOString() ?? null,
+			createdAt: prompt.createdAt.toISOString(),
+		};
+	}
+
 	@Patch('projects/:projectId/brand-prompts/:promptId')
 	async pauseOrResume(
 		@Principal() principal: AuthPrincipal,

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -912,6 +912,26 @@ export function buildOpenApiDocument(): unknown {
 	});
 
 	registry.registerPath({
+		method: 'get',
+		path: '/api/v1/projects/{projectId}/brand-prompts/{promptId}',
+		summary: 'Get a single BrandPrompt by id',
+		description:
+			'Returns the same DTO that appears inside `items[]` of the list endpoint. Use for SDK consumers that need to drill into a single prompt without filtering the list client-side.',
+		tags: ['ai-search-insights'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ projectId: z.string().uuid(), promptId: z.string().uuid() }) },
+		responses: {
+			200: {
+				description: 'BrandPrompt',
+				content: {
+					'application/json': { schema: AiSearchInsightsContracts.BrandPromptDtoSchema },
+				},
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
 		method: 'patch',
 		path: '/api/v1/projects/{projectId}/brand-prompts/{promptId}',
 		summary: 'Pause or resume a BrandPrompt',

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -29,7 +29,7 @@ import { AnthropicApiError } from '@rankpulse/provider-anthropic';
 import { BingApiError } from '@rankpulse/provider-bing';
 import { BrevoApiError } from '@rankpulse/provider-brevo';
 import { CloudflareRadarApiError } from '@rankpulse/provider-cloudflare-radar';
-import type { ManifestProviderRegistry } from '@rankpulse/provider-core';
+import { type ManifestProviderRegistry, ProviderApiError } from '@rankpulse/provider-core';
 import {
 	DataForSeoApiError,
 	extractTop10Domains,
@@ -503,7 +503,17 @@ export class ProviderFetchProcessor {
 			await this.deps.jobDefRepo.save(definition);
 			await this.deps.jobRunRepo.save(run);
 		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
+			// #173: surface upstream response bodies on provider failures. The
+			// `ProviderApiError.body` field has the truncated upstream payload
+			// (≤4KB); including it in both the persisted run.error.message AND
+			// the structured log line means the operator sees Anthropic /
+			// OpenAI / etc.'s actual rejection reason in `/runs?limit=N`
+			// instead of just `"anthropic POST /messages → 400"`.
+			const baseMessage = err instanceof Error ? err.message : String(err);
+			const message =
+				err instanceof ProviderApiError && err.body
+					? `${baseMessage} | body: ${err.body.slice(0, 1024)}`
+					: baseMessage;
 
 			if (isQuotaExhaustedError(err)) {
 				// Auto-pause the definition so the next cron tick is a no-op
@@ -525,19 +535,27 @@ export class ProviderFetchProcessor {
 				// ADR 0001 invariant violation — the entity-bound endpoint
 				// guards (gscPropertyId, ga4PropertyId, trackedPageId,
 				// wikipediaArticleId, bingPropertyId, clarityProjectId,
-				// monitoredDomainId) only fail when a schedule was created
-				// off-path (i.e. bypassing the Auto-Schedule handler). This
-				// is a programmer error — retrying via BullMQ would just
-				// loop. Mark the run failed with a distinct code so the
-				// dashboard can separate it from real upstream fetch
-				// failures, and do NOT re-throw.
-				run.fail({ code: 'INGEST_PRECONDITION_FAILED', message, retryable: false }, this.deps.clock.now());
+				// monitoredDomainId, brandPromptId) only fail when a schedule
+				// was created off-path (i.e. bypassing the Auto-Schedule
+				// handler) OR when the referenced entity was later deleted
+				// without cascading the schedule (#174). This is a permanent
+				// failure — retrying via BullMQ would just loop forever, and
+				// daily cron ticks waste API calls against the upstream.
+				//
+				// #174 defense-in-depth: auto-disable the definition so the
+				// next tick is a no-op. The cascade-delete in
+				// `DeleteBrandPromptUseCase` handles the prevention side;
+				// this handler is the safety net for legacy data and
+				// off-path deletes. The operator can re-enable from the
+				// dashboard if the underlying entity is restored.
+				definition.disable();
 				definition.markRan(this.deps.clock.now());
 				await this.deps.jobDefRepo.save(definition);
+				run.fail({ code: 'INGEST_PRECONDITION_FAILED', message, retryable: false }, this.deps.clock.now());
 				await this.deps.jobRunRepo.save(run);
 				runLog.error(
 					{ err: message },
-					'ingest precondition failed — schedule created off-path (see ADR 0001)',
+					'ingest precondition failed — referenced entity missing; definition auto-disabled (#174)',
 				);
 				return;
 			}
@@ -546,6 +564,17 @@ export class ProviderFetchProcessor {
 			definition.markRan(this.deps.clock.now());
 			await this.deps.jobDefRepo.save(definition);
 			await this.deps.jobRunRepo.save(run);
+			if (err instanceof ProviderApiError) {
+				runLog.error(
+					{
+						err: baseMessage,
+						providerId: err.providerId,
+						status: err.status,
+						body: err.body?.slice(0, 1024),
+					},
+					'provider fetch failed',
+				);
+			}
 			throw err;
 		}
 	}

--- a/packages/application/src/ai-search-insights/module.ts
+++ b/packages/application/src/ai-search-insights/module.ts
@@ -1,4 +1,8 @@
-import type { AiSearchInsights as AISIDomain, SharedKernel } from '@rankpulse/domain';
+import type {
+	AiSearchInsights as AISIDomain,
+	ProviderConnectivity as PCDomain,
+	SharedKernel,
+} from '@rankpulse/domain';
 import type { Clock, IdGenerator } from '@rankpulse/shared';
 import { buildAutoScheduleHandlers } from '../_core/auto-schedule.js';
 import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
@@ -30,6 +34,11 @@ export interface AiSearchInsightsDeps {
 	readonly brandWatchlistResolver: AISIDomain.BrandWatchlistResolver;
 	readonly mentionExtractor: AISIDomain.MentionExtractor;
 	readonly aiSearchInsightsSchemaTables: readonly unknown[];
+	// #174 — DeleteBrandPromptUseCase cascades the prompt removal into the
+	// JobDefinitions that reference it via `params.brandPromptId`. The
+	// brand_prompts ⇄ provider_job_definitions link is JSONB-based, so the
+	// database can't cascade for us.
+	readonly jobDefinitionRepo: PCDomain.JobDefinitionRepository;
 }
 
 export const aiSearchInsightsModule: ContextModule = {
@@ -50,7 +59,7 @@ export const aiSearchInsightsModule: ContextModule = {
 				RegisterBrandPrompt: new RegisterBrandPromptUseCase(d.brandPromptRepo, d.clock, d.ids, d.events),
 				PauseBrandPrompt: new PauseBrandPromptUseCase(d.brandPromptRepo, d.clock, d.events),
 				ResumeBrandPrompt: new ResumeBrandPromptUseCase(d.brandPromptRepo, d.clock, d.events),
-				DeleteBrandPrompt: new DeleteBrandPromptUseCase(d.brandPromptRepo),
+				DeleteBrandPrompt: new DeleteBrandPromptUseCase(d.brandPromptRepo, d.jobDefinitionRepo),
 				ListBrandPrompts: new ListBrandPromptsUseCase(d.brandPromptRepo),
 				RecordLlmAnswer: recordLlmAnswer,
 				QueryLlmAnswers: new QueryLlmAnswersUseCase(d.llmAnswerRepo),

--- a/packages/application/src/ai-search-insights/use-cases/delete-brand-prompt.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/delete-brand-prompt.use-case.spec.ts
@@ -1,4 +1,9 @@
-import { AiSearchInsights, type IdentityAccess, type ProjectManagement } from '@rankpulse/domain';
+import {
+	AiSearchInsights,
+	type IdentityAccess,
+	type ProjectManagement,
+	ProviderConnectivity,
+} from '@rankpulse/domain';
 import { NotFoundError, type Uuid } from '@rankpulse/shared';
 import { InMemoryBrandPromptRepository } from '@rankpulse/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -6,59 +11,211 @@ import { DeleteBrandPromptUseCase } from './delete-brand-prompt.use-case.js';
 
 const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
+const OTHER_PROJECT_ID = '22222222-2222-2222-2222-222222222222' as Uuid as ProjectManagement.ProjectId;
 
-const buildPrompt = (id: string, text: string) =>
+const buildPrompt = (id: string, text: string, projectId: ProjectManagement.ProjectId = PROJECT_ID) =>
 	AiSearchInsights.BrandPrompt.register({
 		id: id as Uuid as AiSearchInsights.BrandPromptId,
 		organizationId: ORG_ID,
-		projectId: PROJECT_ID,
+		projectId,
 		text: AiSearchInsights.PromptText.create(text),
 		kind: 'branded',
 		now: new Date('2026-05-04T10:00:00Z'),
 	});
 
+class StubJobDefinitionRepo implements ProviderConnectivity.JobDefinitionRepository {
+	readonly store = new Map<string, ProviderConnectivity.ProviderJobDefinition>();
+	put(def: ProviderConnectivity.ProviderJobDefinition): void {
+		this.store.set(def.id, def);
+	}
+	async save(d: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
+		this.store.set(d.id, d);
+	}
+	async findById(id: ProviderConnectivity.ProviderJobDefinitionId) {
+		return this.store.get(id) ?? null;
+	}
+	async findFor() {
+		return null;
+	}
+	async findByProjectEndpointAndSystemParam(): Promise<ProviderConnectivity.ProviderJobDefinition | null> {
+		return null;
+	}
+	async listForProject(projectId: ProjectManagement.ProjectId) {
+		return [...this.store.values()].filter((d) => d.projectId === projectId);
+	}
+	async delete(id: ProviderConnectivity.ProviderJobDefinitionId) {
+		this.store.delete(id);
+	}
+}
+
+const buildAiSearchDef = (overrides: {
+	id: string;
+	projectId?: ProjectManagement.ProjectId;
+	providerId: string;
+	endpointId: string;
+	brandPromptId: string;
+}) =>
+	ProviderConnectivity.ProviderJobDefinition.schedule({
+		id: overrides.id as ProviderConnectivity.ProviderJobDefinitionId,
+		projectId: overrides.projectId ?? PROJECT_ID,
+		providerId: ProviderConnectivity.ProviderId.create(overrides.providerId),
+		endpointId: ProviderConnectivity.EndpointId.create(overrides.endpointId),
+		params: {
+			brandPromptId: overrides.brandPromptId,
+			prompt: 'test',
+			locationCountry: 'ES',
+			locationLanguage: 'es',
+			model: 'auto',
+			organizationId: ORG_ID,
+		},
+		cron: ProviderConnectivity.CronExpression.create('0 7 * * *'),
+		credentialOverrideId: null,
+		now: new Date('2026-05-04T10:00:00Z'),
+	});
+
 describe('DeleteBrandPromptUseCase', () => {
-	let repo: InMemoryBrandPromptRepository;
+	let promptRepo: InMemoryBrandPromptRepository;
+	let jobDefRepo: StubJobDefinitionRepo;
 
 	beforeEach(() => {
-		repo = new InMemoryBrandPromptRepository();
+		promptRepo = new InMemoryBrandPromptRepository();
+		jobDefRepo = new StubJobDefinitionRepo();
 	});
 
 	it('removes the prompt from the repository', async () => {
 		const prompt = buildPrompt('bp-1', 'Best CRMs for solo founders?');
-		await repo.save(prompt);
+		await promptRepo.save(prompt);
 
-		const useCase = new DeleteBrandPromptUseCase(repo);
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
 		await useCase.execute({ brandPromptId: prompt.id });
 
-		expect(await repo.findById(prompt.id)).toBeNull();
+		expect(await promptRepo.findById(prompt.id)).toBeNull();
 	});
 
 	it('throws NotFoundError when the prompt does not exist', async () => {
-		const useCase = new DeleteBrandPromptUseCase(repo);
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
 		await expect(useCase.execute({ brandPromptId: 'missing' })).rejects.toBeInstanceOf(NotFoundError);
 	});
 
 	it('only deletes the targeted prompt when several exist for the same project', async () => {
 		const first = buildPrompt('bp-1', 'Best CRMs for solo founders?');
 		const second = buildPrompt('bp-2', 'Top SEO tools 2026');
-		await repo.save(first);
-		await repo.save(second);
+		await promptRepo.save(first);
+		await promptRepo.save(second);
 
-		const useCase = new DeleteBrandPromptUseCase(repo);
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
 		await useCase.execute({ brandPromptId: first.id });
 
-		expect(await repo.findById(first.id)).toBeNull();
-		expect(await repo.findById(second.id)).not.toBeNull();
+		expect(await promptRepo.findById(first.id)).toBeNull();
+		expect(await promptRepo.findById(second.id)).not.toBeNull();
 	});
 
 	it('rejects a re-delete on the same id with NotFoundError (already removed)', async () => {
 		const prompt = buildPrompt('bp-1', 'Best CRMs for solo founders?');
-		await repo.save(prompt);
+		await promptRepo.save(prompt);
 
-		const useCase = new DeleteBrandPromptUseCase(repo);
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
 		await useCase.execute({ brandPromptId: prompt.id });
 
 		await expect(useCase.execute({ brandPromptId: prompt.id })).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('#174: cascades to ALL job-definitions that reference the deleted brandPromptId', async () => {
+		// One BrandPrompt fans out to 4 providers × N locales. Simulate the
+		// real production shape: 3 providers × 2 locales = 6 schedules tied
+		// to the prompt being deleted.
+		const prompt = buildPrompt('bp-cascade', 'Best B2B CRMs?');
+		await promptRepo.save(prompt);
+
+		const matching = [
+			buildAiSearchDef({
+				id: 'def-openai-es',
+				providerId: 'openai',
+				endpointId: 'openai-responses-with-web-search',
+				brandPromptId: prompt.id,
+			}),
+			buildAiSearchDef({
+				id: 'def-openai-en',
+				providerId: 'openai',
+				endpointId: 'openai-responses-with-web-search',
+				brandPromptId: prompt.id,
+			}),
+			buildAiSearchDef({
+				id: 'def-anthropic-es',
+				providerId: 'anthropic',
+				endpointId: 'anthropic-messages-with-web-search',
+				brandPromptId: prompt.id,
+			}),
+			buildAiSearchDef({
+				id: 'def-perplexity-es',
+				providerId: 'perplexity',
+				endpointId: 'perplexity-sonar-search',
+				brandPromptId: prompt.id,
+			}),
+		];
+		for (const def of matching) jobDefRepo.put(def);
+
+		// Schedules belonging to a DIFFERENT prompt — must survive the cascade.
+		const otherPrompt = buildPrompt('bp-other', 'Different prompt');
+		await promptRepo.save(otherPrompt);
+		const survivor = buildAiSearchDef({
+			id: 'def-openai-other',
+			providerId: 'openai',
+			endpointId: 'openai-responses-with-web-search',
+			brandPromptId: otherPrompt.id,
+		});
+		jobDefRepo.put(survivor);
+
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
+		await useCase.execute({ brandPromptId: prompt.id });
+
+		// The prompt is gone…
+		expect(await promptRepo.findById(prompt.id)).toBeNull();
+		// …and all 4 of its schedules with it…
+		for (const def of matching) {
+			expect(await jobDefRepo.findById(def.id)).toBeNull();
+		}
+		// …but the other prompt's schedule is untouched.
+		expect(await jobDefRepo.findById(survivor.id)).not.toBeNull();
+		expect(await promptRepo.findById(otherPrompt.id)).not.toBeNull();
+	});
+
+	it('#174: does NOT touch job-definitions from other projects, even if their params happen to match', async () => {
+		// Cross-project safety: `listForProject` already filters by project,
+		// so a def in another project with the same brandPromptId (impossible
+		// in practice because BrandPromptId is a UUID, but worth covering)
+		// must not be deleted. Also verifies non-AI schedules (DataForSEO,
+		// GSC, etc.) for the SAME project are left alone.
+		const prompt = buildPrompt('bp-iso', 'Isolated prompt');
+		await promptRepo.save(prompt);
+
+		// Same-project non-matching def (no brandPromptId in params).
+		const nonAiSameProject = ProviderConnectivity.ProviderJobDefinition.schedule({
+			id: 'def-dataforseo' as ProviderConnectivity.ProviderJobDefinitionId,
+			projectId: PROJECT_ID,
+			providerId: ProviderConnectivity.ProviderId.create('dataforseo'),
+			endpointId: ProviderConnectivity.EndpointId.create('serp-google-organic-live'),
+			params: { keyword: 'k', locationCode: 2724, languageCode: 'es', device: 'desktop' },
+			cron: ProviderConnectivity.CronExpression.create('0 6 * * 1'),
+			credentialOverrideId: null,
+			now: new Date('2026-05-04T00:00:00Z'),
+		});
+		jobDefRepo.put(nonAiSameProject);
+
+		// Other-project def whose params somehow reference the same id.
+		const otherProjectMatch = buildAiSearchDef({
+			id: 'def-other-project',
+			projectId: OTHER_PROJECT_ID,
+			providerId: 'openai',
+			endpointId: 'openai-responses-with-web-search',
+			brandPromptId: prompt.id,
+		});
+		jobDefRepo.put(otherProjectMatch);
+
+		const useCase = new DeleteBrandPromptUseCase(promptRepo, jobDefRepo);
+		await useCase.execute({ brandPromptId: prompt.id });
+
+		expect(await jobDefRepo.findById(nonAiSameProject.id)).not.toBeNull();
+		expect(await jobDefRepo.findById(otherProjectMatch.id)).not.toBeNull();
 	});
 });

--- a/packages/application/src/ai-search-insights/use-cases/delete-brand-prompt.use-case.ts
+++ b/packages/application/src/ai-search-insights/use-cases/delete-brand-prompt.use-case.ts
@@ -1,4 +1,4 @@
-import type { AiSearchInsights } from '@rankpulse/domain';
+import type { AiSearchInsights, ProviderConnectivity } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
 
 export interface DeleteBrandPromptCommand {
@@ -6,14 +6,37 @@ export interface DeleteBrandPromptCommand {
 }
 
 /**
- * Deletes a BrandPrompt. Note that historical LlmAnswers are kept (the user
- * may want to look back at trends from a prompt they removed); only the
- * prompt and its scheduled JobDefinitions are taken down. The cascade of
- * job-definition deletion happens in the persistence layer via a foreign
- * key with ON DELETE CASCADE.
+ * Deletes a BrandPrompt + cascades to its scheduled JobDefinitions.
+ *
+ * Historical LlmAnswers are kept (the user may want to look back at trends
+ * from a prompt they removed); only the prompt and its schedules are taken
+ * down.
+ *
+ * #174: brand_prompts has NO foreign key from `provider_job_definitions`
+ * (they reference the brandPromptId via `params.brandPromptId` JSONB, not
+ * via a relational column), so the database can't cascade for us. Before
+ * #174 the use case deleted just the prompt and left the schedules in
+ * place, causing every subsequent cron tick to fail with
+ * `INGEST_PRECONDITION_FAILED: BrandPrompt … not found` until the operator
+ * noticed and disabled them by hand. Now the use case enumerates schedules
+ * for the project and deletes any whose `params.brandPromptId` matches the
+ * prompt being removed.
+ *
+ * Defence-in-depth: even when this cascade fails (DB hiccup mid-cascade,
+ * schedules created off-path before this fix shipped, …), the worker's
+ * `INGEST_PRECONDITION_FAILED` handler now auto-disables the definition on
+ * the first failed tick — no second wasted API call.
+ *
+ * Order: delete the schedules FIRST, then the prompt. If only the prompt
+ * delete fails the worst case is an orphan prompt with no schedules,
+ * which is operationally fine; if only the schedule cleanup fails (after
+ * the prompt is gone) we'd leave the bug we're trying to fix.
  */
 export class DeleteBrandPromptUseCase {
-	constructor(private readonly prompts: AiSearchInsights.BrandPromptRepository) {}
+	constructor(
+		private readonly prompts: AiSearchInsights.BrandPromptRepository,
+		private readonly jobDefinitions: ProviderConnectivity.JobDefinitionRepository,
+	) {}
 
 	async execute(cmd: DeleteBrandPromptCommand): Promise<void> {
 		const id = cmd.brandPromptId as AiSearchInsights.BrandPromptId;
@@ -21,6 +44,22 @@ export class DeleteBrandPromptUseCase {
 		if (!prompt) {
 			throw new NotFoundError(`BrandPrompt ${cmd.brandPromptId} not found`);
 		}
+
+		// `listForProject` is the only repo method that surfaces ALL job
+		// definitions in scope — there's no by-systemParam index. The fan-out
+		// touches all 4 AI providers × N locales per prompt, so we'd otherwise
+		// have to enumerate (provider, endpoint) tuples here, which would miss
+		// any future AI provider added later. The in-app filter is O(N_defs)
+		// per call but typical projects have ≤100 schedules; acceptable.
+		const allDefs = await this.jobDefinitions.listForProject(prompt.projectId);
+		const orphans = allDefs.filter((def) => {
+			const params = def.params as Record<string, unknown>;
+			return params.brandPromptId === id;
+		});
+		for (const def of orphans) {
+			await this.jobDefinitions.delete(def.id);
+		}
+
 		await this.prompts.delete(id);
 	}
 }

--- a/packages/application/src/ai-search-insights/use-cases/record-llm-answer.use-case.spec.ts
+++ b/packages/application/src/ai-search-insights/use-cases/record-llm-answer.use-case.spec.ts
@@ -131,4 +131,101 @@ describe('RecordLlmAnswerUseCase', () => {
 		expect(extractor.lastInput?.watchlist).toBe(watchlist);
 		expect(extractor.lastInput?.location.toString()).toBe('es-ES');
 	});
+
+	it('#169 regression: competitor domains in the watchlist are NOT flagged as isOwnDomain=true', async () => {
+		// Real-world reproducer: ES project tracks patroltech.online + 4
+		// competitors. The bug flattened ALL entries' ownDomains into the
+		// "own" list, causing citations of tracktik.com / qrpatrol.com /
+		// silvertracsoftware.com to be marked isOwnDomain=true (which
+		// inflated citationRate above 1.0 — see issue #169).
+		const promptRepo = new InMemoryBrandPromptRepository();
+		const answerRepo = new InMemoryLlmAnswerRepository();
+		const events = new RecordingEventPublisher();
+
+		const orgId = Uuid.generate();
+		const projectId = Uuid.generate();
+		const promptId = '00000000-0000-0000-0000-000000000b01';
+
+		const register = new RegisterBrandPromptUseCase(
+			promptRepo,
+			fixedClock(new Date('2026-05-26T00:00:00Z')),
+			fixedIds([promptId]),
+			events,
+		);
+		await register.execute({
+			organizationId: orgId,
+			projectId,
+			text: 'best guard tour software',
+			kind: 'category',
+		});
+		events.clear();
+
+		const watchlist = [
+			AiSearchInsights.BrandWatchEntry.create({
+				name: 'Patroltech',
+				aliases: [],
+				ownDomains: ['patroltech.online', 'guardtour.app'],
+				isOwnBrand: true,
+			}),
+			AiSearchInsights.BrandWatchEntry.create({
+				name: 'TrackTik',
+				aliases: [],
+				ownDomains: ['tracktik.com'],
+				isOwnBrand: false,
+			}),
+			AiSearchInsights.BrandWatchEntry.create({
+				name: 'QR Patrol',
+				aliases: [],
+				ownDomains: ['qrpatrol.com'],
+				isOwnBrand: false,
+			}),
+		];
+
+		const useCase = new RecordLlmAnswerUseCase(
+			promptRepo,
+			answerRepo,
+			new StaticBrandWatchlistResolver(watchlist),
+			new ScriptedMentionExtractor(),
+			fixedClock(new Date('2026-05-26T07:00:00Z')),
+			fixedIds(['00000000-0000-0000-0000-000000000b02']),
+			events,
+		);
+
+		const result = await useCase.execute({
+			brandPromptId: promptId,
+			country: 'ES',
+			language: 'es',
+			rawPayloadId: null,
+			response: {
+				aiProvider: 'openai',
+				model: 'gpt-5-mini',
+				rawText: 'Top picks: Patroltech, TrackTik, QR Patrol.',
+				citationUrls: [
+					'https://patroltech.online/features',
+					'https://guardtour.app/pricing',
+					'https://tracktik.com/about',
+					'https://qrpatrol.com/blog/post',
+					'https://random-blog.example/article',
+				],
+				tokenUsage: AiSearchInsights.TokenUsage.zero(),
+				costCents: 3.0,
+			},
+		});
+
+		const stored = await answerRepo.findById(
+			result.llmAnswerId as ReturnType<typeof Uuid.generate> as AiSearchInsights.LlmAnswerId,
+		);
+		const byDomain = (domain: string) => stored?.citations.find((c) => c.domain === domain);
+
+		// Own aliases (primary + secondary): must be true.
+		expect(byDomain('patroltech.online')?.isOwnDomain).toBe(true);
+		expect(byDomain('guardtour.app')?.isOwnDomain).toBe(true);
+
+		// Competitors: must NOT be flagged as own.
+		expect(byDomain('tracktik.com')?.isOwnDomain).toBe(false);
+		expect(byDomain('qrpatrol.com')?.isOwnDomain).toBe(false);
+
+		// Random third-party: must be false (sanity).
+		expect(byDomain('random-blog.example')?.isOwnDomain).toBe(false);
+	});
 });

--- a/packages/application/src/ai-search-insights/use-cases/record-llm-answer.use-case.ts
+++ b/packages/application/src/ai-search-insights/use-cases/record-llm-answer.use-case.ts
@@ -61,7 +61,15 @@ export class RecordLlmAnswerUseCase {
 
 		const projectId = prompt.projectId;
 		const watchlist = await this.watchlist.resolveForProject(projectId);
-		const ownDomains = watchlist.flatMap((w) => w.ownDomains);
+		// #169: filter by `isOwnBrand` BEFORE flattening. A `BrandWatchEntry`
+		// stores the brand's owned domains in `ownDomains`, but the watchlist
+		// contains entries for BOTH the project's own brand AND its tracked
+		// competitors. Flattening without filtering caused competitor domains
+		// (silvertracsoftware.com, tracktik.com, qrpatrol.com, …) to flow
+		// into `Citation.fromUrl`'s ownDomains list, marking citations of
+		// competitor URLs as `isOwnDomain: true` and inflating `citationRate`
+		// above 1.0 in the presence read-model.
+		const ownDomains = watchlist.filter((w) => w.isOwnBrand).flatMap((w) => w.ownDomains);
 		const citations = cmd.response.citationUrls.map((url) =>
 			AiSearchInsights.Citation.fromUrl(url, ownDomains),
 		);

--- a/packages/infrastructure/src/persistence/drizzle/migrations/0021_backfill_citations_is_own_domain.sql
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/0021_backfill_citations_is_own_domain.sql
@@ -1,0 +1,54 @@
+-- #169 backfill: recompute `llm_answers.citations[].isOwnDomain` for the
+-- back-history that was written while RecordLlmAnswerUseCase flattened
+-- BOTH own AND competitor domains into the "own" set. After the
+-- use-case fix lands new rows are correct; this one-shot migration
+-- repairs the older rows so dashboards stop reporting inflated
+-- citationRate (the ES project was seeing 107% — silvertrac, tracktik,
+-- qrpatrol were all being counted as own).
+--
+-- Source of truth for "own": `projects.primary_domain` UNION
+-- `project_domains.domain`. Matching mirrors `Citation.fromUrl` —
+-- lowercased exact match OR endsWith('.' + own). Citations whose
+-- `domain` field can't be matched against any own domain become
+-- isOwnDomain=false (the safe default; competitors fall here, as do
+-- random third-party links).
+--
+-- Idempotent: re-running this against already-fixed rows recomputes
+-- the same values.
+
+WITH project_own_domains AS (
+	SELECT
+		p.id AS project_id,
+		LOWER(REGEXP_REPLACE(d.domain, '^www\.', '')) AS domain
+	FROM projects p
+	LEFT JOIN project_domains pd ON pd.project_id = p.id
+	CROSS JOIN LATERAL (
+		VALUES (p.primary_domain), (pd.domain)
+	) AS d(domain)
+	WHERE d.domain IS NOT NULL AND length(trim(d.domain)) > 0
+),
+agg AS (
+	SELECT project_id, array_agg(DISTINCT domain) AS own_domains
+	FROM project_own_domains
+	GROUP BY project_id
+)
+UPDATE llm_answers la
+SET citations = COALESCE((
+	SELECT jsonb_agg(
+		(c - 'isOwnDomain') || jsonb_build_object(
+			'isOwnDomain',
+			EXISTS (
+				SELECT 1 FROM unnest(a.own_domains) AS od
+				WHERE LOWER(c->>'domain') = od
+				   OR LOWER(c->>'domain') LIKE '%.' || od
+			)
+		)
+	)
+	FROM jsonb_array_elements(
+		CASE WHEN jsonb_typeof(la.citations) = 'array' THEN la.citations ELSE '[]'::jsonb END
+	) c
+), '[]'::jsonb)
+FROM agg a
+WHERE la.project_id = a.project_id
+  AND jsonb_typeof(la.citations) = 'array'
+  AND jsonb_array_length(la.citations) > 0;

--- a/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
+++ b/packages/infrastructure/src/persistence/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1779200000000,
 			"tag": "0020_competitor_page_audits",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1779300000000,
+			"tag": "0021_backfill_citations_is_own_domain",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/providers/anthropic/src/endpoints/messages-with-web-search.spec.ts
+++ b/packages/providers/anthropic/src/endpoints/messages-with-web-search.spec.ts
@@ -1,0 +1,83 @@
+import type { FetchContext } from '@rankpulse/provider-core';
+import { describe, expect, it } from 'vitest';
+import type { AnthropicHttp } from '../http.js';
+import { fetchMessagesWithWebSearch, type MessagesWithWebSearchParams } from './messages-with-web-search.js';
+
+// Test fixture only — split + interpolated to avoid secret-scanner false positives.
+const validKey = `sk${'-'}ant${'-'}api03${'-'}${'A'.repeat(22)}`;
+
+const ctx = (): FetchContext => ({
+	credential: { plaintextSecret: validKey },
+	logger: { debug: () => {}, warn: () => {} },
+	now: () => new Date('2026-05-26T00:00:00Z'),
+});
+
+const params: MessagesWithWebSearchParams = {
+	prompt: 'Best B2B CRMs for solo founders?',
+	locationCountry: 'ES',
+	locationLanguage: 'es',
+	model: 'claude-sonnet-4-6',
+	brandPromptId: '00000000-0000-0000-0000-00000000a173',
+};
+
+describe('fetchMessagesWithWebSearch', () => {
+	it('builds a body matching the documented Anthropic web_search example (#173)', async () => {
+		// Issue #173: Anthropic rejected every request with HTTP 400 because
+		// the body included `tool_choice: { type: 'tool', name: 'web_search' }`,
+		// a shape the API does not accept for built-in server tools. The
+		// official docs example for `web_search_20250305` omits `tool_choice`
+		// entirely (the model auto-decides to call the tool). Lock that in so
+		// nobody re-adds `tool_choice` without realising it breaks production.
+		let capturedBody: Record<string, unknown> | undefined;
+		const fakeHttp = {
+			post: async (_path: string, body: unknown) => {
+				capturedBody = body as Record<string, unknown>;
+				return { id: 'msg_test', content: [] };
+			},
+		} as unknown as AnthropicHttp;
+
+		await fetchMessagesWithWebSearch(fakeHttp, params, ctx());
+
+		expect(capturedBody).toBeDefined();
+		expect(capturedBody?.model).toBe('claude-sonnet-4-6');
+		expect(capturedBody?.tool_choice).toBeUndefined();
+
+		const tools = capturedBody?.tools as Record<string, unknown>[];
+		expect(tools).toHaveLength(1);
+		expect(tools[0]?.type).toBe('web_search_20250305');
+		expect(tools[0]?.name).toBe('web_search');
+		expect(tools[0]?.max_uses).toBe(5);
+
+		const userLocation = tools[0]?.user_location as Record<string, string>;
+		expect(userLocation.country).toBe('ES');
+		// ES has a mapped timezone — verify it gets attached for stability.
+		expect(userLocation.timezone).toBe('Europe/Madrid');
+	});
+
+	it('omits the timezone field when the country is not in the mapping table', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		const fakeHttp = {
+			post: async (_path: string, body: unknown) => {
+				capturedBody = body as Record<string, unknown>;
+				return { id: 'msg_test', content: [] };
+			},
+		} as unknown as AnthropicHttp;
+
+		await fetchMessagesWithWebSearch(fakeHttp, { ...params, locationCountry: 'ZA' /* unmapped */ }, ctx());
+
+		const tools = capturedBody?.tools as Record<string, unknown>[];
+		const userLocation = tools[0]?.user_location as Record<string, string>;
+		expect(userLocation.country).toBe('ZA');
+		expect(userLocation.timezone).toBeUndefined();
+	});
+
+	it('returns an empty payload when Anthropic returns a non-object response', async () => {
+		const fakeHttp = {
+			post: async (): Promise<null> => null,
+		} as unknown as AnthropicHttp;
+
+		const result = await fetchMessagesWithWebSearch(fakeHttp, params, ctx());
+
+		expect(result).toEqual({});
+	});
+});

--- a/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
+++ b/packages/providers/anthropic/src/endpoints/messages-with-web-search.ts
@@ -147,12 +147,16 @@ const buildBody = (params: MessagesWithWebSearchParams): unknown => {
 				user_location: userLocation,
 			},
 		],
-		// Force web_search instead of `{ type: 'auto' }`. With `auto`, Claude
-		// can decide to answer from training data and skip the tool entirely
-		// — that silently zeroes the citation rate metric AND, for some
-		// locale × prompt combinations, surfaces as 400s on the messages
-		// endpoint when no tool is chosen.
-		tool_choice: { type: 'tool', name: 'web_search' },
+		// No `tool_choice` — Anthropic's documented examples for the
+		// `web_search_20250305` server tool omit it (the model auto-decides
+		// to call the tool when grounding the answer). Issue #173: forcing
+		// `tool_choice: { type: 'tool', name: 'web_search' }` returned HTTP
+		// 400 on every prompt because Anthropic does not accept that shape
+		// for built-in server tools. Letting the model auto-decide matches
+		// the docs and unblocks all locales × prompts. If a prompt comes
+		// back with zero citations because the model answered from training,
+		// that's still legitimate data — citationRate is computed from what
+		// the model returns.
 		messages: [{ role: 'user', content: params.prompt }],
 		metadata: {
 			user_id: params.brandPromptId,

--- a/packages/sdk/src/resources/ai-search.ts
+++ b/packages/sdk/src/resources/ai-search.ts
@@ -8,6 +8,13 @@ export class AiSearchResource {
 		return this.http.get(`/projects/${encodeURIComponent(projectId)}/brand-prompts`);
 	}
 
+	// #170 — detail by id. Same DTO as `items[]` of `listPrompts`.
+	getPrompt(projectId: string, promptId: string): Promise<AiSearchInsightsContracts.BrandPromptDtoSchema> {
+		return this.http.get(
+			`/projects/${encodeURIComponent(projectId)}/brand-prompts/${encodeURIComponent(promptId)}`,
+		);
+	}
+
 	createPrompt(
 		projectId: string,
 		body: AiSearchInsightsContracts.RegisterBrandPromptRequest,


### PR DESCRIPTION
## Summary

Bundles 4 production bug fixes that all surfaced in the AI Brand Radar pipeline on the ES project today.

| Issue | Severity | Fix |
|-------|----------|-----|
| #173 | P2 | Remove invalid `tool_choice` from Anthropic body + surface upstream response body in worker run errors |
| #174 | P3 | Cascade-delete job-definitions on brand-prompt removal + worker auto-disables orphan defs |
| #170 | P2 | Add missing `GET /projects/{pid}/brand-prompts/{id}` endpoint |
| #169 | P1 | Stop flagging competitor domains as `isOwnDomain=true` + one-shot SQL backfill |

## Per-issue detail

### #173 — Anthropic `messages-with-web-search` HTTP 400 on every prompt
- **Root cause:** the body forced `tool_choice: { type: "tool", name: "web_search" }`. Anthropic's documented examples for the built-in `web_search_20250305` server tool omit `tool_choice` entirely; the forced shape isn't accepted and returns 400 regardless of model / locale.
- **Fix:** drop `tool_choice`, follow the docs example. The model auto-decides to call web_search for brand-mention prompts (which is what we want).
- **Diagnostic improvement:** worker now includes `ProviderApiError.body` in `run.error.message` and structured logs, so future provider 4xx returns the upstream rejection reason instead of just `"anthropic POST /messages → 400"`. Benefits ALL providers, not just Anthropic.

### #174 — Job-definitions left referencing deleted brand-prompts
- **Root cause:** `brand_prompts` ⇄ `provider_job_definitions` is linked via JSONB `params.brandPromptId`, not a relational FK, so `ON DELETE CASCADE` doesn't help. Deleting a prompt left N orphan schedules failing daily with `INGEST_PRECONDITION_FAILED: BrandPrompt … not found`.
- **Preventive (option A):** `DeleteBrandPromptUseCase` now lists project schedules and deletes any with matching `brandPromptId` before removing the prompt. Order matters — schedules first, then prompt — so a mid-flight failure can't leave the buggy state we're trying to fix.
- **Defensive (option B):** worker auto-disables the JobDefinition on `INGEST_PRECONDITION_FAILED` (`NotFoundError`). Catches legacy orphans from before this PR + any future off-path deletes.

### #170 — `GET /api/v1/projects/{pid}/brand-prompts/{id}` returned 404
- Endpoint was missing (only `list`, `patch`, `delete` existed for individual prompts). Added detail route returning the same DTO shape as `items[]` of the list. OpenAPI spec + SDK updated.

### #169 — `citations[].isOwnDomain = true` for competitor domains
- **Root cause:** `record-llm-answer.use-case.ts` flattened ownDomains from the FULL watchlist before passing to `Citation.fromUrl`. But the watchlist mixes own-brand AND competitor entries, and `BrandWatchEntry.ownDomains` semantically holds the brand's owned domains either way — so competitor domains (tracktik.com, qrpatrol.com, silvertracsoftware.com) flowed into the "own" list and got marked as own. That's what inflated ES `citationRate` to 107%.
- **Fix:** filter watchlist by `isOwnBrand` before flattening. One-line change + regression test using the real ES watchlist shape.
- **Backfill:** migration `0021_backfill_citations_is_own_domain.sql` recomputes the flag for back-history rows using `projects.primary_domain` + `project_domains.domain` as the source of truth and the same matching rule as `Citation.fromUrl` (lowercased exact or `.` suffix). Idempotent — safe to re-run.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (27/27 packages)
- [x] `pnpm test` — 411 application tests + 15 anthropic + 16 api all pass
- [x] `pnpm build` clean
- [x] New `messages-with-web-search.spec.ts` locks in absence of `tool_choice`
- [x] New `delete-brand-prompt.use-case.spec.ts` cascade tests cover: 4-schedule fan-out cleanup, isolation against other prompts, isolation against other projects, and non-AI schedules in the same project
- [x] New regression test in `record-llm-answer.use-case.spec.ts` covers the real ES shape (1 own brand + 2 competitors, 5 citations)
- [ ] Post-deploy verification on srv07:
  1. Force-run one Anthropic JobDefinition → expect `status=succeeded` (was failing 8/8 with 400)
  2. Apply migration 0021 → `GET /projects/ES/ai-search/citations?limit=20` → `silvertrac/tracktik/qrpatrol` show `isOwnDomain: false`
  3. Delete a test brand-prompt → confirm associated job-defs are gone from `GET /providers/job-definitions/by-project/{pid}`
  4. `GET /api/v1/projects/{pid}/brand-prompts/{id}` returns 200 with the DTO

## Migration

`0021_backfill_citations_is_own_domain.sql` rewrites `llm_answers.citations` for all projects in one statement. It's idempotent (recomputes from the truth source on every run) and only touches rows where `jsonb_array_length(citations) > 0`. No schema change, no downtime.

Closes #169
Closes #170
Closes #173
Closes #174