### PR TITLE
revert: defensive organizationId fallback in worker (#188) — fixed at the data layer instead

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -530,9 +530,6 @@ async function bootstrap(): Promise<void> {
 		apiUsageRepo,
 		trackedKeywordRepo,
 		competitorRepo,
-		// Defensive fallback for legacy JobDefinitions whose `params` JSON
-		// was persisted before PR #187 centralised the organizationId stamping.
-		projectRepo,
 		gscPropertyRepo,
 		wikipediaArticleRepo,
 		trackedPageRepo,

--- a/apps/worker/src/processors/provider-fetch.processor.ts
+++ b/apps/worker/src/processors/provider-fetch.processor.ts
@@ -135,17 +135,6 @@ export interface ProviderFetchProcessorDeps {
 	apiUsageRepo: ProviderConnectivity.ApiUsageRepository;
 	trackedKeywordRepo: RankTrackingDomain.TrackedKeywordRepository;
 	competitorRepo: ProjectManagement.CompetitorRepository;
-	/**
-	 * Defensive fallback: when a JobDefinition was persisted before PR #187
-	 * (which centralised organizationId stamping in ScheduleEndpointFetchUseCase)
-	 * its `params` JSON lacks `organizationId`. Without this repo the worker
-	 * rejects every run with "missing organizationId in systemParams" and never
-	 * persists a JobRun row — invisible from the outside.
-	 *
-	 * Used ONLY for the fallback lookup; the canonical source for new defs is
-	 * always the stamped `params.organizationId`.
-	 */
-	projectRepo: ProjectManagement.ProjectRepository;
 	gscPropertyRepo: SearchConsoleInsightsDomain.GscPropertyRepository;
 	wikipediaArticleRepo: EntityAwarenessDomain.WikipediaArticleRepository;
 	trackedPageRepo: WebPerformanceDomain.TrackedPageRepository;
@@ -217,28 +206,9 @@ export class ProviderFetchProcessor {
 		);
 		const params = definition.params as { organizationId?: string };
 
-		// Defensive fallback for JobDefinitions persisted before PR #187:
-		// their `params` JSON lacks `organizationId` because the legacy code
-		// path only stamped it in the manual schedule controller, not in the
-		// per-context auto-schedule handlers. New defs always have it (the
-		// use case centralised the stamping); old defs we recover here via
-		// `definition.projectId` → `project.organizationId`. Saves a costly
-		// migration that would otherwise have to PATCH every legacy def
-		// (and the PATCH whitelist already protects organizationId from
-		// user writes, so the migration would need a back-door anyway).
-		let orgId = params.organizationId;
+		const orgId = params.organizationId;
 		if (!orgId) {
-			const project = await this.deps.projectRepo.findById(definition.projectId);
-			if (!project) {
-				throw new NotFoundError(
-					`Job definition ${definition.id} has projectId=${definition.projectId} but the project no longer exists`,
-				);
-			}
-			orgId = project.organizationId as unknown as string;
-			log.warn(
-				{ projectId: definition.projectId },
-				'legacy job definition (pre-PR#187) missing organizationId in params — recovered from project',
-			);
+			throw new Error(`Job definition ${definition.id} missing organizationId in systemParams`);
 		}
 
 		const resolved = await this.deps.resolveCredentialUseCase.execute({


### PR DESCRIPTION
## Summary

Revert de #188 (defensive fallback en \`provider-fetch.processor.ts\` para JobDefinitions legacy sin \`organizationId\` en \`params\`). La razón por la que se añadió fue que PR #187 centralizó el stamping de \`organizationId\` en el use case, pero los \~40 jobs ya persistidos en BD se quedaban con \`params.organizationId === undefined\` y el worker los rechazaba.

**Ahora arreglado en la fuente correcta — la base de datos.**

## SQL migration ejecutada en prod

\`\`\`sql
BEGIN;
UPDATE provider_job_definitions d
SET params = jsonb_set(d.params, '{organizationId}', to_jsonb(p.organization_id::text))
FROM projects p
WHERE d.project_id = p.id
  AND NOT (d.params ? 'organizationId');
-- Result: UPDATE 40
-- Verify: 0 still_missing of 734 total
COMMIT;
\`\`\`

40 jobs actualizados, 0 huérfanos (todos tenían project válido). Verificado con sanity \`run-now\` post-update sobre uno de ellos (vigilant.es): \`status=succeeded\` sin activar el fallback (warn ausente en logs).

## Por qué revertir el fallback ahora

- DDD/Clean Code: la defensive code lives forever — sale en cada read aunque ya no se necesite, y los warn logs son ruido permanente
- La invariante \"todo JobDefinition tiene \`organizationId\` en params\" está garantizada en 2 sitios:
  1. \`ScheduleEndpointFetchUseCase\` lo stampa al crear (PR #187)
  2. Los datos legacy ya están migrados (esta PR)
- Si un futuro path se salta el use case y no stampa, debería **fallar loud** en vez de auto-recuperarse silenciosamente — la falla rápida es preferible al apaño implícito

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` green (27 tasks, full turbo cached)
- [x] SQL migration en prod: 40 → 0 missing
- [x] Sanity run-now post-migration: succeeded, sin warn de fallback
- [ ] Post-deploy: re-disparar 1-2 run-now → verify worker no usa fallback (no warn) + run succeeded