### PR TITLE
feat(project-management): make AddCompetitorUseCase idempotent (ensure-and-refeed)

### DIFF
--- a/apps/api/src/modules/project-management/projects.controller.ts
+++ b/apps/api/src/modules/project-management/projects.controller.ts
@@ -184,12 +184,13 @@ export class ProjectsController {
 	}
 
 	@Post(':id/competitors')
+	@HttpCode(200)
 	@BulkWriteThrottle
 	async addCompetitorToProject(
 		@Principal() principal: AuthPrincipal,
 		@Param('id') id: string,
 		@Body(new ZodValidationPipe(ProjectManagementContracts.AddCompetitorRequest)) body: AddCompetitorRequest,
-	): Promise<{ competitorId: string }> {
+	): Promise<{ competitorId: string; created: boolean }> {
 		const project = await this.loadProject(id);
 		await this.orgMembership.require(principal, project.organizationId);
 		return this.addCompetitor.execute({ projectId: id, ...body });

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -201,7 +201,9 @@ export function buildOpenApiDocument(): unknown {
 	registry.registerPath({
 		method: 'post',
 		path: '/api/v1/projects/{id}/competitors',
-		summary: 'Track a competitor for a project',
+		summary: 'Track a competitor for a project (idempotent)',
+		description:
+			'Idempotent ensure-and-refeed. If the competitor already exists for this project, returns the existing id with `created: false` and re-publishes the CompetitorAdded event so the auto-schedule handlers backfill any missing feeders (wayback, backlinks, ranked-keywords, domain-intersection). The downstream scheduler dedupes by systemParamKey, so healthy schedules are no-ops.',
 		tags: ['project-management'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {
@@ -209,11 +211,18 @@ export function buildOpenApiDocument(): unknown {
 			body: { content: { 'application/json': { schema: ProjectManagementContracts.AddCompetitorRequest } } },
 		},
 		responses: {
-			201: {
-				description: 'Competitor id',
-				content: { 'application/json': { schema: z.object({ competitorId: z.string().uuid() }) } },
+			200: {
+				description: 'Competitor id + whether the call created a new row or refed an existing one',
+				content: {
+					'application/json': {
+						schema: z.object({
+							competitorId: z.string().uuid(),
+							created: z.boolean(),
+						}),
+					},
+				},
 			},
-			...errorResponses([400, 401, 403, 404, 409]),
+			...errorResponses([400, 401, 403, 404]),
 		},
 	});
 

--- a/packages/application/src/project-management/use-cases/add-competitor.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/add-competitor.use-case.spec.ts
@@ -1,5 +1,5 @@
 import type { IdentityAccess, ProjectManagement } from '@rankpulse/domain';
-import { ConflictError, FakeClock, FixedIdGenerator, NotFoundError, Uuid } from '@rankpulse/shared';
+import { FakeClock, FixedIdGenerator, NotFoundError, Uuid } from '@rankpulse/shared';
 import {
 	aProject,
 	InMemoryCompetitorRepository,
@@ -33,7 +33,7 @@ describe('AddCompetitorUseCase', () => {
 		await projects.save(project);
 	});
 
-	it('persists a competitor, publishes CompetitorAdded', async () => {
+	it('persists a competitor and publishes CompetitorAdded on first add', async () => {
 		const result = await useCase.execute({
 			projectId: project.id,
 			domain: 'vigilant.es',
@@ -41,24 +41,74 @@ describe('AddCompetitorUseCase', () => {
 		});
 
 		expect(result.competitorId).toBe(competitorId);
+		expect(result.created).toBe(true);
 		const list = await competitors.listForProject(project.id);
 		expect(list).toHaveLength(1);
 		expect(list[0]?.label).toBe('Vigilant');
 		expect(events.publishedTypes()).toContain('project-management.CompetitorAdded');
 	});
 
-	it('rejects when the project does not exist', async () => {
+	it('throws NotFoundError when the project does not exist', async () => {
 		await expect(
 			useCase.execute({ projectId: Uuid.generate(), domain: 'vigilant.es' }),
 		).rejects.toBeInstanceOf(NotFoundError);
 	});
 
-	it('rejects duplicate competitor domains for the same project', async () => {
+	// Idempotency contract: re-adding an existing competitor MUST return the
+	// existing id and re-publish CompetitorAdded so the auto-schedule
+	// handlers can backfill any feeders missing from the JobDefinition table
+	// (operator cleanup, late-arriving handler, etc.). Pre-fix this threw
+	// ConflictError, forcing operators into a DELETE + POST cycle that
+	// destroyed wayback + backlinks run history.
+	it('is idempotent: re-adding existing competitor returns same id without throwing', async () => {
+		const first = await useCase.execute({
+			projectId: project.id,
+			domain: 'vigilant.es',
+			label: 'Vigilant',
+		});
+
+		ids = new FixedIdGenerator([Uuid.generate()]); // would-be new id
+		const refeed = new AddCompetitorUseCase(projects, competitors, clock, ids, events);
+		const second = await refeed.execute({ projectId: project.id, domain: 'vigilant.es' });
+
+		expect(second.competitorId).toBe(first.competitorId);
+		expect(second.created).toBe(false);
+		const list = await competitors.listForProject(project.id);
+		expect(list).toHaveLength(1);
+	});
+
+	it('re-emits CompetitorAdded on the idempotent path so auto-schedule handlers can backfill', async () => {
 		await useCase.execute({ projectId: project.id, domain: 'vigilant.es' });
-		ids = new FixedIdGenerator([Uuid.generate()]);
-		const duplicateUseCase = new AddCompetitorUseCase(projects, competitors, clock, ids, events);
-		await expect(
-			duplicateUseCase.execute({ projectId: project.id, domain: 'vigilant.es' }),
-		).rejects.toBeInstanceOf(ConflictError);
+		const firstEventCount = events
+			.publishedTypes()
+			.filter((t) => t === 'project-management.CompetitorAdded').length;
+		expect(firstEventCount).toBe(1);
+
+		const refeed = new AddCompetitorUseCase(projects, competitors, clock, ids, events);
+		await refeed.execute({ projectId: project.id, domain: 'vigilant.es' });
+
+		const totalEventCount = events
+			.publishedTypes()
+			.filter((t) => t === 'project-management.CompetitorAdded').length;
+		expect(totalEventCount).toBe(2);
+	});
+
+	it('preserves the existing competitor label on the idempotent path (does not overwrite with cmd.label)', async () => {
+		await useCase.execute({
+			projectId: project.id,
+			domain: 'vigilant.es',
+			label: 'Original Label',
+		});
+
+		const refeed = new AddCompetitorUseCase(projects, competitors, clock, ids, events);
+		const result = await refeed.execute({
+			projectId: project.id,
+			domain: 'vigilant.es',
+			label: 'Tried To Rename',
+		});
+
+		expect(result.created).toBe(false);
+		const list = await competitors.listForProject(project.id);
+		expect(list[0]?.label).toBe('Original Label');
 	});
 });

--- a/packages/application/src/project-management/use-cases/add-competitor.use-case.ts
+++ b/packages/application/src/project-management/use-cases/add-competitor.use-case.ts
@@ -1,5 +1,5 @@
 import { ProjectManagement, type SharedKernel } from '@rankpulse/domain';
-import { type Clock, ConflictError, type IdGenerator, NotFoundError } from '@rankpulse/shared';
+import { type Clock, type IdGenerator, NotFoundError } from '@rankpulse/shared';
 
 export interface AddCompetitorCommand {
 	projectId: string;
@@ -9,8 +9,31 @@ export interface AddCompetitorCommand {
 
 export interface AddCompetitorResult {
 	competitorId: string;
+	/**
+	 * `true` when this call created a new competitor; `false` when the
+	 * competitor already existed and the call only re-emitted
+	 * `CompetitorAdded` to backfill any missing feeders. Lets the
+	 * controller pick the right HTTP status (201 vs 200).
+	 */
+	created: boolean;
 }
 
+/**
+ * Idempotent add. If the competitor already exists for this project,
+ * the call returns the existing id WITHOUT throwing — and re-publishes
+ * `CompetitorAdded` so the auto-schedule handlers can backfill any
+ * feeders missing from the JobDefinition table.
+ *
+ * Why re-publish on the idempotent path: `ScheduleEndpointFetchUseCase`
+ * has its own idempotency check via `systemParamKey + value`, so
+ * existing healthy schedules are no-ops. But schedules that were
+ * deleted (operator cleanup of broken jobs) or schedules whose
+ * auto-schedule handler didn't exist when the competitor was first
+ * added (e.g. wayback + backlinks were wired in PR #185) will be
+ * created. This makes `POST /competitors` a safe "ensure-and-refeed"
+ * operation, removing the need for a DELETE + POST cycle that would
+ * lose run history.
+ */
 export class AddCompetitorUseCase {
 	constructor(
 		private readonly projects: ProjectManagement.ProjectRepository,
@@ -30,7 +53,16 @@ export class AddCompetitorUseCase {
 		const domain = ProjectManagement.DomainName.create(cmd.domain);
 		const existing = await this.competitors.findByDomain(projectId, domain);
 		if (existing) {
-			throw new ConflictError(`Competitor "${domain.value}" already tracked for this project`);
+			await this.events.publish([
+				new ProjectManagement.CompetitorAdded({
+					competitorId: existing.id,
+					projectId,
+					domain: domain.value,
+					label: existing.label,
+					occurredAt: this.clock.now(),
+				}),
+			]);
+			return { competitorId: existing.id, created: false };
 		}
 
 		const competitorId = this.ids.generate() as ProjectManagement.CompetitorId;
@@ -43,15 +75,16 @@ export class AddCompetitorUseCase {
 		});
 		await this.competitors.save(competitor);
 
-		const event = new ProjectManagement.CompetitorAdded({
-			competitorId,
-			projectId,
-			domain: domain.value,
-			label: competitor.label,
-			occurredAt: this.clock.now(),
-		});
-		await this.events.publish([event]);
+		await this.events.publish([
+			new ProjectManagement.CompetitorAdded({
+				competitorId,
+				projectId,
+				domain: domain.value,
+				label: competitor.label,
+				occurredAt: this.clock.now(),
+			}),
+		]);
 
-		return { competitorId };
+		return { competitorId, created: true };
 	}
 }

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -53,10 +53,16 @@ export class ProjectsResource {
 		return this.http.post(`/projects/${encodeURIComponent(projectId)}/locations`, body);
 	}
 
+	/**
+	 * Idempotent ensure-and-refeed. Returns `created: true` for a fresh
+	 * competitor, `created: false` if it already existed (in which case
+	 * the call only re-published CompetitorAdded so auto-schedule
+	 * handlers backfill missing feeders).
+	 */
 	addCompetitor(
 		projectId: string,
 		body: ProjectManagementContracts.AddCompetitorRequest,
-	): Promise<{ competitorId: string }> {
+	): Promise<{ competitorId: string; created: boolean }> {
 		return this.http.post(`/projects/${encodeURIComponent(projectId)}/competitors`, body);
 	}
 


### PR DESCRIPTION
## Summary

POST \`/projects/{id}/competitors\` se hace idempotente. Si el competitor ya existe, devuelve su id con \`created: false\` y re-publica \`CompetitorAdded\` para que los auto-schedule handlers backfilleen feeders faltantes.

## Por qué

Cuando un operador limpia jobs huérfanos (como en el cleanup post-PR #185 — 16 \`dataforseo-labs-ranked-keywords\` borrados), los competitors quedan sin feeder. Antes la única forma de regenerarlos era \`DELETE + POST\` del competitor → perdías run history de wayback + backlinks + label custom. Ahora basta con repetir POST.

\`ScheduleEndpointFetchUseCase\` ya hace dedupe por \`systemParamKey + value\` ([schedule-endpoint-fetch.use-case.ts:71](packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts#L71)), así que re-emitir el evento es seguro: los schedules sanos quedan no-op, los faltantes se crean.

## Cambios

| Capa | Cambio |
|---|---|
| Use case | Quita \`ConflictError\`; devuelve \`{competitorId, created}\`. Path idempotente preserva el label existente (no lo sobreescribe con cmd.label — silent overwrites son footgun) |
| Controller | \`@HttpCode(200)\` consistente para ambos paths |
| SDK | Return type updated + JSDoc |
| OpenAPI | Status 200 (era 201), 409 quitado de errorResponses, descripción reescrita como "idempotent ensure-and-refeed" |

## Tests

- Test existente "persists + publishes" extendido con assertion \`created: true\`
- Test "rejects duplicate" reemplazado por 3 nuevos:
  - Idempotencia: re-add devuelve mismo id, list.length sigue en 1
  - Re-emit: CompetitorAdded dispara en ambas llamadas
  - Label-preservation: cmd.label se ignora en path idempotente
- 429 application tests pasan

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean (application, api, sdk, web)
- [x] \`pnpm test\` green
- [ ] Post-deploy: ejecutar refeed bulk de los 16 competitors cuyos ranked-keywords se borraron en el cleanup → verificar que aparecen 16 nuevos \`dataforseo-labs-ranked-keywords\` jobs con \`systemParams.targetDomain\` correctos