### PR TITLE
fix: backlog cleanup — UUID casts + worker bug + ranking deltas + freshness + Gemini wrapper filter (#176 #171 #172 #178 #179 #180 #181)

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -263,6 +263,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		identityAccessSchemaTables: DrizzlePersistence.schema.identityAccessSchemaTables,
 	} satisfies IAUseCases.IdentityAccessDeps as unknown as SharedDeps);
 
+	const projectFreshnessReadModel = new DrizzlePersistence.DrizzleProjectFreshnessReadModel(drizzle.db);
+
 	const projectManagement = PMUseCases.projectManagementModule.compose({
 		clock: SystemClock,
 		ids: SystemIdGenerator,
@@ -279,6 +281,9 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		// over the tracked-keyword repo so suggestions stay project-management-pure.
 		trackedKeywordCountForProject: (projectId) =>
 			trackedKeywordRepo.countForProject(projectId as ProjectManagement.ProjectId),
+		// #172 — freshness summary read-model (rankings, ai-search, gsc, ga4,
+		// bing, pagespeed, clarity) for the daily-health-check endpoint.
+		projectFreshnessReadModel,
 		projectManagementSchemaTables: DrizzlePersistence.schema.projectManagementSchemaTables,
 	} satisfies PMUseCases.ProjectManagementDeps as unknown as SharedDeps);
 
@@ -542,6 +547,7 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		value(Tokens.RecordCompetitorWaybackSnapshot, pm.RecordCompetitorWaybackSnapshot),
 		value(Tokens.RecordCompetitorBacklinksProfile, pm.RecordCompetitorBacklinksProfile),
 		value(Tokens.QueryCompetitorActivity, pm.QueryCompetitorActivity),
+		value(Tokens.QueryProjectFreshness, pm.QueryProjectFreshness),
 
 		// provider-connectivity
 		value(Tokens.CredentialRepository, credentialRepo),

--- a/apps/api/src/composition/tokens.ts
+++ b/apps/api/src/composition/tokens.ts
@@ -50,6 +50,7 @@ export const Tokens = {
 	RecordCompetitorWaybackSnapshot: Symbol('RecordCompetitorWaybackSnapshotUseCase'),
 	RecordCompetitorBacklinksProfile: Symbol('RecordCompetitorBacklinksProfileUseCase'),
 	QueryCompetitorActivity: Symbol('QueryCompetitorActivityUseCase'),
+	QueryProjectFreshness: Symbol('QueryProjectFreshnessUseCase'),
 
 	// Provider-Connectivity ports
 	CredentialRepository: Symbol('CredentialRepository'),

--- a/apps/api/src/modules/project-management/projects.controller.ts
+++ b/apps/api/src/modules/project-management/projects.controller.ts
@@ -71,6 +71,8 @@ export class ProjectsController {
 		private readonly promoteSuggestion: PMUseCases.PromoteCompetitorSuggestionUseCase,
 		@Inject(Tokens.DismissCompetitorSuggestion)
 		private readonly dismissSuggestion: PMUseCases.DismissCompetitorSuggestionUseCase,
+		@Inject(Tokens.QueryProjectFreshness)
+		private readonly queryFreshness: PMUseCases.QueryProjectFreshnessUseCase,
 		@Inject(Tokens.ProjectRepository) private readonly projects: ProjectManagement.ProjectRepository,
 		@Inject(Tokens.CompetitorRepository) private readonly competitors: ProjectManagement.CompetitorRepository,
 		@Inject(Tokens.CompetitorSuggestionRepository)
@@ -107,6 +109,54 @@ export class ProjectsController {
 		const project = await this.loadProject(id);
 		await this.orgMembership.require(principal, project.organizationId);
 		return this.serialize(project);
+	}
+
+	/**
+	 * #172 — single-round-trip data-freshness summary across rankings,
+	 * AI-search, GSC, GA4, Bing, PageSpeed, and Clarity. Used by external
+	 * integrations (daily health-check, status dashboards) to answer "is
+	 * everything fresh? what's stale?" without iterating per-subsystem
+	 * endpoints. Project membership is enforced as in `getProject`.
+	 */
+	@Get(':id/freshness')
+	async getFreshness(
+		@Principal() principal: AuthPrincipal,
+		@Param('id') id: string,
+	): Promise<ProjectManagementContracts.ProjectFreshnessResponse> {
+		const project = await this.loadProject(id);
+		await this.orgMembership.require(principal, project.organizationId);
+		const summary = await this.queryFreshness.execute({ projectId: id });
+		const iso = (d: Date | null): string | null => (d ? d.toISOString() : null);
+		return {
+			projectId: summary.projectId,
+			checkedAt: summary.checkedAt.toISOString(),
+			sources: {
+				rankings: {
+					lastSeenAt: iso(summary.sources.rankings.lastSeenAt),
+					count: summary.sources.rankings.count,
+				},
+				aiSearch: {
+					lastSeenAt: iso(summary.sources.aiSearch.lastSeenAt),
+					count: summary.sources.aiSearch.count,
+					providers: [...summary.sources.aiSearch.providers],
+				},
+				brandPrompts: {
+					activeCount: summary.sources.brandPrompts.activeCount,
+					pausedCount: summary.sources.brandPrompts.pausedCount,
+				},
+				ga4: { lastSeenAt: iso(summary.sources.ga4.lastSeenAt), count: summary.sources.ga4.count },
+				gsc: { lastSeenAt: iso(summary.sources.gsc.lastSeenAt), count: summary.sources.gsc.count },
+				bing: { lastSeenAt: iso(summary.sources.bing.lastSeenAt), count: summary.sources.bing.count },
+				pageSpeed: {
+					lastSeenAt: iso(summary.sources.pageSpeed.lastSeenAt),
+					count: summary.sources.pageSpeed.count,
+				},
+				clarity: {
+					lastSeenAt: iso(summary.sources.clarity.lastSeenAt),
+					count: summary.sources.clarity.count,
+				},
+			},
+		};
 	}
 
 	@Post(':id/domains')

--- a/apps/api/src/modules/rank-tracking/rank-tracking.controller.ts
+++ b/apps/api/src/modules/rank-tracking/rank-tracking.controller.ts
@@ -120,6 +120,47 @@ export class RankTrackingController {
 		}));
 	}
 
+	/**
+	 * #171 — per-keyword summary endpoint with 1d / 7d position deltas.
+	 *
+	 * Kept separate from `/rankings` (which returns the RAW observation
+	 * list, multi-row per keyword, used by the SPA's time-series charts)
+	 * to avoid breaking the SPA's grouping logic. External integrations —
+	 * specifically the daily health check that needs to detect rank
+	 * movements without accumulating its own snapshot history — should
+	 * call this endpoint instead.
+	 */
+	@Get('projects/:projectId/rankings/summary')
+	async rankingsSummary(
+		@Principal() principal: AuthPrincipal,
+		@Param('projectId') projectId: string,
+	): Promise<RankTrackingContracts.ProjectRankingsResponse> {
+		const project = await this.projects.findById(projectId as ProjectManagement.ProjectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${projectId} not found`);
+		}
+		await this.orgMembership.require(principal, project.organizationId);
+		const snapshots = await this.obsRepo.listProjectRankingsWithDeltas(project.id);
+		return {
+			items: snapshots.map((s) => ({
+				trackedKeywordId: s.trackedKeywordId,
+				phrase: s.phrase,
+				domain: s.domain,
+				country: s.country,
+				language: s.language,
+				device: s.device,
+				position: s.position,
+				url: s.url,
+				observedAt: s.observedAt.toISOString(),
+				previousPosition: s.previousPosition,
+				position1dAgo: s.position1dAgo,
+				position7dAgo: s.position7dAgo,
+				positionChange1d: s.positionChange1d,
+				positionChange7d: s.positionChange7d,
+			})),
+		};
+	}
+
 	@Get('rank-tracking/keywords/:id/history')
 	async history(
 		@Principal() principal: AuthPrincipal,

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -181,6 +181,24 @@ export function buildOpenApiDocument(): unknown {
 	});
 
 	registry.registerPath({
+		method: 'get',
+		path: '/api/v1/projects/{id}/freshness',
+		summary: '#172 — Data-freshness summary across all linked subsystems',
+		description:
+			'Single round-trip summary of when each upstream data subsystem (rankings, ai-search, gsc, ga4, bing, pagespeed, clarity) last ingested for the project. Each source returns `lastSeenAt` (null if no data yet) + `count` (rows / linked entities depending on source). Use this in daily health checks to answer "is everything fresh? what is stale?" without iterating per-subsystem endpoints.',
+		tags: ['project-management', 'observability'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ id: z.string().uuid() }) },
+		responses: {
+			200: {
+				description: 'Project freshness summary',
+				content: { 'application/json': { schema: ProjectManagementContracts.ProjectFreshnessResponse } },
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
 		method: 'post',
 		path: '/api/v1/projects/{id}/competitors',
 		summary: 'Track a competitor for a project',
@@ -511,7 +529,9 @@ export function buildOpenApiDocument(): unknown {
 	registry.registerPath({
 		method: 'get',
 		path: '/api/v1/projects/{projectId}/rankings',
-		summary: 'List the latest ranking observations for a project',
+		summary: 'List the latest ranking observations for a project (raw list)',
+		description:
+			'Returns up to 500 raw observations from the last 14 days. Multiple rows per tracked keyword — the SPA uses this for time-series charts. For a deduplicated per-keyword summary with 1d/7d position deltas, use `/rankings/summary` instead.',
 		tags: ['rank-tracking'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: { params: z.object({ projectId: z.string().uuid() }) },
@@ -519,6 +539,24 @@ export function buildOpenApiDocument(): unknown {
 			200: {
 				description: 'Ranking observations',
 				content: { 'application/json': { schema: z.array(z.unknown()) } },
+			},
+			...errorResponses([401, 403, 404]),
+		},
+	});
+
+	registry.registerPath({
+		method: 'get',
+		path: '/api/v1/projects/{projectId}/rankings/summary',
+		summary: '#171 — Per-keyword ranking snapshot with 1d / 7d position deltas',
+		description:
+			'One row per tracked keyword. Each row carries the current `position`, the immediately previous observation (`previousPosition`), and positions from ~1d and ~7d ago for delta computation. `positionChange*` follow SEO convention: negative = improvement (e.g. 10 → 5 is delta -5), positive = worsening. Deltas are `null` when no comparison observation exists in the window (typical for keywords tracked < 7d). Use this for external integrations that need to detect rank movements without folding raw observations client-side.',
+		tags: ['rank-tracking'],
+		security: [{ [ApiTokenAuthHeader]: [] }],
+		request: { params: z.object({ projectId: z.string().uuid() }) },
+		responses: {
+			200: {
+				description: 'Project rankings with deltas',
+				content: { 'application/json': { schema: RankTrackingContracts.ProjectRankingsResponse } },
 			},
 			...errorResponses([401, 403, 404]),
 		},

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -607,7 +607,7 @@ export function buildOpenApiDocument(): unknown {
 		path: '/api/v1/projects/{projectId}/ranked-keywords',
 		summary: 'Ranked keywords — keyword universe of a target domain',
 		description:
-			'Returns the most recent snapshot of all keywords for which the given target domain ranks on Google, sourced from DataForSEO Labs `ranked_keywords/live` (issue #127). Optional filters: `minVolume` to drop low-volume tail; `limit` to cap row count. Snapshots are typically refreshed monthly via the auto-schedule, so the same response is served between snapshots.',
+			"**Required query**: `targetDomain` — fully-qualified domain (e.g. `tracktik.com`). Must match either the project's `primaryDomain`/aliases (`GET /projects/{projectId}` → `domains[]`) or a registered competitor (`GET /projects/{projectId}/competitors`). Returns the most recent snapshot of all keywords for which the target domain ranks on Google, sourced from DataForSEO Labs `ranked_keywords/live` (issue #127). Optional filters: `minVolume` to drop low-volume tail; `limit` to cap row count (default 500, max 1000). Snapshots are typically refreshed monthly via the auto-schedule, so the same response is served between snapshots. **Coverage caveat**: today only the US/en-US locale is wired by default; ES/MX/FR competitors may return empty until per-locale schedules are configured (#181).",
 		tags: ['rank-tracking'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {
@@ -619,7 +619,7 @@ export function buildOpenApiDocument(): unknown {
 				description: 'Ranked keywords for the target domain',
 				content: { 'application/json': { schema: RankTrackingContracts.RankedKeywordsResponse } },
 			},
-			...errorResponses([401, 403, 404]),
+			...errorResponses([400, 401, 403, 404]),
 		},
 	});
 
@@ -628,7 +628,7 @@ export function buildOpenApiDocument(): unknown {
 		path: '/api/v1/projects/{projectId}/keyword-gaps',
 		summary: 'Competitor keyword gaps — keywords competitor ranks for that we do not',
 		description:
-			'Returns the latest snapshot of keyword gaps between `ourDomain` and `competitorDomain` — keywords where the competitor ranks in Google top-100 and we either do not, or rank worse. Sourced from DataForSEO Labs `domain_intersection/live` (issue #128). Output is sorted by ROI score `(volume × cpc) / (kd + 1)` DESC so the highest-leverage "fagocitar" candidates surface first. Optional filters: `minVolume` to drop the long tail, `limit` to cap row count.',
+			'**Required query**: `ourDomain` and `competitorDomain`, both fully-qualified. `ourDomain` must be one of the project\'s tracked domains (`GET /projects/{projectId}` → `domains[]`); `competitorDomain` must be a registered competitor (`GET /projects/{projectId}/competitors`). Returns the latest snapshot of keyword gaps between the two — keywords where the competitor ranks in Google top-100 and we either do not, or rank worse. Sourced from DataForSEO Labs `domain_intersection/live` (issue #128). Output is sorted by ROI score `(volume × cpc) / (kd + 1)` DESC so the highest-leverage "fagocitar" candidates surface first. Optional filters: `minVolume` to drop the long tail, `limit` to cap row count (default 500, max 1000).',
 		tags: ['competitor-intelligence'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {
@@ -642,7 +642,7 @@ export function buildOpenApiDocument(): unknown {
 					'application/json': { schema: CompetitorIntelligenceContracts.KeywordGapsResponse },
 				},
 			},
-			...errorResponses([401, 403, 404]),
+			...errorResponses([400, 401, 403, 404]),
 		},
 	});
 

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -263,14 +263,42 @@ export class ProviderFetchProcessor {
 					definition,
 					dateBucket,
 				});
+				run.complete(existing.id, this.deps.clock.now());
 				runLog.info({ requestHash }, 'idempotent skip — replayed ingest from cached payload');
 			} catch (err) {
-				runLog.warn(
-					{ requestHash, err: err instanceof Error ? err.message : String(err) },
-					'idempotent skip — ingest replay failed (raw payload preserved)',
-				);
+				if (err instanceof NotFoundError) {
+					// #176: a `NotFoundError` on the ingest replay is the SAME
+					// permanent failure the outer catch escalates — the
+					// referenced entity is gone (brand prompt deleted, GSC
+					// property unlinked, etc.). Without this branch the run
+					// silently marks `succeeded` and the def stays enabled
+					// forever, because the cache hit short-circuits past the
+					// outer catch. Mirror the outer NotFoundError handler:
+					// disable the def + record INGEST_PRECONDITION_FAILED.
+					definition.disable();
+					run.fail(
+						{
+							code: 'INGEST_PRECONDITION_FAILED',
+							message: err.message,
+							retryable: false,
+						},
+						this.deps.clock.now(),
+					);
+					runLog.error(
+						{ err: err.message, requestHash },
+						'idempotent ingest replay: referenced entity missing; definition auto-disabled (#176)',
+					);
+				} else {
+					// Transient ingest error on a cache hit — keep the raw
+					// payload, warn, and let the next tick try again. NOT a
+					// reason to disable the def or fail the run.
+					run.complete(existing.id, this.deps.clock.now());
+					runLog.warn(
+						{ requestHash, err: err instanceof Error ? err.message : String(err) },
+						'idempotent skip — ingest replay failed (raw payload preserved)',
+					);
+				}
 			}
-			run.complete(existing.id, this.deps.clock.now());
 			// #160: lastRunAt must update even on cache-hit so the dashboard
 			// stops reporting these defs as "never run".
 			definition.markRan(this.deps.clock.now());

--- a/packages/application/src/project-management/index.ts
+++ b/packages/application/src/project-management/index.ts
@@ -7,6 +7,7 @@ export * from './use-cases/create-project.use-case.js';
 export * from './use-cases/import-keywords.use-case.js';
 export * from './use-cases/manage-portfolios.use-cases.js';
 export * from './use-cases/query-competitor-activity.use-case.js';
+export * from './use-cases/query-project-freshness.use-case.js';
 export * from './use-cases/record-competitor-backlinks-profile.use-case.js';
 export * from './use-cases/record-competitor-wayback-snapshot.use-case.js';
 export * from './use-cases/remove-competitor.use-case.js';

--- a/packages/application/src/project-management/module.ts
+++ b/packages/application/src/project-management/module.ts
@@ -19,6 +19,7 @@ import {
 	RenamePortfolioUseCase,
 } from './use-cases/manage-portfolios.use-cases.js';
 import { QueryCompetitorActivityUseCase } from './use-cases/query-competitor-activity.use-case.js';
+import { QueryProjectFreshnessUseCase } from './use-cases/query-project-freshness.use-case.js';
 import { RecordCompetitorBacklinksProfileUseCase } from './use-cases/record-competitor-backlinks-profile.use-case.js';
 import { RecordCompetitorWaybackSnapshotUseCase } from './use-cases/record-competitor-wayback-snapshot.use-case.js';
 import { RemoveCompetitorUseCase } from './use-cases/remove-competitor.use-case.js';
@@ -41,6 +42,8 @@ export interface ProjectManagementDeps {
 	 * composition root provides the actual `trackedKeywordRepo.countForProject`.
 	 */
 	readonly trackedKeywordCountForProject: (projectId: string) => Promise<number>;
+	/** #172 — multi-source freshness summary (rankings, ai-search, gsc, ga4, …). */
+	readonly projectFreshnessReadModel: PMDomain.ProjectFreshnessReadModel;
 	readonly projectManagementSchemaTables: readonly unknown[];
 }
 
@@ -145,6 +148,7 @@ export const projectManagementModule: ContextModule = {
 					d.competitorRepo,
 					d.competitorActivityRepo,
 				),
+				QueryProjectFreshness: new QueryProjectFreshnessUseCase(d.projectRepo, d.projectFreshnessReadModel),
 			},
 			ingestUseCases: {
 				'project-management:record-competitor-wayback-snapshot': waybackIngest,

--- a/packages/application/src/project-management/use-cases/query-project-freshness.use-case.ts
+++ b/packages/application/src/project-management/use-cases/query-project-freshness.use-case.ts
@@ -1,0 +1,33 @@
+import type { ProjectManagement } from '@rankpulse/domain';
+import { NotFoundError } from '@rankpulse/shared';
+
+export interface QueryProjectFreshnessCommand {
+	readonly projectId: string;
+}
+
+/**
+ * #172 — single round-trip summary of when each upstream data subsystem
+ * (rankings, ai-search, gsc, ga4, bing, pagespeed, clarity) last
+ * ingested for a project. Lets the daily health check answer "is
+ * everything fresh? what's stale?" without iterating subsystem-specific
+ * endpoints.
+ *
+ * Defers the actual heavy SQL to the read-model adapter; this use case
+ * just guards "project exists" so a typo returns 404 instead of an
+ * empty-but-200 freshness reply (which would mislead the operator into
+ * thinking nothing's ingesting).
+ */
+export class QueryProjectFreshnessUseCase {
+	constructor(
+		private readonly projects: ProjectManagement.ProjectRepository,
+		private readonly freshness: ProjectManagement.ProjectFreshnessReadModel,
+	) {}
+
+	async execute(cmd: QueryProjectFreshnessCommand): Promise<ProjectManagement.ProjectFreshnessSummary> {
+		const project = await this.projects.findById(cmd.projectId as ProjectManagement.ProjectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${cmd.projectId} not found`);
+		}
+		return this.freshness.summarize(project.id);
+	}
+}

--- a/packages/application/src/rank-tracking/use-cases/query-ranking-history.use-case.spec.ts
+++ b/packages/application/src/rank-tracking/use-cases/query-ranking-history.use-case.spec.ts
@@ -54,6 +54,9 @@ class InMemoryObsRepo implements RankTracking.RankingObservationRepository {
 	async listLatestForProject(): Promise<readonly RankTracking.RankingObservation[]> {
 		return [];
 	}
+	async listProjectRankingsWithDeltas(): Promise<readonly RankTracking.ProjectRankingSnapshot[]> {
+		return [];
+	}
 }
 
 const buildTracked = (id: RankTracking.TrackedKeywordId = TRACKED_ID): RankTracking.TrackedKeyword =>

--- a/packages/application/src/rank-tracking/use-cases/record-ranking-observation.use-case.spec.ts
+++ b/packages/application/src/rank-tracking/use-cases/record-ranking-observation.use-case.spec.ts
@@ -62,6 +62,9 @@ class ObservationRepo implements RankTracking.RankingObservationRepository {
 	async listLatestForProject(): Promise<readonly RankTracking.RankingObservation[]> {
 		return [];
 	}
+	async listProjectRankingsWithDeltas(): Promise<readonly RankTracking.ProjectRankingSnapshot[]> {
+		return [];
+	}
 }
 
 class CapturingPublisher implements SharedKernel.EventPublisher {

--- a/packages/contracts/src/project-management/index.ts
+++ b/packages/contracts/src/project-management/index.ts
@@ -149,3 +149,33 @@ export const CompetitorActivityResponse = z.object({
 	maxScore: z.number().int().min(0).max(100),
 });
 export type CompetitorActivityResponse = z.infer<typeof CompetitorActivityResponse>;
+
+// --- Project freshness (issue #172) ---
+
+const FreshnessTimestampedCountDto = z.object({
+	lastSeenAt: z.string().datetime().nullable(),
+	count: z.number().int().nonnegative(),
+});
+
+export const ProjectFreshnessResponse = z.object({
+	projectId: z.string().uuid(),
+	checkedAt: z.string().datetime(),
+	sources: z.object({
+		rankings: FreshnessTimestampedCountDto,
+		aiSearch: z.object({
+			lastSeenAt: z.string().datetime().nullable(),
+			count: z.number().int().nonnegative(),
+			providers: z.array(z.string()),
+		}),
+		brandPrompts: z.object({
+			activeCount: z.number().int().nonnegative(),
+			pausedCount: z.number().int().nonnegative(),
+		}),
+		ga4: FreshnessTimestampedCountDto,
+		gsc: FreshnessTimestampedCountDto,
+		bing: FreshnessTimestampedCountDto,
+		pageSpeed: FreshnessTimestampedCountDto,
+		clarity: FreshnessTimestampedCountDto,
+	}),
+});
+export type ProjectFreshnessResponse = z.infer<typeof ProjectFreshnessResponse>;

--- a/packages/contracts/src/rank-tracking/index.ts
+++ b/packages/contracts/src/rank-tracking/index.ts
@@ -34,6 +34,36 @@ export const StartTrackingKeywordResponse = z.object({
 });
 export type StartTrackingKeywordResponse = z.infer<typeof StartTrackingKeywordResponse>;
 
+/**
+ * #171 — `/projects/{pid}/rankings` response shape: one entry per tracked
+ * keyword with current position + 1d / 7d deltas. `positionChange*` use
+ * SEO convention (negative = improvement, positive = worsening). `null`
+ * deltas indicate no historical observation in the comparison window —
+ * typical for keywords tracked < 7 days.
+ */
+export const ProjectRankingDto = z.object({
+	trackedKeywordId: z.string().uuid(),
+	phrase: z.string(),
+	domain: z.string(),
+	country: z.string(),
+	language: z.string(),
+	device: z.enum(['desktop', 'mobile']),
+	position: z.number().int().nullable(),
+	url: z.string().nullable(),
+	observedAt: z.string().datetime(),
+	previousPosition: z.number().int().nullable(),
+	position1dAgo: z.number().int().nullable(),
+	position7dAgo: z.number().int().nullable(),
+	positionChange1d: z.number().int().nullable(),
+	positionChange7d: z.number().int().nullable(),
+});
+export type ProjectRankingDto = z.infer<typeof ProjectRankingDto>;
+
+export const ProjectRankingsResponse = z.object({
+	items: z.array(ProjectRankingDto),
+});
+export type ProjectRankingsResponse = z.infer<typeof ProjectRankingsResponse>;
+
 export const RankingHistoryQuery = z.object({
 	from: z.string().datetime().optional(),
 	to: z.string().datetime().optional(),

--- a/packages/domain/src/project-management/index.ts
+++ b/packages/domain/src/project-management/index.ts
@@ -19,6 +19,7 @@ export * from './ports/competitor-suggestion-repository.js';
 export * from './ports/keyword-list-repository.js';
 // Ports
 export * from './ports/portfolio-repository.js';
+export * from './ports/project-freshness-read-model.js';
 export * from './ports/project-repository.js';
 export * from './value-objects/domain-name.js';
 export * from './value-objects/identifiers.js';

--- a/packages/domain/src/project-management/ports/project-freshness-read-model.ts
+++ b/packages/domain/src/project-management/ports/project-freshness-read-model.ts
@@ -1,0 +1,31 @@
+import type { ProjectId } from '../value-objects/identifiers.js';
+
+/**
+ * #172 — observability summary. One snapshot per (project) summarising
+ * when each upstream data subsystem last ingested. Lets the daily health
+ * check answer "is everything fresh? what's stale?" with a single
+ * round-trip instead of iterating each `/projects/{pid}/...` endpoint.
+ */
+export interface FreshnessTimestampedCount {
+	readonly lastSeenAt: Date | null;
+	readonly count: number;
+}
+
+export interface ProjectFreshnessSummary {
+	readonly projectId: ProjectId;
+	readonly checkedAt: Date;
+	readonly sources: {
+		readonly rankings: FreshnessTimestampedCount;
+		readonly aiSearch: FreshnessTimestampedCount & { readonly providers: readonly string[] };
+		readonly brandPrompts: { readonly activeCount: number; readonly pausedCount: number };
+		readonly ga4: FreshnessTimestampedCount;
+		readonly gsc: FreshnessTimestampedCount;
+		readonly bing: FreshnessTimestampedCount;
+		readonly pageSpeed: FreshnessTimestampedCount;
+		readonly clarity: FreshnessTimestampedCount;
+	};
+}
+
+export interface ProjectFreshnessReadModel {
+	summarize(projectId: ProjectId): Promise<ProjectFreshnessSummary>;
+}

--- a/packages/domain/src/rank-tracking/ports/ranking-observation-repository.ts
+++ b/packages/domain/src/rank-tracking/ports/ranking-observation-repository.ts
@@ -1,6 +1,35 @@
 import type { ProjectId } from '../../project-management/value-objects/identifiers.js';
 import type { RankingObservation } from '../entities/ranking-observation.js';
+import type { Device } from '../value-objects/device.js';
 import type { TrackedKeywordId } from '../value-objects/identifiers.js';
+
+/**
+ * #171 — one row per (tracked keyword) summarising its current rank AND
+ * how it has moved vs ~1d and ~7d ago. The deltas use SEO convention:
+ * negative = improvement (e.g. went from position 10 → 5 → delta -5),
+ * positive = worsening. `null` deltas mean we don't have a historical
+ * observation in the comparison window — typical for brand-new keywords.
+ */
+export interface ProjectRankingSnapshot {
+	readonly trackedKeywordId: TrackedKeywordId;
+	readonly phrase: string;
+	readonly domain: string;
+	readonly country: string;
+	readonly language: string;
+	readonly device: Device;
+	readonly position: number | null;
+	readonly url: string | null;
+	readonly observedAt: Date;
+	/** Position from the immediately preceding observation, regardless of how old. */
+	readonly previousPosition: number | null;
+	/** Position closest to ~24h before `observedAt` (≥20h gap). */
+	readonly position1dAgo: number | null;
+	/** Position closest to ~7d before `observedAt` (≥6d gap). */
+	readonly position7dAgo: number | null;
+	/** `position - position1dAgo`. Negative = improvement, positive = worsening, null if no comparison point. */
+	readonly positionChange1d: number | null;
+	readonly positionChange7d: number | null;
+}
 
 export interface RankingObservationRepository {
 	save(observation: RankingObservation): Promise<void>;
@@ -11,4 +40,12 @@ export interface RankingObservationRepository {
 		to: Date,
 	): Promise<readonly RankingObservation[]>;
 	listLatestForProject(projectId: ProjectId): Promise<readonly RankingObservation[]>;
+	/**
+	 * #171 — latest snapshot per (tracked keyword) with 1d / 7d position
+	 * deltas. Used by the `/projects/{pid}/rankings` endpoint so the daily
+	 * health check can detect rank movements without accumulating its own
+	 * snapshot history. One row per tracked keyword (deduplicated, ordered
+	 * by latest `observedAt` descending).
+	 */
+	listProjectRankingsWithDeltas(projectId: ProjectId): Promise<readonly ProjectRankingSnapshot[]>;
 }

--- a/packages/infrastructure/src/persistence/drizzle/index.ts
+++ b/packages/infrastructure/src/persistence/drizzle/index.ts
@@ -27,6 +27,7 @@ export { DrizzleCompetitorSuggestionRepository } from './repositories/project-ma
 export { DrizzleKeywordListRepository } from './repositories/project-management/keyword-list.repository.js';
 export { DrizzlePortfolioRepository } from './repositories/project-management/portfolio.repository.js';
 export { DrizzleProjectRepository } from './repositories/project-management/project.repository.js';
+export { DrizzleProjectFreshnessReadModel } from './repositories/project-management/project-freshness.read-model.js';
 export { DrizzleApiUsageRepository } from './repositories/provider-connectivity/api-usage.repository.js';
 export { DrizzleCredentialRepository } from './repositories/provider-connectivity/credential.repository.js';
 export {

--- a/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/ai-search-insights/drizzle-llm-answer-read-model.ts
@@ -230,6 +230,14 @@ export class DrizzleLlmAnswerReadModel implements AiSearchInsights.LlmAnswerRead
 			FROM expanded
 			WHERE (${onlyOwn}::bool = false OR is_own_domain)
 			  AND url IS NOT NULL
+			  -- #180: exclude LLM grounding wrappers that eclipse real domains
+			  -- in the top citations. vertexaisearch.cloud.google.com is the
+			  -- redirector Gemini wraps every cited URL with; the real URL is
+			  -- buried inside the grounding-api-redirect blob path. Until the
+			  -- ingest pipeline parses that blob and re-attributes to the
+			  -- canonical domain, we drop the wrapper here so the cluster
+			  -- top-N reflects actual competitor / own domains.
+			  AND domain NOT IN ('vertexaisearch.cloud.google.com')
 			GROUP BY url, domain
 			ORDER BY total_citations DESC
 			LIMIT 200

--- a/packages/infrastructure/src/persistence/drizzle/repositories/competitor-intelligence/competitor-keyword-gap.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/competitor-intelligence/competitor-keyword-gap.repository.ts
@@ -64,7 +64,7 @@ export class DrizzleCompetitorKeywordGapRepository
 						competitorKeywordGaps.observedAt,
 						sql<Date>`(
 							SELECT MAX(observed_at) FROM competitor_keyword_gaps
-							WHERE project_id = ${projectId}
+							WHERE project_id = ${projectId}::uuid
 								AND our_domain = ${ourDomain}
 								AND competitor_domain = ${competitorDomain}
 						)`,

--- a/packages/infrastructure/src/persistence/drizzle/repositories/project-management/competitor-activity-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/project-management/competitor-activity-observation.repository.ts
@@ -92,7 +92,7 @@ export class DrizzleCompetitorActivityObservationRepository
 						ORDER BY observed_at DESC
 					) AS rank
 				FROM competitor_activity_observations
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 					AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 			)
 			SELECT

--- a/packages/infrastructure/src/persistence/drizzle/repositories/project-management/project-freshness.read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/project-management/project-freshness.read-model.ts
@@ -1,0 +1,114 @@
+import type { ProjectManagement } from '@rankpulse/domain';
+import { sql } from 'drizzle-orm';
+import type { DrizzleDatabase } from '../../client.js';
+
+/**
+ * #172 — single round-trip summary of when each upstream subsystem last
+ * ingested data for a project. All sub-queries scope by `project_id` so
+ * the work doesn't grow with org size, only with project depth.
+ *
+ * One row, many columns. Sub-queries instead of UNION ALL because each
+ * source has a slightly different shape (count vs paused-count vs
+ * provider-array). A few of the sources store dates as text
+ * `YYYY-MM-DD` (ga4_daily_metrics, bing_traffic_observations,
+ * clarity_daily_metrics) — we project them to `timestamptz` at UTC
+ * midnight so the API surface is uniform ISO 8601.
+ */
+const unwrap = <T>(rows: unknown): T[] => ((rows as { rows?: unknown[] }).rows ?? (rows as unknown[])) as T[];
+
+interface FreshnessRow {
+	rankings_last: Date | string | null;
+	rankings_count: number;
+	ai_search_last: Date | string | null;
+	ai_search_count: number;
+	ai_providers: string[] | null;
+	brand_prompts_active: number;
+	brand_prompts_paused: number;
+	ga4_last: Date | string | null;
+	ga4_count: number;
+	gsc_last: Date | string | null;
+	gsc_count: number;
+	bing_last: Date | string | null;
+	bing_count: number;
+	pagespeed_last: Date | string | null;
+	pagespeed_count: number;
+	clarity_last: Date | string | null;
+	clarity_count: number;
+}
+
+export class DrizzleProjectFreshnessReadModel implements ProjectManagement.ProjectFreshnessReadModel {
+	constructor(private readonly db: DrizzleDatabase) {}
+
+	async summarize(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<ProjectManagement.ProjectFreshnessSummary> {
+		const result = await this.db.execute(sql<FreshnessRow>`
+			SELECT
+				(SELECT MAX(observed_at) FROM ranking_observations WHERE project_id = ${projectId}::uuid) AS rankings_last,
+				(SELECT COUNT(*)::int FROM ranking_observations WHERE project_id = ${projectId}::uuid) AS rankings_count,
+
+				(SELECT MAX(captured_at) FROM llm_answers WHERE project_id = ${projectId}::uuid) AS ai_search_last,
+				(SELECT COUNT(*)::int FROM llm_answers WHERE project_id = ${projectId}::uuid) AS ai_search_count,
+				(SELECT COALESCE(array_agg(DISTINCT ai_provider ORDER BY ai_provider), '{}'::text[])
+					FROM llm_answers WHERE project_id = ${projectId}::uuid) AS ai_providers,
+
+				(SELECT COUNT(*)::int FROM brand_prompts WHERE project_id = ${projectId}::uuid AND paused_at IS NULL) AS brand_prompts_active,
+				(SELECT COUNT(*)::int FROM brand_prompts WHERE project_id = ${projectId}::uuid AND paused_at IS NOT NULL) AS brand_prompts_paused,
+
+				(SELECT MAX((observed_date || 'T00:00:00Z')::timestamptz)
+					FROM ga4_daily_metrics WHERE project_id = ${projectId}::uuid) AS ga4_last,
+				(SELECT COUNT(*)::int FROM ga4_properties
+					WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL) AS ga4_count,
+
+				(SELECT MAX(observed_at) FROM gsc_observations WHERE project_id = ${projectId}::uuid) AS gsc_last,
+				(SELECT COUNT(*)::int FROM gsc_properties
+					WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL) AS gsc_count,
+
+				(SELECT MAX((observed_date || 'T00:00:00Z')::timestamptz)
+					FROM bing_traffic_observations WHERE project_id = ${projectId}::uuid) AS bing_last,
+				(SELECT COUNT(*)::int FROM bing_properties
+					WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL) AS bing_count,
+
+				(SELECT MAX(observed_at) FROM page_speed_snapshots WHERE project_id = ${projectId}::uuid) AS pagespeed_last,
+				(SELECT COUNT(*)::int FROM tracked_pages WHERE project_id = ${projectId}::uuid) AS pagespeed_count,
+
+				(SELECT MAX((observed_date || 'T00:00:00Z')::timestamptz)
+					FROM clarity_daily_metrics WHERE project_id = ${projectId}::uuid) AS clarity_last,
+				(SELECT COUNT(*)::int FROM clarity_projects
+					WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL) AS clarity_count
+		`);
+
+		const row = unwrap<FreshnessRow>(result)[0];
+		const ts = (v: Date | string | null): Date | null => {
+			if (v == null) return null;
+			return v instanceof Date ? v : new Date(v);
+		};
+		return {
+			projectId,
+			checkedAt: new Date(),
+			sources: {
+				rankings: { lastSeenAt: ts(row?.rankings_last ?? null), count: Number(row?.rankings_count ?? 0) },
+				aiSearch: {
+					lastSeenAt: ts(row?.ai_search_last ?? null),
+					count: Number(row?.ai_search_count ?? 0),
+					providers: row?.ai_providers ?? [],
+				},
+				brandPrompts: {
+					activeCount: Number(row?.brand_prompts_active ?? 0),
+					pausedCount: Number(row?.brand_prompts_paused ?? 0),
+				},
+				ga4: { lastSeenAt: ts(row?.ga4_last ?? null), count: Number(row?.ga4_count ?? 0) },
+				gsc: { lastSeenAt: ts(row?.gsc_last ?? null), count: Number(row?.gsc_count ?? 0) },
+				bing: { lastSeenAt: ts(row?.bing_last ?? null), count: Number(row?.bing_count ?? 0) },
+				pageSpeed: {
+					lastSeenAt: ts(row?.pagespeed_last ?? null),
+					count: Number(row?.pagespeed_count ?? 0),
+				},
+				clarity: {
+					lastSeenAt: ts(row?.clarity_last ?? null),
+					count: Number(row?.clarity_count ?? 0),
+				},
+			},
+		};
+	}
+}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/ranked-keyword-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/ranked-keyword-observation.repository.ts
@@ -65,7 +65,7 @@ export class DrizzleRankedKeywordObservationRepository
 						rankedKeywordsObservations.observedAt,
 						sql<Date>`(
 							SELECT MAX(observed_at) FROM ranked_keywords_observations
-							WHERE project_id = ${projectId} AND target_domain = ${targetDomain}
+							WHERE project_id = ${projectId}::uuid AND target_domain = ${targetDomain}
 						)`,
 					),
 					minVolume != null ? gte(rankedKeywordsObservations.searchVolume, minVolume) : sql`TRUE`,
@@ -124,7 +124,7 @@ export class DrizzleRankedKeywordObservationRepository
 					keyword,
 					search_volume
 				FROM ranked_keywords_observations
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 					AND observed_at >= now() - (${months}::int * interval '1 month')
 					${targetDomain ? sql`AND target_domain = ${targetDomain}` : sql``}
 				ORDER BY date_trunc('month', observed_at), target_domain, keyword, observed_at DESC

--- a/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/ranking-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/ranking-observation.repository.ts
@@ -4,6 +4,8 @@ import { and, between, desc, eq, gte, sql } from 'drizzle-orm';
 import type { DrizzleDatabase } from '../../client.js';
 import { rankingObservations } from '../../schema/index.js';
 
+const unwrap = <T>(rows: unknown): T[] => ((rows as { rows?: unknown[] }).rows ?? (rows as unknown[])) as T[];
+
 export class DrizzleRankingObservationRepository implements RankTracking.RankingObservationRepository {
 	constructor(private readonly db: DrizzleDatabase) {}
 
@@ -69,6 +71,115 @@ export class DrizzleRankingObservationRepository implements RankTracking.Ranking
 			.orderBy(desc(rankingObservations.observedAt))
 			.limit(500);
 		return rows.map((r) => this.toAggregate(r));
+	}
+
+	/**
+	 * #171 — one row per tracked keyword with the latest position + position
+	 * snapshots from ~1d and ~7d ago. Computed as 3 correlated lookups per
+	 * row (cheap at the project scale: ≤500 tracked keywords). The 20h /
+	 * 6d gaps tolerate same-day re-runs and weekend skips without forcing
+	 * the comparison to land on the exact-second cron tick.
+	 */
+	async listProjectRankingsWithDeltas(
+		projectId: ProjectManagement.ProjectId,
+	): Promise<readonly RankTracking.ProjectRankingSnapshot[]> {
+		const result = await this.db.execute(sql<{
+			tracked_keyword_id: string;
+			phrase: string;
+			domain: string;
+			country: string;
+			language: string;
+			device: string;
+			position: number | null;
+			url: string | null;
+			observed_at: Date;
+			previous_position: number | null;
+			position_1d_ago: number | null;
+			position_7d_ago: number | null;
+		}>`
+			WITH latest AS (
+				SELECT DISTINCT ON (tracked_keyword_id)
+					tracked_keyword_id, phrase, domain, country, language, device,
+					position, url, observed_at
+				FROM ranking_observations
+				WHERE project_id = ${projectId}::uuid
+				  AND observed_at >= now() - interval '30 days'
+				ORDER BY tracked_keyword_id, observed_at DESC
+			)
+			SELECT
+				l.tracked_keyword_id,
+				l.phrase,
+				l.domain,
+				l.country,
+				l.language,
+				l.device,
+				l.position,
+				l.url,
+				l.observed_at,
+				(
+					SELECT r.position FROM ranking_observations r
+					WHERE r.tracked_keyword_id = l.tracked_keyword_id
+					  AND r.observed_at < l.observed_at
+					ORDER BY r.observed_at DESC
+					LIMIT 1
+				) AS previous_position,
+				(
+					SELECT r.position FROM ranking_observations r
+					WHERE r.tracked_keyword_id = l.tracked_keyword_id
+					  AND r.observed_at <= l.observed_at - interval '20 hours'
+					ORDER BY r.observed_at DESC
+					LIMIT 1
+				) AS position_1d_ago,
+				(
+					SELECT r.position FROM ranking_observations r
+					WHERE r.tracked_keyword_id = l.tracked_keyword_id
+					  AND r.observed_at <= l.observed_at - interval '6 days 12 hours'
+					ORDER BY r.observed_at DESC
+					LIMIT 1
+				) AS position_7d_ago
+			FROM latest l
+			ORDER BY l.observed_at DESC
+			LIMIT 500
+		`);
+		const rows = unwrap<{
+			tracked_keyword_id: string;
+			phrase: string;
+			domain: string;
+			country: string;
+			language: string;
+			device: string;
+			position: number | null;
+			url: string | null;
+			observed_at: Date | string;
+			previous_position: number | null;
+			position_1d_ago: number | null;
+			position_7d_ago: number | null;
+		}>(result);
+		return rows.map((r) => {
+			if (!RankTracking.isDevice(r.device)) {
+				throw new InvalidInputError(`Stored ranking observation has invalid device "${r.device}"`);
+			}
+			const position = r.position ?? null;
+			const previousPosition = r.previous_position ?? null;
+			const position1dAgo = r.position_1d_ago ?? null;
+			const position7dAgo = r.position_7d_ago ?? null;
+			return {
+				trackedKeywordId: r.tracked_keyword_id as RankTracking.TrackedKeywordId,
+				phrase: r.phrase,
+				domain: r.domain,
+				country: r.country,
+				language: r.language,
+				device: r.device,
+				position,
+				url: r.url,
+				observedAt: r.observed_at instanceof Date ? r.observed_at : new Date(r.observed_at),
+				previousPosition,
+				position1dAgo,
+				position7dAgo,
+				positionChange1d: position !== null && position1dAgo !== null ? position - position1dAgo : null,
+				positionChange7d: position !== null && position7dAgo !== null ? position - position7dAgo : null,
+			};
+		});
 	}
 
 	private toAggregate(row: typeof rankingObservations.$inferSelect): RankTracking.RankingObservation {

--- a/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/serp-observation.repository.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/rank-tracking/serp-observation.repository.ts
@@ -80,7 +80,7 @@ export class DrizzleSerpObservationRepository implements RankTracking.SerpObserv
 			WITH latest AS (
 				SELECT project_id, phrase, country, language, device, MAX(observed_at) AS observed_at
 				FROM serp_observations
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 					AND observed_at >= ${since}
 					${wherePhrase}
 					${whereCountry}

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
@@ -36,7 +36,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					     THEN SUM(position * impressions) / SUM(impressions)
 					     ELSE 0 END AS weighted_position
 				FROM gsc_observations
-				WHERE project_id = ${projectId}
+				WHERE project_id = ${projectId}::uuid
 					-- Exclude observations from unlinked properties so the cockpit
 					-- only surfaces data from currently-active GSC properties.
 					-- Bug A of #164: unlinking a property left historical rows
@@ -44,7 +44,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					-- aged out of the window. This subquery makes unlink immediate.
 					AND gsc_property_id IN (
 						SELECT id FROM gsc_properties
-						WHERE project_id = ${projectId} AND unlinked_at IS NULL
+						WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL
 					)
 					AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 					AND query <> ''
@@ -97,9 +97,9 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 				SUM(clicks)::bigint AS clicks,
 				SUM(impressions)::bigint AS impressions
 			FROM gsc_observations
-			WHERE project_id = ${projectId}
+			WHERE project_id = ${projectId}::uuid
 				AND gsc_property_id IN (
-					SELECT id FROM gsc_properties WHERE project_id = ${projectId} AND unlinked_at IS NULL
+					SELECT id FROM gsc_properties WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL
 				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 				AND query <> ''
@@ -139,9 +139,9 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 				SUM(clicks)::bigint AS clicks,
 				SUM(impressions)::bigint AS impressions
 			FROM gsc_observations
-			WHERE project_id = ${projectId}
+			WHERE project_id = ${projectId}::uuid
 				AND gsc_property_id IN (
-					SELECT id FROM gsc_properties WHERE project_id = ${projectId} AND unlinked_at IS NULL
+					SELECT id FROM gsc_properties WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL
 				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 			GROUP BY day

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -25,6 +25,14 @@ export class ProjectsResource {
 		return this.http.get(`/projects/${encodeURIComponent(id)}`);
 	}
 
+	/**
+	 * #172 — data-freshness summary across rankings, ai-search, gsc, ga4,
+	 * bing, pagespeed, clarity. Single round-trip for daily health checks.
+	 */
+	getFreshness(id: string): Promise<ProjectManagementContracts.ProjectFreshnessResponse> {
+		return this.http.get(`/projects/${encodeURIComponent(id)}/freshness`);
+	}
+
 	create(
 		body: ProjectManagementContracts.CreateProjectRequest,
 	): Promise<ProjectManagementContracts.ProjectDto> {

--- a/packages/sdk/src/resources/rank-tracking.ts
+++ b/packages/sdk/src/resources/rank-tracking.ts
@@ -26,6 +26,16 @@ export class RankTrackingResource {
 		return this.http.get(`/projects/${encodeURIComponent(projectId)}/rankings`);
 	}
 
+	/**
+	 * #171 — per-keyword summary with 1d / 7d position deltas. Kept
+	 * separate from `listProjectRankings` (raw observation list, used by
+	 * the SPA time-series charts) so external integrations can detect
+	 * rank movements without folding the raw list client-side.
+	 */
+	listProjectRankingsSummary(projectId: string): Promise<RankTrackingContracts.ProjectRankingsResponse> {
+		return this.http.get(`/projects/${encodeURIComponent(projectId)}/rankings/summary`);
+	}
+
 	history(
 		trackedKeywordId: string,
 		query?: RankTrackingContracts.RankingHistoryQuery,


### PR DESCRIPTION
## Summary

Cleanup batch — fixes 7 issues from the open backlog:

| Issue | Severity | What |
|-------|----------|------|
| #178 | P2 | UUID cast bug: `/cockpit/search-demand-trend` returned 500 INTERNAL |
| #179 | P2 | UUID cast bug: `/cockpit/competitor-activity` silently returned all zeros |
| #181 | P2 | Doc bug: `ranked-keywords` + `keyword-gaps` required-params not surfaced |
| #180 | P2 | Gemini's `vertexaisearch.cloud.google.com` wrapper dominated top-cited domains |
| #176 | P3 | Worker idempotent-skip swallowed `NotFoundError` on ingest replay |
| #171 | P1 | New `GET /projects/{pid}/rankings/summary` with 1d / 7d position deltas |
| #172 | P2 | New `GET /projects/{id}/freshness` summary across 8 subsystems |

#157 deferred — needs a time-driven cron mechanism + `managedBy` flag on `JobDefinition`. Unclaimed for a dedicated PR.

Other open issues are larger features that need brainstorming (#120, #144, #143, #145) or provider integrations (excluded per cleanup scope).

## Per-issue detail

### Systemic UUID cast bug (#178, #179, contributes to #181)
postgres-js + raw SQL doesn't auto-coerce `text → uuid` (same root cause as PR #168). Audited every `${projectId}` in raw SQL across `packages/infrastructure/.../repositories/` and added `::uuid` in 6 sites across 5 files:
- `ranked-keyword-observation.repository.ts` (2 sites — #178)
- `competitor-activity-observation.repository.ts` — #179
- `competitor-keyword-gap.repository.ts`
- `serp-observation.repository.ts`
- `gsc-cockpit-read-model.ts` (3 sites — 2 main WHEREs + 1 subquery)

**Why some endpoints 500ed and others silently returned empty**: postgres only triggers the cast failure when it has rows to evaluate. With empty tables (like `competitor_activity_observations` in #179) the WHERE short-circuits and returns empty — the cockpit then renders all zeros. With populated tables (like `ranked_keywords_observations` in #178) every row needs the comparison and we get 500.

### #180 — Gemini's `vertexaisearch.cloud.google.com` wrapper
Added `AND domain NOT IN ('vertexaisearch.cloud.google.com')` in `citationsForProject`. Until the ingest pipeline parses the `/grounding-api-redirect/<blob>` and re-attributes to the canonical domain, this query-time filter is the cheapest fix and doesn't need a backfill.

### #181 Part 1 — OpenAPI descriptions
`ranked-keywords` and `keyword-gaps` already declared required params via Zod, but the descriptions didn't call them out nor point to where valid values live. Updated both to lead with `**Required query**:`, reference the endpoint that lists valid values, document `limit` defaults / max, flag the per-locale coverage gap, and add 400 to the error response list.

Part 2 (per-locale schedules for ES/MX/FR) is data/config work — deferred from this code-only PR.

### #176 — Cached ingest replay swallowed permanent failures
Worker's cache-hit branch wrapped the ingest dispatch in a generic try/catch (warn + mark succeeded), so a permanent `NotFoundError` never reached the outer handler that auto-disables the def (#174 defensive layer). Now the cache-hit branch escalates `NotFoundError` the same way: `definition.disable()` + `run.fail({ code: 'INGEST_PRECONDITION_FAILED' })`. Other ingest errors keep the existing warn-and-keep-payload behaviour.

### #171 — Position deltas
New `GET /projects/{pid}/rankings/summary` returning one row per tracked keyword with `previousPosition`, `position1dAgo`, `position7dAgo`, and the corresponding `positionChange*` deltas. **Kept the existing `/rankings` endpoint untouched** because the SPA's time-series charts consume the raw multi-row observation list. The summary endpoint is what external integrations (daily health check) should hit.

### #172 — Project freshness summary
New `GET /projects/{id}/freshness` returning a single round-trip summary of when each upstream subsystem last ingested for the project: rankings, ai-search (with provider list), brand-prompts (active + paused), ga4, gsc, bing, pageSpeed, clarity.

## Test plan

- [x] `pnpm lint` clean (1028 files)
- [x] `pnpm typecheck` clean (27/27 packages)
- [x] `pnpm test` — 411 application tests pass, 16 api, plus the rest
- [x] `pnpm build` clean
- [ ] Post-deploy verification:
  1. `GET /projects/{ES}/cockpit/search-demand-trend` → 200 (#178)
  2. `GET /projects/{ES}/cockpit/competitor-activity` → non-zero `activityScore` for at least one competitor with wayback/backlinks data (#179)
  3. `GET /projects/{ES}/ai-search/citations` → `vertexaisearch.cloud.google.com` absent (#180)
  4. `GET /projects/{ES}/ranked-keywords` (no params) → 400 with clear hint about `targetDomain` (#181)
  5. `GET /projects/{ES}/rankings/summary` → 70 rows with delta fields (#171)
  6. `GET /projects/{ES}/freshness` → structured summary across 8 sources (#172)
  7. Force `run-now` on a stuck orphan def (e.g. `ca8ce5d0-...`) → run reports `INGEST_PRECONDITION_FAILED` AND def is now `enabled=false` (#176)

Closes #176
Closes #171
Closes #172
Closes #178
Closes #179
Closes #180
Closes #181