### PR TITLE
fix(provider-connectivity): centralise organizationId stamping in ScheduleEndpointFetchUseCase

### DIFF
--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -317,6 +317,8 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		jobRunRepo,
 		apiUsageRepo,
 		jobScheduler,
+		// project repo so ScheduleEndpointFetchUseCase can stamp organizationId
+		projectRepo,
 		credentialFormatValidator: {
 			validate: (providerId, plaintextSecret) => {
 				providerRegistry.get(providerId).validateCredentialPlaintext(plaintextSecret);

--- a/apps/api/src/composition/composition-root.ts
+++ b/apps/api/src/composition/composition-root.ts
@@ -210,6 +210,10 @@ export function buildCompositionRoot(env: AppEnv): BootstrapResult {
 		SystemClock,
 		SystemIdGenerator,
 		eventPublisher,
+		// project repo needed so the use case can stamp `organizationId`
+		// in systemParams without every caller (controller + every
+		// auto-schedule handler) doing the lookup itself.
+		projectRepo,
 	);
 
 	// ADR 0002 Phase 4a — the auto-schedule logger is shared across every

--- a/packages/application/src/provider-connectivity/module.ts
+++ b/packages/application/src/provider-connectivity/module.ts
@@ -1,4 +1,4 @@
-import type { ProviderConnectivity as PCDomain, SharedKernel } from '@rankpulse/domain';
+import type { ProviderConnectivity as PCDomain, ProjectManagement, SharedKernel } from '@rankpulse/domain';
 import type { Clock, IdGenerator } from '@rankpulse/shared';
 import type { ContextModule, ContextRegistrations, SharedDeps } from '../_core/module.js';
 import { ListJobRunsUseCase } from './use-cases/list-job-runs.use-case.js';
@@ -30,6 +30,14 @@ export interface ProviderConnectivityDeps {
 	readonly jobRunRepo: PCDomain.JobRunRepository;
 	readonly apiUsageRepo: PCDomain.ApiUsageRepository;
 	readonly jobScheduler: PCDomain.JobScheduler;
+	/**
+	 * Needed by `ScheduleEndpointFetchUseCase` to look up
+	 * `project.organizationId` and stamp it into `systemParams.organizationId`
+	 * automatically — the worker processor rejects runs without it.
+	 * Crossing the bounded-context boundary here is deliberate: there is no
+	 * cleaner way to share `organizationId` than reading the project itself.
+	 */
+	readonly projectRepo: ProjectManagement.ProjectRepository;
 	/**
 	 * Tiny adapter the composition root builds over the actual provider
 	 * registry. Keeps the application layer decoupled from
@@ -68,6 +76,7 @@ export const providerConnectivityModule: ContextModule = {
 					d.clock,
 					d.ids,
 					d.events,
+					d.projectRepo,
 				),
 				TriggerJobDefinitionRun: new TriggerJobDefinitionRunUseCase(d.jobDefRepo, d.jobScheduler, d.ids),
 				ListJobDefinitions: new ListJobDefinitionsUseCase(d.jobDefRepo),

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.spec.ts
@@ -1,6 +1,7 @@
+import type { IdentityAccess } from '@rankpulse/domain';
 import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
-import { FakeClock, FixedIdGenerator, InvalidInputError, type Uuid } from '@rankpulse/shared';
-import { RecordingEventPublisher } from '@rankpulse/testing';
+import { FakeClock, FixedIdGenerator, InvalidInputError, NotFoundError, type Uuid } from '@rankpulse/shared';
+import { aProject, InMemoryProjectRepository, RecordingEventPublisher } from '@rankpulse/testing';
 import { describe, expect, it } from 'vitest';
 import {
 	type EndpointParamsValidator,
@@ -8,7 +9,7 @@ import {
 } from './schedule-endpoint-fetch.use-case.js';
 
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as ProjectManagement.ProjectId;
-const ORG_ID = '22222222-2222-2222-2222-222222222222';
+const ORG_ID = '22222222-2222-2222-2222-222222222222' as Uuid as IdentityAccess.OrganizationId;
 const TRACKED_KW_ID = '33333333-3333-3333-3333-333333333333';
 
 class StubDefinitionRepo implements ProviderConnectivity.JobDefinitionRepository {
@@ -46,10 +47,16 @@ const passThroughValidator: EndpointParamsValidator = {
 	validate: (_p, _e, params) => params as Record<string, unknown>,
 };
 
-const buildUseCase = (validator: EndpointParamsValidator = passThroughValidator) => {
+const buildUseCase = async (validator: EndpointParamsValidator = passThroughValidator) => {
 	const repo = new StubDefinitionRepo();
 	const scheduler = new RecordingScheduler();
 	const events = new RecordingEventPublisher();
+	const projects = new InMemoryProjectRepository();
+	// Pre-seed the project so `findById(PROJECT_ID)` returns a real
+	// project with `organizationId === ORG_ID`. Required since the use
+	// case now looks up the project to stamp organizationId.
+	const project = aProject({ id: PROJECT_ID, organizationId: ORG_ID });
+	await projects.save(project);
 	const useCase = new ScheduleEndpointFetchUseCase(
 		repo,
 		scheduler,
@@ -57,8 +64,9 @@ const buildUseCase = (validator: EndpointParamsValidator = passThroughValidator)
 		new FakeClock(new Date('2026-05-04T10:00:00Z')),
 		new FixedIdGenerator(['def-id-1' as Uuid]),
 		events,
+		projects,
 	);
-	return { useCase, repo, scheduler, events };
+	return { useCase, repo, scheduler, events, projects };
 };
 
 const baseCmd = {
@@ -71,7 +79,7 @@ const baseCmd = {
 
 describe('ScheduleEndpointFetchUseCase', () => {
 	it('persists, registers in the scheduler, and emits an event for valid input', async () => {
-		const { useCase, repo, scheduler, events } = buildUseCase();
+		const { useCase, repo, scheduler, events } = await buildUseCase();
 
 		const result = await useCase.execute(baseCmd);
 
@@ -89,7 +97,7 @@ describe('ScheduleEndpointFetchUseCase', () => {
 				);
 			},
 		};
-		const { useCase, repo, scheduler } = buildUseCase(reject);
+		const { useCase, repo, scheduler } = await buildUseCase(reject);
 
 		await expect(useCase.execute({ ...baseCmd, params: { phrase: 'wrong-shape' } })).rejects.toBeInstanceOf(
 			InvalidInputError,
@@ -107,36 +115,39 @@ describe('ScheduleEndpointFetchUseCase', () => {
 				device: 'desktop',
 			}),
 		};
-		const { useCase, repo } = buildUseCase(normalize);
+		const { useCase, repo } = await buildUseCase(normalize);
 
 		await useCase.execute({ ...baseCmd, params: { keyword: 'control de rondas' } });
 
 		expect(repo.saved[0]?.params).toMatchObject({ device: 'desktop' });
 	});
 
-	it('merges systemParams (organizationId, trackedKeywordId) AFTER validation so they survive Zod strip (BACKLOG #9)', async () => {
+	it('merges systemParams (trackedKeywordId, …) AFTER validation so they survive Zod strip (BACKLOG #9)', async () => {
 		const stripExtras: EndpointParamsValidator = {
 			validate: () => ({ keyword: 'k', locationCode: 2724, languageCode: 'es', device: 'desktop' }),
 		};
-		const { useCase, repo } = buildUseCase(stripExtras);
+		const { useCase, repo } = await buildUseCase(stripExtras);
 
 		await useCase.execute({
 			...baseCmd,
-			systemParams: { organizationId: ORG_ID, trackedKeywordId: TRACKED_KW_ID },
+			systemParams: { trackedKeywordId: TRACKED_KW_ID },
 		});
 
 		expect(repo.saved[0]?.params).toMatchObject({
 			keyword: 'k',
-			organizationId: ORG_ID,
 			trackedKeywordId: TRACKED_KW_ID,
 			// #147: projectId is unconditionally stamped so the worker IngestRouter
 			// can scope persisted rows even when the caller did not pass it.
 			projectId: PROJECT_ID,
+			// Centralised stamping — the use case now derives organizationId from
+			// the project itself (lookup via injected ProjectRepository) so every
+			// caller, including auto-schedule handlers, gets it without remembering.
+			organizationId: ORG_ID,
 		});
 	});
 
 	it('attaches the credentialOverrideId when provided', async () => {
-		const { useCase, repo } = buildUseCase();
+		const { useCase, repo } = await buildUseCase();
 		const overrideId = '44444444-4444-4444-4444-444444444444';
 
 		await useCase.execute({ ...baseCmd, credentialOverrideId: overrideId });
@@ -156,7 +167,7 @@ describe('ScheduleEndpointFetchUseCase', () => {
 			credentialOverrideId: null,
 			now: new Date('2026-05-04T00:00:00Z'),
 		});
-		const { useCase, repo, scheduler, events } = buildUseCase();
+		const { useCase, repo, scheduler, events } = await buildUseCase();
 		repo.idempotencyHit = existing;
 
 		const result = await useCase.execute({
@@ -164,7 +175,7 @@ describe('ScheduleEndpointFetchUseCase', () => {
 			providerId: 'google-search-console',
 			endpointId: 'gsc-search-analytics',
 			params: { siteUrl: 'sc-domain:example.com' },
-			systemParams: { organizationId: ORG_ID, gscPropertyId: 'prop-1' },
+			systemParams: { gscPropertyId: 'prop-1' },
 			cron: '0 5 * * *',
 			idempotencyKey: { systemParamKey: 'gscPropertyId', systemParamValue: 'prop-1' },
 		});
@@ -174,5 +185,36 @@ describe('ScheduleEndpointFetchUseCase', () => {
 		expect(scheduler.registered).toHaveLength(0);
 		expect(repo.saved).toHaveLength(0);
 		expect(events.publishedTypes()).toHaveLength(0);
+	});
+
+	// Regression guard: the worker processor requires `organizationId` in
+	// systemParams and rejects the run BEFORE persisting the JobRun row
+	// ("missing organizationId in systemParams"). Pre-fix only the manual
+	// schedule controller stamped it; auto-schedule handlers (CompetitorAdded,
+	// DomainAdded, GscPropertyLinked, …) skipped it, so every auto-scheduled
+	// run failed invisibly. Centralising the lookup here means every caller
+	// gets organizationId for free.
+	it('stamps organizationId from the project even when the caller omits systemParams entirely', async () => {
+		const { useCase, repo } = await buildUseCase();
+
+		await useCase.execute(baseCmd); // no systemParams field at all
+
+		expect(repo.saved[0]?.params).toMatchObject({
+			organizationId: ORG_ID,
+			projectId: PROJECT_ID,
+		});
+	});
+
+	it('throws NotFoundError when the project does not exist (fail fast before persisting)', async () => {
+		const { useCase, repo, scheduler } = await buildUseCase();
+
+		await expect(
+			useCase.execute({
+				...baseCmd,
+				projectId: '99999999-9999-9999-9999-999999999999' as ProjectManagement.ProjectId,
+			}),
+		).rejects.toBeInstanceOf(NotFoundError);
+		expect(repo.saved).toHaveLength(0);
+		expect(scheduler.registered).toHaveLength(0);
 	});
 });

--- a/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
+++ b/packages/application/src/provider-connectivity/use-cases/schedule-endpoint-fetch.use-case.ts
@@ -1,5 +1,5 @@
 import { type ProjectManagement, ProviderConnectivity, type SharedKernel } from '@rankpulse/domain';
-import { type Clock, type IdGenerator, InvalidInputError } from '@rankpulse/shared';
+import { type Clock, type IdGenerator, InvalidInputError, NotFoundError } from '@rankpulse/shared';
 
 /**
  * Application-layer port over `ProviderRegistry.endpoint().paramsSchema` so
@@ -49,6 +49,7 @@ export class ScheduleEndpointFetchUseCase {
 		private readonly clock: Clock,
 		private readonly ids: IdGenerator,
 		private readonly events: SharedKernel.EventPublisher,
+		private readonly projects: ProjectManagement.ProjectRepository,
 	) {}
 
 	async execute(cmd: ScheduleEndpointFetchCommand): Promise<ScheduleEndpointFetchResult> {
@@ -77,16 +78,31 @@ export class ScheduleEndpointFetchUseCase {
 			if (existing) return { definitionId: existing.id };
 		}
 
+		// Look up the project once to derive `organizationId` — the worker
+		// processor (`provider-fetch.processor.ts`) requires it as a
+		// systemParam and fails the run with "missing organizationId in
+		// systemParams" before persisting the JobRun row. Centralising the
+		// stamping here means EVERY caller (direct controller route AND every
+		// per-context auto-schedule handler) gets it for free. Pre-fix only
+		// the controller stamped it, so auto-scheduled jobs (CompetitorAdded,
+		// DomainAdded, GscPropertyLinked, …) all failed silently on run-now.
+		const project = await this.projects.findById(projectId);
+		if (!project) {
+			throw new NotFoundError(`Project ${projectId} not found`);
+		}
+
 		// `projectId` is stamped here unconditionally so the worker IngestRouter
 		// path can scope persisted rows to the right project even when the
 		// caller (auto-schedule handler or direct API) did not include it in
 		// `cmd.systemParams`. Centralising this avoids the silent skip
 		// (`logger.warn + return`) the worker handlers do when the systemParam
-		// is missing — see #147.
+		// is missing — see #147. `organizationId` is centralised here for the
+		// same reason — see commit referencing this comment.
 		const finalParams: Record<string, unknown> = {
 			...validatedParams,
 			...(cmd.systemParams ?? {}),
 			projectId: projectId as unknown as string,
+			organizationId: project.organizationId as unknown as string,
 		};
 
 		const id = this.ids.generate() as ProviderConnectivity.ProviderJobDefinitionId;


### PR DESCRIPTION
## Summary

El worker rechaza cada run que llega sin \`systemParams.organizationId\` con error \`missing organizationId in systemParams\`. La rechazo es ANTES de persistir el JobRun row, lo que hace que \`GET /runs\` devuelva \`[]\` aunque el run sí se procesó. Desde fuera parece "worker no procesa" — exactamente el síntoma que tuvimos confundidos durante horas tras los deploys de PR #185/#186.

## Root cause

Solo el manual schedule controller stampaba \`organizationId\` ([providers.controller.ts:357](apps/api/src/modules/provider-connectivity/providers.controller.ts#L357)). Los auto-schedule handlers per-contexto (\`CompetitorAdded\` → wayback + backlinks + ranked-keywords + domain-intersection; \`DomainAdded\`, \`Ga4PropertyLinked\`, \`GscPropertyLinked\`, \`BrandPromptCreated\`, …) construían systemParams via su propio \`systemParamsBuilder\` y NINGUNO lo añadía. Todo auto-scheduled run fallaba invisiblemente.

## Fix

Inyectar \`ProjectRepository\` en el use case y stampar \`organizationId\` automáticamente — mismo patrón que ya se usa para \`projectId\` (#147). Single place, every caller benefits sin que cada handler lo recuerde.

\`\`\`ts
const project = await this.projects.findById(projectId);
if (!project) throw new NotFoundError(...);

const finalParams = {
  ...validatedParams,
  ...(cmd.systemParams ?? {}),
  projectId: projectId as unknown as string,
  organizationId: project.organizationId as unknown as string,  // NEW
};
\`\`\`

El stamping del controller en \`providers.controller.ts:366\` queda redundante pero harmless (re-stampa el mismo valor) — separate cleanup task.

## Evidencia del bug en prod

Worker logs (srv07, 17:23 UTC):
\`\`\`
{"queue":"provider-dataforseo","jobId":"manual-f4a299b6-...","msg":"processing fetch job"}
{"queue":"provider-dataforseo","jobId":"manual-f4a299b6-...","err":"Job definition 75b5c3cf-... missing organizationId in systemParams","msg":"fetch job failed"}
\`\`\`

32 jobs disparados via \`/run-now\` después del refeed de competitors, los 32 con el mismo error.

## Test plan

- [x] \`pnpm lint\` clean (1037 ficheros)
- [x] \`pnpm typecheck\` clean (27 packages)
- [x] \`pnpm test\` green (431 application + 20 api + 36 infrastructure)
- [x] 2 nuevos regression tests en \`schedule-endpoint-fetch.use-case.spec.ts\`:
  - stamps organizationId even when caller omits systemParams entirely
  - throws NotFoundError fast when project doesn't exist
- [ ] Post-deploy: re-disparar los 32 run-now de los refeeds (ranked-keywords + domain-intersection ES/MX/FR) → verificar runs aparecen en \`/runs\` con status \`succeeded\` y datos en \`ranked_keywords_observations\`