### PR TITLE
fix(worker): defensive fallback for organizationId in legacy JobDefinitions

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -530,6 +530,9 @@ async function bootstrap(): Promise<void> {
 		apiUsageRepo,
 		trackedKeywordRepo,
 		competitorRepo,
+		// Defensive fallback for legacy JobDefinitions whose `params` JSON
+		// was persisted before PR #187 centralised the organizationId stamping.
+		projectRepo,
 		gscPropertyRepo,
 		wikipediaArticleRepo,
 		trackedPageRepo,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -135,6 +135,17 @@ export interface ProviderFetchProcessorDeps {
 	apiUsageRepo: ProviderConnectivity.ApiUsageRepository;
 	trackedKeywordRepo: RankTrackingDomain.TrackedKeywordRepository;
 	competitorRepo: ProjectManagement.CompetitorRepository;
+	/**
+	 * Defensive fallback: when a JobDefinition was persisted before PR #187
+	 * (which centralised organizationId stamping in ScheduleEndpointFetchUseCase)
+	 * its `params` JSON lacks `organizationId`. Without this repo the worker
+	 * rejects every run with "missing organizationId in systemParams" and never
+	 * persists a JobRun row — invisible from the outside.
+	 *
+	 * Used ONLY for the fallback lookup; the canonical source for new defs is
+	 * always the stamped `params.organizationId`.
+	 */
+	projectRepo: ProjectManagement.ProjectRepository;
 	gscPropertyRepo: SearchConsoleInsightsDomain.GscPropertyRepository;
 	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
 	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
@@ -206,9 +217,28 @@ export class ProviderFetchProcessor {
 		);
 		const params = definition.params as { organizationId?: string };
 
-		const orgId = params.organizationId;
+		// Defensive fallback for JobDefinitions persisted before PR #187:
+		// their `params` JSON lacks `organizationId` because the legacy code
+		// path only stamped it in the manual schedule controller, not in the
+		// per-context auto-schedule handlers. New defs always have it (the
+		// use case centralised the stamping); old defs we recover here via
+		// `definition.projectId` → `project.organizationId`. Saves a costly
+		// migration that would otherwise have to PATCH every legacy def
+		// (and the PATCH whitelist already protects organizationId from
+		// user writes, so the migration would need a back-door anyway).
+		let orgId = params.organizationId;
 		if (!orgId) {
-			throw new Error(`Job definition ${definition.id} missing organizationId in systemParams`);
+			const project = await this.deps.projectRepo.findById(definition.projectId);
+			if (!project) {
+				throw new NotFoundError(
+					`Job definition ${definition.id} has projectId=${definition.projectId} but the project no longer exists`,
+				);
+			}
+			orgId = project.organizationId as unknown as string;
+			log.warn(
+				{ projectId: definition.projectId },
+				'legacy job definition (pre-PR#187) missing organizationId in params — recovered from project',
+			);
 		}
 
 		const resolved = await this.deps.resolveCredentialUseCase.execute({


### PR DESCRIPTION
## Summary

PR #187 centralizó el stamping de \`organizationId\` en \`ScheduleEndpointFetchUseCase\`, pero solo afecta a JobDefinitions **nuevas**. Los \~32 jobs del refeed post-PR #186 (y cualquier feeder auto-scheduled anterior a hoy) tienen \`params.organizationId === undefined\` persistido en BD. El worker rechaza cada run y nunca persiste el JobRun row — invisible desde fuera.

## Fix

En \`provider-fetch.processor.ts\`: cuando \`params.organizationId\` falta, recovery desde \`definition.projectId\` via \`projectRepo.findById()\`. Defs nuevas siguen el fast path; defs legacy se self-heal al primer run y emiten un warn que nos permite medir cuándo eliminar el fallback.

## ¿Por qué no migration script?

- \`PATCH /job-definitions/{id}\` no puede tocar \`organizationId\` (está en SYSTEM_PARAM_KEYS whitelist que PR #185 añadió como defensa). Un PATCH user-driven se rechazaría.
- UPDATE SQL directo bypass-ea el audit trail.
- El fallback es O(1) por run y el warn log nos da una métrica clara para auditar y eventualmente retirarlo.

## Evidencia en prod tras deploy de PR #187

Worker logs (srv07, 18:48 UTC):
\`\`\`
{"err":"Job definition c348671f-... missing organizationId in systemParams","msg":"fetch job failed"}
\`\`\`
32 jobs, todos el mismo error — código nuevo desplegado pero los params persistidos siguen sin organizationId.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean (worker + app + api)
- [x] \`pnpm test\` green
- [ ] Post-deploy: re-disparar los 32 run-now → verificar runs aparecen en \`/runs\` con status \`succeeded\` y datos en \`ranked_keywords_observations\` + \`competitor_keyword_gaps\`