### PR TITLE
fix(dataforseo): ensureTaskOk validates per-task status (#179)

### DIFF
--- a/packages/providers/dataforseo/src/http.spec.ts
+++ b/packages/providers/dataforseo/src/http.spec.ts
@@ -52,4 +52,98 @@ describe('ensureTaskOk', () => {
 			expect((err as Error).message).toContain('/v3/serp');
 		}
 	});
+
+	// --- Task-level status validation (regression tests for #179) ---
+	//
+	// DataForSEO returns envelope `status_code: 20000` even when individual
+	// tasks fail with 4xxxx — the per-task status is the actual outcome.
+	// Prior implementation only inspected the envelope, so a 40204 "no
+	// Backlinks subscription" arrived as a "succeeded" run, charged the
+	// operator's ledger, and persisted an empty payload that the ACL
+	// translated to `totalBacklinks: 0`. These cases pin the contract so
+	// any future regression surfaces in CI rather than in production.
+
+	it('throws when the envelope is ok but a task reports 40204 (subscription denied)', () => {
+		expect(() =>
+			ensureTaskOk('/v3/backlinks/summary/live', {
+				status_code: 20000,
+				status_message: 'Ok.',
+				tasks: [
+					{
+						status_code: 40204,
+						status_message:
+							'Access denied. Visit Plans and Subscriptions to activate your subscription and get access to this API.',
+					},
+				],
+			}),
+		).toThrow(DataForSeoApiError);
+	});
+
+	it('surfaces the failing task status (not the envelope status) in the thrown error', () => {
+		try {
+			ensureTaskOk('/v3/backlinks/summary/live', {
+				status_code: 20000,
+				status_message: 'Ok.',
+				tasks: [{ status_code: 40204, status_message: 'Access denied.' }],
+			});
+			expect.fail('should have thrown');
+		} catch (err) {
+			expect(err).toBeInstanceOf(DataForSeoApiError);
+			expect((err as DataForSeoApiError).status).toBe(40204);
+			expect((err as Error).message).toContain('40204');
+			expect((err as Error).message).toContain('Access denied');
+			expect((err as Error).message).toContain('/v3/backlinks/summary/live');
+		}
+	});
+
+	it('returns silently when envelope and all tasks are ok', () => {
+		expect(() =>
+			ensureTaskOk('/v3/test', {
+				status_code: 20000,
+				status_message: 'Ok.',
+				tasks: [
+					{ status_code: 20000, status_message: 'Ok.' },
+					{ status_code: 20000, status_message: 'Ok.' },
+				],
+			}),
+		).not.toThrow();
+	});
+
+	it('returns silently when a task uses an informational success code (20100)', () => {
+		expect(() =>
+			ensureTaskOk('/v3/test', {
+				status_code: 20000,
+				status_message: 'Ok.',
+				tasks: [{ status_code: 20100, status_message: 'No results for the requested keyword.' }],
+			}),
+		).not.toThrow();
+	});
+
+	it('throws on the first failing task in a multi-task response', () => {
+		try {
+			ensureTaskOk('/v3/test', {
+				status_code: 20000,
+				status_message: 'Ok.',
+				tasks: [
+					{ status_code: 20000, status_message: 'Ok.' },
+					{ status_code: 40501, status_message: 'Monthly limit reached.' },
+					{ status_code: 20000, status_message: 'Ok.' },
+				],
+			});
+			expect.fail('should have thrown');
+		} catch (err) {
+			expect((err as DataForSeoApiError).status).toBe(40501);
+			expect((err as Error).message).toContain('Monthly limit reached');
+		}
+	});
+
+	it('returns silently when the response omits the tasks array (backward compatibility)', () => {
+		expect(() => ensureTaskOk('/v3/test', { status_code: 20000, status_message: 'Ok.' })).not.toThrow();
+	});
+
+	it('returns silently when the tasks array is empty', () => {
+		expect(() =>
+			ensureTaskOk('/v3/test', { status_code: 20000, status_message: 'Ok.', tasks: [] }),
+		).not.toThrow();
+	});
 });

--- a/packages/providers/dataforseo/src/http.ts
+++ b/packages/providers/dataforseo/src/http.ts
@@ -129,25 +129,64 @@ export const DataForSeoApiError = ProviderApiError;
 export type DataForSeoApiError = ProviderApiError;
 
 /**
- * DataForSEO returns HTTP 200 even when the task itself failed — the
- * real status lives in the body's `status_code`. Codes:
- *   - 20000          : task ok
- *   - 20100-20999    : informational (still success, no items)
+ * Shape of every DataForSEO response. Both the HTTP envelope AND each
+ * individual task in `tasks[]` carry their own `status_code` — and the
+ * envelope is misleading on its own (it reports 20000 whenever the HTTP
+ * service is up, even when every task underneath failed with 4xxxx).
+ */
+export interface DataForSeoTaskStatus {
+	readonly status_code: number;
+	readonly status_message: string;
+}
+
+export interface DataForSeoResponseEnvelope extends DataForSeoTaskStatus {
+	readonly tasks?: readonly DataForSeoTaskStatus[];
+}
+
+/**
+ * DataForSEO status code ranges per their API spec:
+ *   - 20000          : ok
+ *   - 20100-29999    : informational (still success, e.g. "no items found")
  *   - 40000-49999    : client/auth/quota error
  *   - 50000-59999    : provider-side error
- *
- * Without this check the processor persists an empty payload as a
- * successful run AND charges the operator's ledger. Failure budget +
- * silent data loss.
  */
-export const ensureTaskOk = (path: string, raw: { status_code: number; status_message: string }): void => {
-	if (raw.status_code === 20000 || (raw.status_code >= 20100 && raw.status_code < 30000)) return;
+const isDataForSeoSuccessStatus = (code: number): boolean =>
+	code === 20000 || (code >= 20100 && code < 30000);
+
+const raiseDataForSeoError = (
+	path: string,
+	level: 'envelope' | 'task',
+	status: DataForSeoTaskStatus,
+): never => {
 	throw new ProviderApiError(
 		PROVIDER_ID,
-		raw.status_code,
-		raw.status_message,
-		`DataForSEO ${path} task error ${raw.status_code}: ${raw.status_message}`,
+		status.status_code,
+		status.status_message,
+		`DataForSEO ${path} ${level} error ${status.status_code}: ${status.status_message}`,
 	);
+};
+
+/**
+ * Validates a DataForSEO response by checking BOTH the envelope and
+ * every task within. The envelope alone is insufficient: subscription,
+ * quota and per-target authorisation failures manifest as `20000` at the
+ * envelope with `4xxxx` on the offending task. Without per-task checks
+ * the processor persists an empty payload as a "succeeded" run AND
+ * charges the operator's ledger — silent data loss compounded by
+ * silent spend (issue #179).
+ *
+ * Throws on the first failing task; the rest are ignored. This matches
+ * the existing contract for envelope-level failures: one error per call.
+ */
+export const ensureTaskOk = (path: string, raw: DataForSeoResponseEnvelope): void => {
+	if (!isDataForSeoSuccessStatus(raw.status_code)) {
+		raiseDataForSeoError(path, 'envelope', raw);
+	}
+	for (const task of raw.tasks ?? []) {
+		if (!isDataForSeoSuccessStatus(task.status_code)) {
+			raiseDataForSeoError(path, 'task', task);
+		}
+	}
 };
 
 /**


### PR DESCRIPTION
## Summary

- `ensureTaskOk` now validates BOTH the response envelope AND each task within. Prior implementation only inspected the envelope (`raw.status_code`), so DataForSEO failures expressed at the task level (`tasks[].status_code: 4xxxx`) — subscription denied, quota exhausted, per-target auth failure — slipped through as "succeeded" runs.
- Same fix covers the 14 DataForSEO endpoints that route through `ensureTaskOk`.
- Backward compatible: envelopes without `tasks` continue to validate envelope-only.

## Root cause (verified on prod)

Inspecting `raw_payloads` for `dataforseo-backlinks-summary`:

\`\`\`
n_payloads | task_status |                       status_message
-----------+-------------+----------------------------------------------------------------
        66 | 40204       | Access denied. Visit Plans and Subscriptions to activate
                         | your subscription and get access to this API.
\`\`\`

Despite 100% task-level denial, 65 runs were marked \`succeeded\`, the ledger was charged, and 33 competitors persisted with \`backlinks_total=0\` — silent data loss compounded by silent spend. Closes #179.

The function's own docstring already described the intended behaviour (*"the processor persists an empty payload as a successful run AND charges the operator's ledger. Failure budget + silent data loss"*) — the implementation now matches.

## Design (DDD / SOLID / Clean Code)

- **Named domain types** `DataForSeoTaskStatus` and `DataForSeoResponseEnvelope` make the per-task contract explicit (was: anonymous structural type that only covered the envelope).
- **`isDataForSeoSuccessStatus`** extracted — single classification predicate, reused for envelope and tasks. Kills duplicated magic ranges (`20000`, `20100..29999`).
- **`raiseDataForSeoError`** extracted — single error-construction path, reused for envelope and task failures.
- **`ensureTaskOk`** keeps its name (the original intent was always per-task) and now iterates `raw.tasks ?? []`, throwing on the first failing task with that task's status surfaced in the error (not the envelope's misleading 20000).

## Test plan

- [x] RED: 3 new tests reproducing the bug fail before the fix (envelope 20000 + task 40204 must throw; failing task status surfaced; multi-task partial failure throws on first).
- [x] GREEN: all 67 tests pass after the fix (10 spec files in @rankpulse/provider-dataforseo).
- [x] Backward compatibility: 5 tests cover envelope without tasks, empty tasks, informational task code 20100.
- [x] \`pnpm typecheck\` clean across 27 packages.
- [x] \`pnpm lint\` clean (Biome).
- [x] \`pnpm test\` clean across full workspace (27 packages).

## Post-merge verification

- [ ] Force a run of one \`dataforseo-backlinks-summary\` job in prod; verify it now lands as \`status=failed\` with \`error_json\` containing the 40204 task error (was: \`status=succeeded\` with empty data).
- [ ] Cockpit \`/competitor-activity\` still returns 200 (the 33 existing observations with \`backlinks_total=0\` remain; they will be superseded once the DataForSEO Backlinks subscription is activated and fresh runs succeed).

## Out of scope (operator action)

The underlying external cause is that the DataForSEO account does not have Backlinks API access. This PR makes that failure visible and stops billing for void runs; activating the subscription (or disabling the 33 \`dataforseo-backlinks-summary\` job definitions) is an operator decision.