### PR TITLE
feat(project-management): drop Backlinks from competitor radar (#179)

### DIFF
--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -203,7 +203,7 @@ export function buildOpenApiDocument(): unknown {
 		path: '/api/v1/projects/{id}/competitors',
 		summary: 'Track a competitor for a project (idempotent)',
 		description:
-			'Idempotent ensure-and-refeed. If the competitor already exists for this project, returns the existing id with `created: false` and re-publishes the CompetitorAdded event so the auto-schedule handlers backfill any missing feeders (wayback, backlinks, ranked-keywords, domain-intersection). The downstream scheduler dedupes by systemParamKey, so healthy schedules are no-ops.',
+			'Idempotent ensure-and-refeed. If the competitor already exists for this project, returns the existing id with `created: false` and re-publishes the CompetitorAdded event so the auto-schedule handlers backfill any missing feeders (wayback, ranked-keywords, domain-intersection). The downstream scheduler dedupes by systemParamKey, so healthy schedules are no-ops.',
 		tags: ['project-management'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {
@@ -830,9 +830,9 @@ export function buildOpenApiDocument(): unknown {
 	registry.registerPath({
 		method: 'get',
 		path: '/api/v1/projects/{projectId}/cockpit/competitor-activity',
-		summary: 'Competitor Activity Radar — Wayback CDX + Backlinks deltas per competitor',
+		summary: 'Competitor Activity Radar — Wayback CDX snapshot deltas per competitor',
 		description:
-			'For each registered competitor, returns the latest Wayback snapshot count and Backlinks summary plus week-over-week deltas. Activity score is normalised 0-100 across the project so the cockpit can render a comparable bar (issue #117 Sprint 2).',
+			'For each registered competitor, returns the latest Wayback snapshot count plus week-over-week deltas. Activity score is normalised 0-100 across the project so the cockpit can render a comparable bar (issue #117 Sprint 2). Backlinks signal dropped in the #179 follow-up — DataForSEO Backlinks API is a paid subscription and the wayback delta captures the same "competitor is shipping" intent at zero cost.',
 		tags: ['decision-cockpit'],
 		security: [{ [ApiTokenAuthHeader]: [] }],
 		request: {

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -692,19 +692,17 @@ const en = {
 		},
 		competitorActivityPage: {
 			title: 'Competitor Activity Radar',
-			subtitle: 'Wayback snapshot frequency + backlinks delta per registered competitor.',
+			subtitle: 'Wayback snapshot frequency per registered competitor — proxy for "they are shipping".',
 			tableTitle: 'Competitor activity',
 			tableHint:
-				'Activity score is a 0-100 normalised composite of Wayback snapshot delta and backlinks delta — higher means the competitor is shipping more.',
+				'Activity score is a 0-100 normalised view of the week-over-week Wayback snapshot delta — higher means the competitor is shipping more pages.',
 			competitor: 'Competitor',
 			wayback: 'Wayback snapshots (Δ)',
-			backlinks: 'Backlinks (Δ)',
-			referringDomains: 'Ref. domains (Δ)',
 			activityScore: 'Activity score',
 			noData: 'No data yet',
 			empty: 'No competitor activity captured yet',
 			emptyDescription:
-				'Schedule a Wayback CDX or DataForSEO Backlinks fetch per competitor from the Schedules page to populate this view.',
+				'Schedule a Wayback CDX fetch per competitor from the Schedules page to populate this view.',
 			kpi: {
 				tracked: 'Competitors tracked',
 				trackedHint: 'Registered in this project',
@@ -1667,19 +1665,17 @@ const es = {
 		},
 		competitorActivityPage: {
 			title: 'Competitor Activity Radar',
-			subtitle: 'Frecuencia de snapshots de Wayback + delta de backlinks por competidor registrado.',
+			subtitle: 'Frecuencia de snapshots de Wayback por competidor registrado — proxy de "está publicando".',
 			tableTitle: 'Actividad de competidores',
 			tableHint:
-				'Activity score es un compuesto normalizado 0-100 entre delta de snapshots Wayback y delta de backlinks — más alto = el competidor está moviéndose más.',
+				'Activity score es una vista normalizada 0-100 del delta semanal de snapshots Wayback — más alto = el competidor está publicando más páginas.',
 			competitor: 'Competidor',
 			wayback: 'Snapshots Wayback (Δ)',
-			backlinks: 'Backlinks (Δ)',
-			referringDomains: 'Dominios ref. (Δ)',
 			activityScore: 'Activity score',
 			noData: 'Sin datos aún',
 			empty: 'Aún no se ha capturado actividad de competidores',
 			emptyDescription:
-				'Programa un fetch de Wayback CDX o DataForSEO Backlinks por competidor desde Schedules para poblar esta vista.',
+				'Programa un fetch de Wayback CDX por competidor desde Schedules para poblar esta vista.',
 			kpi: {
 				tracked: 'Competidores trackeados',
 				trackedHint: 'Registrados en este proyecto',

--- a/apps/web/src/pages/competitor-activity.page.tsx
+++ b/apps/web/src/pages/competitor-activity.page.tsx
@@ -86,38 +86,6 @@ export const CompetitorActivityPage = () => {
 			hideOnMobile: true,
 		},
 		{
-			key: 'backlinks',
-			header: t('cockpit:competitorActivityPage.backlinks'),
-			cell: (row) =>
-				row.backlinks ? (
-					<div className="text-sm">
-						<span className="font-mono">{formatNumber(row.backlinks.totalBacklinks)}</span>
-						<span className="ml-2 text-xs text-muted-foreground">
-							{formatDelta(row.backlinks.deltaBacklinks)}
-						</span>
-					</div>
-				) : (
-					<span className="text-xs text-muted-foreground">{t('cockpit:competitorActivityPage.noData')}</span>
-				),
-			hideOnMobile: true,
-		},
-		{
-			key: 'referringDomains',
-			header: t('cockpit:competitorActivityPage.referringDomains'),
-			cell: (row) =>
-				row.backlinks ? (
-					<div className="text-sm">
-						<span className="font-mono">{formatNumber(row.backlinks.referringDomains)}</span>
-						<span className="ml-2 text-xs text-muted-foreground">
-							{formatDelta(row.backlinks.deltaReferringDomains)}
-						</span>
-					</div>
-				) : (
-					<span className="text-xs text-muted-foreground">—</span>
-				),
-			hideOnMobile: true,
-		},
-		{
 			key: 'activityScore',
 			header: t('cockpit:competitorActivityPage.activityScore'),
 			cell: (row) => (

--- a/packages/application/src/project-management/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/project-management/event-handlers/auto-schedule.config.spec.ts
@@ -11,7 +11,6 @@ import { projectManagementAutoScheduleConfigs } from './auto-schedule.config.js'
 // (the bug in PR #185 review P0-1: `target` vs `domain`) fails loudly.
 const WAYBACK_REQUIRED_FIELDS = ['domain', 'from', 'to'] as const;
 const WAYBACK_DATE_PATTERN = /^\d{8}(?:\d{2})?$|^\{\{today(?:-\d+)?\}\}$/;
-const BACKLINKS_REQUIRED_FIELDS = ['target'] as const;
 
 const PROJECT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' as Uuid as ProjectManagement.ProjectId;
 const COMPETITOR_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as ProjectManagement.CompetitorId;
@@ -28,7 +27,7 @@ describe('project-management auto-schedule', () => {
 	});
 });
 
-describe('CompetitorAdded → wayback + backlinks schedules (#181, #184)', () => {
+describe('CompetitorAdded → wayback-only schedule (#179 — dropped DataForSEO Backlinks)', () => {
 	const event = new ProjectManagement.CompetitorAdded({
 		competitorId: COMPETITOR_ID,
 		projectId: PROJECT_ID,
@@ -37,43 +36,36 @@ describe('CompetitorAdded → wayback + backlinks schedules (#181, #184)', () =>
 		occurredAt: new Date('2026-05-09T12:00:00Z'),
 	});
 
-	it('emits exactly 1 wayback + 1 backlinks schedule per competitor (no locale fan-out)', async () => {
+	it('emits exactly 1 wayback schedule per competitor (no backlinks, no locale fan-out)', async () => {
 		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
-		expect(specs).toHaveLength(2);
+		expect(specs).toHaveLength(1);
 
 		const wayback = specs?.find((s) => s.endpointId === 'wayback-cdx-snapshots');
-		const backlinks = specs?.find((s) => s.endpointId === 'dataforseo-backlinks-summary');
 		expect(wayback).toBeDefined();
-		expect(backlinks).toBeDefined();
 		expect(wayback?.providerId).toBe('wayback');
-		expect(backlinks?.providerId).toBe('dataforseo');
 	});
 
-	it('stamps systemParams.competitorId so the ingest handlers find it', async () => {
+	it('does NOT emit a dataforseo-backlinks-summary schedule (#179 — Backlinks API is paid and dropped)', async () => {
 		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
+		expect(specs?.find((s) => s.endpointId === 'dataforseo-backlinks-summary')).toBeUndefined();
+		expect(specs?.find((s) => s.providerId === 'dataforseo')).toBeUndefined();
+	});
 
+	it('stamps systemParams.competitorId so the wayback ingest handler finds it', async () => {
+		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
 		const wayback = specs?.find((s) => s.endpointId === 'wayback-cdx-snapshots');
-		const backlinks = specs?.find((s) => s.endpointId === 'dataforseo-backlinks-summary');
 
 		expect(wayback?.systemParamKey).toBe('competitorId');
 		expect(wayback?.systemParamsBuilder(event)).toEqual({ competitorId: COMPETITOR_ID });
-		expect(backlinks?.systemParamKey).toBe('competitorId');
-		expect(backlinks?.systemParamsBuilder(event)).toEqual({ competitorId: COMPETITOR_ID });
 	});
 
-	it('stamps params with the competitor domain in the field name each provider expects', async () => {
+	it('stamps params with the competitor domain in the wayback-expected field', async () => {
 		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
-
 		const wayback = specs?.find((s) => s.endpointId === 'wayback-cdx-snapshots');
-		const backlinks = specs?.find((s) => s.endpointId === 'dataforseo-backlinks-summary');
 
 		// Wayback CDX uses `domain` (NOT `target` — that's DataForSEO).
 		expect(wayback?.paramsBuilder(event)).toMatchObject({
 			domain: 'silvertraconline.com',
-		});
-		// DataForSEO backlinks-summary uses `target`.
-		expect(backlinks?.paramsBuilder(event)).toMatchObject({
-			target: 'silvertraconline.com',
 		});
 	});
 
@@ -97,18 +89,6 @@ describe('CompetitorAdded → wayback + backlinks schedules (#181, #184)', () =>
 		expect(params.to).toMatch(WAYBACK_DATE_PATTERN);
 	});
 
-	it('backlinks paramsBuilder uses {target} (NOT {domain})', async () => {
-		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
-		const backlinks = specs?.find((s) => s.endpointId === 'dataforseo-backlinks-summary');
-		const params = backlinks?.paramsBuilder(event) as Record<string, unknown>;
-
-		for (const field of BACKLINKS_REQUIRED_FIELDS) {
-			expect(params).toHaveProperty(field);
-		}
-		expect(params.target).toBe('silvertraconline.com');
-		expect(params).not.toHaveProperty('domain');
-	});
-
 	it('uses competitorId as the idempotency key so re-firing the event is a no-op', async () => {
 		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
 		for (const spec of specs ?? []) {
@@ -117,15 +97,6 @@ describe('CompetitorAdded → wayback + backlinks schedules (#181, #184)', () =>
 			expect(typeof sysParams.competitorId).toBe('string');
 			expect(sysParams.competitorId).toBe(COMPETITOR_ID);
 		}
-	});
-
-	it('spreads crons across Monday morning to avoid same-second rate-limit collisions', async () => {
-		const specs = await competitorAddedConfig?.dynamicSchedules?.(event, {} as never);
-		const crons = (specs ?? []).map((s) => s.cron);
-		// Both Monday early morning, but different hours
-		expect(crons).toContain('0 5 * * 1');
-		expect(crons).toContain('0 6 * * 1');
-		expect(new Set(crons).size).toBe(crons.length);
 	});
 
 	it('returns empty array for unrelated events', async () => {

--- a/packages/application/src/project-management/event-handlers/auto-schedule.config.ts
+++ b/packages/application/src/project-management/event-handlers/auto-schedule.config.ts
@@ -3,17 +3,19 @@ import type { AutoScheduleConfig, AutoScheduleSpec } from '../../_core/auto-sche
 import type { SharedDeps } from '../../_core/module.js';
 
 /**
- * Default scheduling parameters for the competitor-activity feeders. Crons
- * spread across Monday morning so the per-provider rate limit doesn't
- * reject runs that all fire at the same second.
- *
- * Each spec uses `competitorId` as the idempotency key — one schedule per
+ * Default scheduling parameters for the competitor-activity feeder. The
+ * spec uses `competitorId` as the idempotency key — one schedule per
  * competitor regardless of how many times the event fires (re-adding the
  * same competitor is a no-op at the JobDefinition layer).
  *
- * Date tokens `{{today-N}}` / `{{today}}` are accepted by the providers'
- * Zod schemas (literal regex) and resolved at dispatch time by
+ * Date tokens `{{today-N}}` / `{{today}}` are accepted by the provider's
+ * Zod schema (literal regex) and resolved at dispatch time by
  * `resolveDateTokens` in the worker (BACKLOG #22).
+ *
+ * #179 follow-up: the second feeder (`dataforseo-backlinks-summary`) was
+ * dropped because DataForSEO's Backlinks API requires a paid subscription
+ * (~$100/mo) on top of the pay-as-you-go balance and the activity radar
+ * already captures "competitor is shipping" via wayback snapshots alone.
  */
 const WAYBACK_DEFAULTS = {
 	providerId: 'wayback',
@@ -27,28 +29,18 @@ const WAYBACK_DEFAULTS = {
 	to: '{{today}}',
 };
 
-const BACKLINKS_DEFAULTS = {
-	providerId: 'dataforseo',
-	endpointId: 'dataforseo-backlinks-summary',
-	cron: '0 6 * * 1', // Mondays 06:00 UTC (1h offset from wayback)
-};
-
 /**
- * Build the spec list for the `CompetitorAdded` event. Two feeders are
- * scheduled per competitor — both domain-level (NO per-locale fan-out):
+ * Build the spec list for the `CompetitorAdded` event. One feeder is
+ * scheduled per competitor (domain-level, NO per-locale fan-out):
  *
  *  • `wayback-cdx-snapshots` (free, ~30 req/s rate limit)
- *  • `dataforseo-backlinks-summary` (~$0.02 per call, weekly cadence)
  *
- * Both ingest into `competitor_activity_observations` keyed by
- * `(competitor_id, source)`, so the cockpit panel can show "snapshots +
- * backlinks" rollups without further joining.
- *
- * Idempotency key is `competitorId` for both — re-firing the event
- * (e.g. via competitor-suggestion promotion) MUST NOT create a duplicate
- * schedule. `ScheduleEndpointFetchUseCase` looks up
- * `params[systemParamKey]` via a string `equals` match, so we stamp it
- * into both `params` and `systemParams` for the lookup.
+ * Ingests into `competitor_activity_observations` keyed by
+ * `(competitor_id, source)`. Idempotency key is `competitorId` —
+ * re-firing the event (e.g. via competitor-suggestion promotion) MUST
+ * NOT create a duplicate schedule. `ScheduleEndpointFetchUseCase` looks
+ * up `params[systemParamKey]` via a string `equals` match, so we stamp
+ * it into both `params` and `systemParams` for the lookup.
  */
 const buildCompetitorAddedSpecs = async (
 	event: SharedKernel.DomainEvent,
@@ -74,20 +66,6 @@ const buildCompetitorAddedSpecs = async (
 				domain: competitorDomain,
 				from: WAYBACK_DEFAULTS.from,
 				to: WAYBACK_DEFAULTS.to,
-			}),
-			systemParamsBuilder: () => ({
-				competitorId,
-			}),
-		},
-		{
-			providerId: BACKLINKS_DEFAULTS.providerId,
-			endpointId: BACKLINKS_DEFAULTS.endpointId,
-			cron: BACKLINKS_DEFAULTS.cron,
-			systemParamKey: 'competitorId',
-			// DataForSEO backlinks-summary uses `target`. Confirmed against
-			// the endpoint's Zod schema (BacklinksSummaryParams).
-			paramsBuilder: () => ({
-				target: competitorDomain,
 			}),
 			systemParamsBuilder: () => ({
 				competitorId,

--- a/packages/application/src/project-management/use-cases/query-competitor-activity.use-case.spec.ts
+++ b/packages/application/src/project-management/use-cases/query-competitor-activity.use-case.spec.ts
@@ -80,7 +80,26 @@ describe('QueryCompetitorActivityUseCase', () => {
 		const result = await useCase.execute({ projectId: PROJECT_ID });
 		expect(result.rows).toHaveLength(2);
 		expect(result.rows.every((r) => r.activityScore === 0)).toBe(true);
-		expect(result.rows.every((r) => r.wayback === null && r.backlinks === null)).toBe(true);
+		expect(result.rows.every((r) => r.wayback === null)).toBe(true);
+	});
+
+	it('does not expose a backlinks field on the response (#179 — dropped DataForSEO Backlinks dependency)', async () => {
+		activity.rollups = [
+			{
+				competitorId: COMP_A,
+				latestObservedAt: NOW,
+				latestWayback: { snapshotCount: 50, latestSnapshotAt: NOW, observedAt: NOW },
+				priorWayback: { snapshotCount: 30, observedAt: PRIOR },
+				// Even if the repo still surfaces backlinks rollups (legacy rows in BD),
+				// the query layer must NOT propagate them — the field is gone from the contract.
+				latestBacklinks: { totalBacklinks: 999, referringDomains: 99, observedAt: NOW },
+				priorBacklinks: { totalBacklinks: 500, referringDomains: 50, observedAt: PRIOR },
+			},
+		];
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+		const compA = result.rows.find((r) => r.competitorId === COMP_A);
+		expect(compA).toBeDefined();
+		expect(compA).not.toHaveProperty('backlinks');
 	});
 
 	it('computes wayback delta and exposes the latest snapshot', async () => {
@@ -121,30 +140,34 @@ describe('QueryCompetitorActivityUseCase', () => {
 		expect(compA?.wayback?.deltaSnapshots).toBe(-40);
 	});
 
-	it('normalises across competitors so the most-active hits 100', async () => {
+	it('wayback delta alone drives the activity score across the full 0-100 range', async () => {
 		activity.rollups = [
 			{
 				competitorId: COMP_A,
 				latestObservedAt: NOW,
 				latestWayback: { snapshotCount: 100, latestSnapshotAt: NOW, observedAt: NOW },
-				priorWayback: { snapshotCount: 50, observedAt: PRIOR },
-				latestBacklinks: { totalBacklinks: 1000, referringDomains: 100, observedAt: NOW },
-				priorBacklinks: { totalBacklinks: 500, referringDomains: 80, observedAt: PRIOR },
+				priorWayback: { snapshotCount: 50, observedAt: PRIOR }, // +50
+				latestBacklinks: null,
+				priorBacklinks: null,
 			},
 			{
 				competitorId: COMP_B,
 				latestObservedAt: NOW,
 				latestWayback: { snapshotCount: 30, latestSnapshotAt: NOW, observedAt: NOW },
-				priorWayback: { snapshotCount: 20, observedAt: PRIOR },
+				priorWayback: { snapshotCount: 20, observedAt: PRIOR }, // +10
 				latestBacklinks: null,
 				priorBacklinks: null,
 			},
 		];
 		const result = await useCase.execute({ projectId: PROJECT_ID });
+		// COMP_A leads the wayback delta → normalised to 1.0 → score 100.
+		// COMP_B has 10/50 = 0.2 of the top → score 20.
+		// Pre-fix the formula was `(wayback + backlinks) * 50` so wayback alone
+		// could never exceed 50 — the bar would have looked broken on the cockpit.
 		expect(result.maxScore).toBe(100);
 		expect(result.rows[0]?.competitorId).toBe(COMP_A);
 		expect(result.rows[0]?.activityScore).toBe(100);
 		expect(result.rows[1]?.competitorId).toBe(COMP_B);
-		expect(result.rows[1]?.activityScore).toBeLessThan(100);
+		expect(result.rows[1]?.activityScore).toBe(20);
 	});
 });

--- a/packages/application/src/project-management/use-cases/query-competitor-activity.use-case.ts
+++ b/packages/application/src/project-management/use-cases/query-competitor-activity.use-case.ts
@@ -17,13 +17,6 @@ export interface CompetitorActivityRowDto {
 		observedAt: string;
 		deltaSnapshots: number | null;
 	} | null;
-	backlinks: {
-		totalBacklinks: number;
-		referringDomains: number;
-		observedAt: string;
-		deltaBacklinks: number | null;
-		deltaReferringDomains: number | null;
-	} | null;
 	activityScore: number;
 }
 
@@ -36,16 +29,23 @@ const DEFAULT_WINDOW_DAYS = 60;
 
 /**
  * Aggregates the latest competitor-activity observations into one row per
- * competitor. The activity score combines two normalised signals:
+ * competitor. The activity score is derived from a single normalised
+ * signal:
  *
  *   - Wayback snapshot delta (latest count − prior count) — proxy for
  *     "they are shipping site changes".
- *   - Backlinks delta (latest total − prior total) — proxy for
- *     "they are running outreach / content gaining links".
  *
- * Both are zero-clamped (we don't reward decreases) and normalised by the
- * project-wide maximum so the cockpit can render a 0-100 bar without
- * needing to know absolute numbers.
+ * Backlinks delta was dropped in the #179 follow-up: DataForSEO Backlinks
+ * API requires a paid subscription on top of the pay-as-you-go balance
+ * (~$100/mo) and the radar's job is to detect *activity*, not absolute
+ * link counts. The wayback signal captures the same "competitor is
+ * shipping" intent without recurring cost. If/when a cheaper backlinks
+ * source ships (SE Ranking, Common Crawl), re-introduce a second signal
+ * and blend the weights here.
+ *
+ * The signal is zero-clamped (we don't reward decreases) and normalised
+ * by the project-wide maximum so the cockpit can render a 0-100 bar
+ * without needing to know absolute numbers.
  */
 export class QueryCompetitorActivityUseCase {
 	constructor(
@@ -73,22 +73,10 @@ export class QueryCompetitorActivityUseCase {
 			const rollup = rollupByCompetitor.get(competitor.id);
 			const latestWayback = rollup?.latestWayback ?? null;
 			const priorWayback = rollup?.priorWayback ?? null;
-			const latestBacklinks = rollup?.latestBacklinks ?? null;
-			const priorBacklinks = rollup?.priorBacklinks ?? null;
 
 			const deltaSnapshots =
 				latestWayback && priorWayback ? latestWayback.snapshotCount - priorWayback.snapshotCount : null;
-			const deltaBacklinks =
-				latestBacklinks && priorBacklinks
-					? latestBacklinks.totalBacklinks - priorBacklinks.totalBacklinks
-					: null;
-			const deltaReferringDomains =
-				latestBacklinks && priorBacklinks
-					? latestBacklinks.referringDomains - priorBacklinks.referringDomains
-					: null;
-
 			const waybackSignal = Math.max(deltaSnapshots ?? 0, 0);
-			const backlinksSignal = Math.max(deltaBacklinks ?? 0, 0);
 
 			return {
 				competitorId: competitor.id,
@@ -96,27 +84,18 @@ export class QueryCompetitorActivityUseCase {
 				label: competitor.label,
 				latestObservedAt: rollup?.latestObservedAt ?? null,
 				latestWayback,
-				priorWayback,
-				latestBacklinks,
-				priorBacklinks,
 				deltaSnapshots,
-				deltaBacklinks,
-				deltaReferringDomains,
 				waybackSignal,
-				backlinksSignal,
 			};
 		});
 
-		// Normalise per signal so a competitor with 200k backlinks doesn't
-		// dwarf one with 12 new wayback snapshots — we want the activity bar
-		// to highlight the most-active rival across either dimension.
+		// Normalise the wayback signal across competitors so the most-active
+		// rival anchors the 100 mark and the rest read as a relative %.
 		const maxWayback = Math.max(0, ...rawRows.map((r) => r.waybackSignal));
-		const maxBacklinks = Math.max(0, ...rawRows.map((r) => r.backlinksSignal));
 
 		const rows: CompetitorActivityRowDto[] = rawRows.map((r) => {
 			const waybackNormalised = maxWayback === 0 ? 0 : r.waybackSignal / maxWayback;
-			const backlinksNormalised = maxBacklinks === 0 ? 0 : r.backlinksSignal / maxBacklinks;
-			const activityScore = Math.round((waybackNormalised + backlinksNormalised) * 50);
+			const activityScore = Math.round(waybackNormalised * 100);
 
 			return {
 				competitorId: r.competitorId,
@@ -131,15 +110,6 @@ export class QueryCompetitorActivityUseCase {
 								: null,
 							observedAt: r.latestWayback.observedAt.toISOString(),
 							deltaSnapshots: r.deltaSnapshots,
-						}
-					: null,
-				backlinks: r.latestBacklinks
-					? {
-							totalBacklinks: r.latestBacklinks.totalBacklinks,
-							referringDomains: r.latestBacklinks.referringDomains,
-							observedAt: r.latestBacklinks.observedAt.toISOString(),
-							deltaBacklinks: r.deltaBacklinks,
-							deltaReferringDomains: r.deltaReferringDomains,
 						}
 					: null,
 				activityScore,

--- a/packages/contracts/src/project-management/index.ts
+++ b/packages/contracts/src/project-management/index.ts
@@ -125,21 +125,17 @@ const CompetitorActivityWaybackDto = z.object({
 	deltaSnapshots: z.number().int().nullable(),
 });
 
-const CompetitorActivityBacklinksDto = z.object({
-	totalBacklinks: z.number().int().nonnegative(),
-	referringDomains: z.number().int().nonnegative(),
-	observedAt: z.string().datetime(),
-	deltaBacklinks: z.number().int().nullable(),
-	deltaReferringDomains: z.number().int().nullable(),
-});
-
+// Backlinks DTO removed in #179 follow-up — DataForSEO Backlinks API is a
+// paid-only subscription ($100/mo) and the activity radar now uses only the
+// free Wayback CDX signal. If/when a cheaper backlinks source ships
+// (SE Ranking, Common Crawl), re-add a {provider}Dto with explicit fields
+// rather than reviving the old generic shape.
 export const CompetitorActivityRowDto = z.object({
 	competitorId: z.string().uuid(),
 	domain: z.string(),
 	label: z.string(),
 	latestObservedAt: z.string().datetime().nullable(),
 	wayback: CompetitorActivityWaybackDto.nullable(),
-	backlinks: CompetitorActivityBacklinksDto.nullable(),
 	activityScore: z.number().int().min(0).max(100),
 });
 export type CompetitorActivityRowDto = z.infer<typeof CompetitorActivityRowDto>;


### PR DESCRIPTION
## Summary

DataForSEO Backlinks API requires a paid \$100/mo subscription on top of the pay-as-you-go balance the rest of their API uses. Verified via DataForSEO appendix (`backlinks_subscription_expiry_date: None`) — the account has Labs/SERP/OnPage active but not Backlinks. After #190 made the silent failure visible, the operator decision is to drop the dependency entirely rather than pay.

- Auto-schedule emits **1** schedule per `CompetitorAdded` (wayback) instead of **2** (wayback + backlinks).
- `CompetitorActivityRowDto.backlinks` field removed from the contract; cockpit drops the "Backlinks (Δ)" + "Ref. domains (Δ)" columns.
- Activity score formula simplifies from `(waybackNorm + backlinksNorm) * 50` to `waybackNorm * 100` so the most-active competitor anchors the 100 mark on the cockpit bar (previously capped at 50 if a competitor had no backlinks signal).

Net: **-98 lines**, single signal, zero recurring cost. The 33 prod JobDefs for `dataforseo-backlinks-summary` are already disabled (operator action earlier today) so this PR is purely codepath cleanup.

## Why wayback alone is enough

The radar's purpose is to flag "competitors that are shipping". Total backlinks is a vanity proxy — what matters is the velocity of change. Wayback CDX snapshot delta captures **new pages published** week-over-week, which is a tighter proxy than aggregate backlinks count for "rival just released a campaign / refreshed their site". If a cheaper backlinks source ships later (SE Ranking at \$23/mo, Common Crawl + Athena), a second signal can be blended back in here without touching the contract twice.

## What stays (no dead-code deletion in this PR)

- `competitor_activity_observations` table keeps `backlinks_total` / `backlinks_referring_domains` columns — no migration risk. Legacy rows stay; the repo still surfaces them via `CompetitorActivityRollupRow.latestBacklinks/priorBacklinks` so any future re-introduction only has to wire the query layer back in.
- `RecordCompetitorBacklinksProfileUseCase`, the `dataforseo-backlinks-summary` endpoint descriptor + ACL, and the IngestBinding in the DataForSEO manifest remain registered. Removing them is a follow-up if the decision proves durable past a few weeks.

## Test plan

- [x] RED: 4 tests updated to reflect new behavior fail before the implementation (3 in use-case spec assuming dual-signal score, 1 in auto-schedule spec assuming 2-schedule fan-out).
- [x] GREEN: all 431 application tests pass after the fix.
- [x] New explicit regression guards:
  - `auto-schedule.config.spec`: NO dataforseo provider spec is emitted for `CompetitorAdded`.
  - `query-competitor-activity.use-case.spec`: response shape has NO `backlinks` field even when the repo rollup still surfaces backlinks data (legacy rows in BD).
- [x] `pnpm typecheck` clean across 27 packages.
- [x] `pnpm lint` clean (Biome).
- [x] `pnpm test` clean across full workspace.

## Post-merge verification

- [ ] Cockpit page renders without the dropped columns; activity score bar shows 0-100 distribution across competitors.
- [ ] Adding a new competitor in any project creates **only** the wayback JobDef (no dataforseo backlinks JobDef).
- [ ] Existing wayback JobDefs continue to run on schedule and populate the radar.

Closes #179 (this time for real — the data is no longer 0 because the column is gone).