### PR TITLE
fix(providers): compact date format for Wayback + Wikipedia (#179)

### DIFF
--- a/packages/providers/wayback/src/endpoints/cdx-snapshots.spec.ts
+++ b/packages/providers/wayback/src/endpoints/cdx-snapshots.spec.ts
@@ -1,0 +1,111 @@
+import type { FetchContext, HttpClient } from '@rankpulse/provider-core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type CdxResponse, fetchCdxSnapshots } from './cdx-snapshots.js';
+
+/**
+ * Captures the (path, query) of the last HTTP call so tests can assert on
+ * the EXACT shape sent over the wire. Returns `[]` by default to satisfy
+ * the response contract; tests can override `responseBody` to drive
+ * different ACL paths.
+ */
+class RecordingHttpClient implements HttpClient {
+	lastPath: string | null = null;
+	lastQuery: Record<string, string> | null = null;
+	responseBody: unknown = [];
+
+	async get<T>(path: string, query: Record<string, string>, _ctx: FetchContext): Promise<T> {
+		this.lastPath = path;
+		this.lastQuery = query;
+		return this.responseBody as T;
+	}
+	async post<T>(): Promise<T> {
+		throw new Error('not used in CDX tests');
+	}
+	async put<T>(): Promise<T> {
+		throw new Error('not used in CDX tests');
+	}
+	async delete<T>(): Promise<T> {
+		throw new Error('not used in CDX tests');
+	}
+}
+
+const fakeCtx = (): FetchContext => ({
+	credential: { plaintextSecret: '' },
+	logger: { debug: () => {}, warn: () => {} },
+	now: () => new Date('2026-05-26T00:00:00Z'),
+});
+
+describe('fetchCdxSnapshots — wire-format guarantees', () => {
+	let http: RecordingHttpClient;
+
+	beforeEach(() => {
+		http = new RecordingHttpClient();
+	});
+
+	// Regression for #179 follow-up: the worker's `resolveDateTokens`
+	// substitutes `{{today-N}}` with canonical ISO `YYYY-MM-DD`. Wayback CDX
+	// strictly requires `YYYYMMDD` (no separators) and silently returns `[]`
+	// when given the ISO form — so 33 prod runs persisted snapshot_count=0
+	// and the activity radar showed all zeros despite Wayback having real
+	// data. The fetch layer MUST strip the separators before dispatch.
+	it('converts ISO YYYY-MM-DD `from`/`to` to the YYYYMMDD shape Wayback CDX requires', async () => {
+		await fetchCdxSnapshots(
+			http,
+			{ domain: 'silvertracsoftware.com', from: '2026-02-25', to: '2026-05-26', limit: 2000 },
+			fakeCtx(),
+		);
+		expect(http.lastQuery?.from).toBe('20260225');
+		expect(http.lastQuery?.to).toBe('20260526');
+	});
+
+	it('passes through `from`/`to` already in compact YYYYMMDD form unchanged (idempotent)', async () => {
+		await fetchCdxSnapshots(
+			http,
+			{ domain: 'silvertracsoftware.com', from: '20260225', to: '20260526', limit: 2000 },
+			fakeCtx(),
+		);
+		expect(http.lastQuery?.from).toBe('20260225');
+		expect(http.lastQuery?.to).toBe('20260526');
+	});
+
+	it('keeps the rest of the query stable (url, matchType, output, limit) — only date fields are normalised', async () => {
+		await fetchCdxSnapshots(
+			http,
+			{ domain: 'example.com', from: '2026-01-01', to: '2026-12-31', limit: 500 },
+			fakeCtx(),
+		);
+		expect(http.lastPath).toBe('/cdx/search/cdx');
+		expect(http.lastQuery).toEqual({
+			url: 'example.com',
+			matchType: 'prefix',
+			output: 'json',
+			from: '20260101',
+			to: '20261231',
+			limit: '500',
+		});
+	});
+
+	it('returns the response as-is when shape is valid (ACL is a separate concern)', async () => {
+		const payload: CdxResponse = [
+			['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+			['com,example)/', '20260315120000', 'https://example.com/', 'text/html', '200', 'a', '1'],
+		];
+		http.responseBody = payload;
+		const result = await fetchCdxSnapshots(
+			http,
+			{ domain: 'example.com', from: '2026-02-25', to: '2026-05-26', limit: 2000 },
+			fakeCtx(),
+		);
+		expect(result).toEqual(payload);
+	});
+
+	it('returns [] when the API responds with null/undefined (defensive against transient upstream blips)', async () => {
+		http.responseBody = null;
+		const result = await fetchCdxSnapshots(
+			http,
+			{ domain: 'example.com', from: '2026-02-25', to: '2026-05-26', limit: 2000 },
+			fakeCtx(),
+		);
+		expect(result).toEqual([]);
+	});
+});

--- a/packages/providers/wayback/src/endpoints/cdx-snapshots.ts
+++ b/packages/providers/wayback/src/endpoints/cdx-snapshots.ts
@@ -58,12 +58,22 @@ export type CdxResponse = readonly CdxRow[];
 
 const buildPath = (): string => '/cdx/search/cdx';
 
+/**
+ * Wayback CDX strictly requires `YYYYMMDD` (8 digits, no separators) in
+ * `from`/`to`. The worker's `resolveDateTokens` substitutes the persisted
+ * `{{today-N}}` tokens with canonical ISO `YYYY-MM-DD` (hyphens), so we
+ * normalise here at the wire boundary — Wayback's silent-empty response
+ * for the ISO form caused 33 prod runs to record snapshot_count=0 with
+ * no error (see #179 follow-up). Idempotent for already-compact input.
+ */
+const toCompactCdxDate = (raw: string): string => raw.replace(/-/g, '');
+
 const buildQuery = (params: CdxSnapshotsParams): Record<string, string> => ({
 	url: params.domain,
 	matchType: 'prefix',
 	output: 'json',
-	from: params.from,
-	to: params.to,
+	from: toCompactCdxDate(params.from),
+	to: toCompactCdxDate(params.to),
 	limit: String(params.limit),
 });
 

--- a/packages/providers/wikipedia/src/endpoints/pageviews-per-article.spec.ts
+++ b/packages/providers/wikipedia/src/endpoints/pageviews-per-article.spec.ts
@@ -1,0 +1,144 @@
+import type { FetchContext } from '@rankpulse/provider-core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { WikipediaHttp } from '../http.js';
+import { fetchPageviewsPerArticle, type PageviewsPerArticleResponse } from './pageviews-per-article.js';
+
+/**
+ * Captures the path of the last HTTP call so tests can assert on the
+ * EXACT URL segments sent to Wikimedia. Returns an empty `items` array
+ * by default — tests can override `responseBody`.
+ */
+class RecordingWikipediaHttp implements Pick<WikipediaHttp, 'get'> {
+	lastPath: string | null = null;
+	responseBody: unknown = { items: [] };
+
+	async get(path: string, _signal?: AbortSignal): Promise<unknown> {
+		this.lastPath = path;
+		return this.responseBody;
+	}
+}
+
+const fakeCtx = (): FetchContext => ({
+	credential: { plaintextSecret: 'public' },
+	logger: { debug: () => {}, warn: () => {} },
+	now: () => new Date('2026-05-26T00:00:00Z'),
+});
+
+describe('fetchPageviewsPerArticle — wire-format guarantees', () => {
+	let http: RecordingWikipediaHttp;
+
+	beforeEach(() => {
+		http = new RecordingWikipediaHttp();
+	});
+
+	// Regression for #179 follow-up: the worker's `resolveDateTokens`
+	// substitutes `{{today-N}}` with canonical ISO `YYYY-MM-DD`. Wikimedia's
+	// pageviews REST endpoint embeds the dates as path segments and requires
+	// `YYYYMMDD` — handing it `2026-02-25` returns 404 / empty items
+	// silently, matching the same failure shape as the Wayback bug.
+	it('converts ISO YYYY-MM-DD `start`/`end` to YYYYMMDD in the URL path', async () => {
+		await fetchPageviewsPerArticle(
+			http as unknown as WikipediaHttp,
+			{
+				project: 'en.wikipedia.org',
+				article: 'Eiffel_Tower',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '2026-02-25',
+				end: '2026-05-26',
+			},
+			fakeCtx(),
+		);
+		expect(http.lastPath).toBe(
+			'/metrics/pageviews/per-article/en.wikipedia.org/all-access/user/Eiffel_Tower/daily/20260225/20260526',
+		);
+	});
+
+	it('passes through `start`/`end` already in compact YYYYMMDD form unchanged (idempotent)', async () => {
+		await fetchPageviewsPerArticle(
+			http as unknown as WikipediaHttp,
+			{
+				project: 'en.wikipedia.org',
+				article: 'Eiffel_Tower',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '20260225',
+				end: '20260526',
+			},
+			fakeCtx(),
+		);
+		expect(http.lastPath).toBe(
+			'/metrics/pageviews/per-article/en.wikipedia.org/all-access/user/Eiffel_Tower/daily/20260225/20260526',
+		);
+	});
+
+	it('URL-encodes the article title (only its segment, not the dates)', async () => {
+		await fetchPageviewsPerArticle(
+			http as unknown as WikipediaHttp,
+			{
+				project: 'es.wikipedia.org',
+				article: 'Torre Eiffel',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '2026-02-25',
+				end: '2026-05-26',
+			},
+			fakeCtx(),
+		);
+		// Article is URL-encoded; dates stay numeric.
+		expect(http.lastPath).toContain('/Torre%20Eiffel/');
+		expect(http.lastPath).toContain('/20260225/20260526');
+	});
+
+	it('returns the response as-is when shape is valid (ACL is a separate concern)', async () => {
+		const payload: PageviewsPerArticleResponse = {
+			items: [
+				{
+					project: 'en.wikipedia.org',
+					article: 'Eiffel_Tower',
+					granularity: 'daily',
+					timestamp: '2026022500',
+					access: 'all-access',
+					agent: 'user',
+					views: 1234,
+				},
+			],
+		};
+		http.responseBody = payload;
+		const result = await fetchPageviewsPerArticle(
+			http as unknown as WikipediaHttp,
+			{
+				project: 'en.wikipedia.org',
+				article: 'Eiffel_Tower',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '2026-02-25',
+				end: '2026-05-26',
+			},
+			fakeCtx(),
+		);
+		expect(result).toEqual(payload);
+	});
+
+	it('returns `{ items: [] }` when upstream returns null/undefined (defensive)', async () => {
+		http.responseBody = null;
+		const result = await fetchPageviewsPerArticle(
+			http as unknown as WikipediaHttp,
+			{
+				project: 'en.wikipedia.org',
+				article: 'Eiffel_Tower',
+				access: 'all-access',
+				agent: 'user',
+				granularity: 'daily',
+				start: '2026-02-25',
+				end: '2026-05-26',
+			},
+			fakeCtx(),
+		);
+		expect(result).toEqual({ items: [] });
+	});
+});

--- a/packages/providers/wikipedia/src/endpoints/pageviews-per-article.ts
+++ b/packages/providers/wikipedia/src/endpoints/pageviews-per-article.ts
@@ -61,6 +61,17 @@ export interface PageviewsPerArticleResponse {
 	items?: PageviewItem[];
 }
 
+/**
+ * Wikimedia's pageviews REST embeds dates as URL path segments and
+ * strictly requires `YYYYMMDD` (8 digits, no separators). The worker's
+ * `resolveDateTokens` substitutes the persisted `{{today-N}}` tokens
+ * with canonical ISO `YYYY-MM-DD` (hyphens), so we normalise here at
+ * the wire boundary — same shape of bug as Wayback (#179 follow-up),
+ * where the ISO form silently produces empty `items` instead of
+ * surfacing a 404. Idempotent for already-compact input.
+ */
+const toCompactWikiDate = (raw: string): string => raw.replace(/-/g, '');
+
 const buildPath = (params: PageviewsPerArticleParams): string => {
 	const segments = [
 		'/metrics/pageviews/per-article',
@@ -69,8 +80,8 @@ const buildPath = (params: PageviewsPerArticleParams): string => {
 		params.agent,
 		encodeURIComponent(params.article),
 		params.granularity,
-		params.start,
-		params.end,
+		toCompactWikiDate(params.start),
+		toCompactWikiDate(params.end),
 	];
 	return segments.join('/');
 };


### PR DESCRIPTION
## Summary

Both Wayback CDX and Wikipedia pageviews APIs strictly require `YYYYMMDD` (8 digits, no separators) in their date params, but the worker's `resolveDateTokens` substitutes the persisted `{{today-N}}` tokens with canonical ISO `YYYY-MM-DD` (hyphens). Neither endpoint normalised at the wire boundary, so prod runs landed `succeeded` with empty payloads and the cockpit showed all zeros — same failure shape as #190, different layer.

## Evidence (verified via direct curl)

\`\`\`
Wayback CDX /cdx/search/cdx?...&from=2026-02-25 → []          (silent empty)
Wayback CDX /cdx/search/cdx?...&from=20260225   → 5+ snapshots  (real data)

Wikipedia /metrics/pageviews/.../2026-02-25/2026-05-26 → 404 / {items:[]}
Wikipedia /metrics/pageviews/.../20260225/20260526    → real items
\`\`\`

Both endpoints already accepted `YYYYMMDD` in their Zod schemas — the gap was between schema (token form) and wire (compact form). Fix in the provider's wire-builder (Wayback `buildQuery`, Wikipedia `buildPath`) strips hyphens before dispatch. Idempotent for already-compact input.

## Audit findings (parallel review of all 13 other provider packages)

| Provider | Endpoint | Date params | API format | Normalises | Risk |
|---|---|---|---|---|---|
| **wayback** | cdx-snapshots | from, to | `YYYYMMDD` | ❌ → ✅ **(this PR)** | was HIGH |
| **wikipedia** | pageviews-per-article | start, end | `YYYYMMDD` | ❌ → ✅ **(this PR)** | was HIGH |
| dataforseo | historical-serps | dateFrom, dateTo | `YYYY-MM-DD` | ✅ matches | LOW |
| ga4 | run-report | startDate, endDate | `YYYY-MM-DD` | ✅ matches | LOW |
| gsc | search-analytics | startDate, endDate | `YYYY-MM-DD` | ✅ matches | LOW (fragile) |
| brevo | email-statistics | startDate, endDate | `YYYY-MM-DD` | ✅ matches | LOW (fragile) |
| brevo | conversation-stats | dateFrom, dateTo | epoch ms | ✅ explicit `toUnixMs` | LOW |
| meta | ads-insights | startDate, endDate | `YYYY-MM-DD` in JSON | ✅ matches | LOW |
| meta | pixel-events-stats | startDate, endDate | epoch seconds | ✅ explicit `toUnixSeconds` | LOW |
| bing/clarity/pagespeed/anthropic/openai/perplexity/google-ai-studio | (various) | (none) | n/a | n/a | LOW |
| dataforseo (12 other endpoints) | (various) | (none) | n/a | n/a | LOW |

**No other HIGH-RISK cases.** Brevo `conversation-stats` and Meta `pixel-events-stats` already serve as the reference pattern for defensive transformations.

GSC, Brevo email-statistics, Meta ads-insights are MEDIUM-fragile (format coincidentally matches, no defensive validation) — out of scope for this PR; tracked as follow-ups if a future bug surfaces.

## Test plan

- [x] RED: 4 wire-format tests fail before the fix (2 in each provider) — assert hyphenated input produces compact output.
- [x] GREEN: all 9 wayback + 17 wikipedia tests pass after the fix.
- [x] New spec files for both endpoints (previously untested at the wire level).
- [x] Tests pin BOTH the ISO→compact transformation AND backward compatibility for already-compact callers via a full-query snapshot.
- [x] `pnpm typecheck` clean (27 packages).
- [x] `pnpm lint` clean (Biome).
- [x] `pnpm test` clean (27 packages).

## Post-merge verification

- [ ] Trigger \`run-now\` on a wayback JobDef in prod; verify the raw_payload now contains snapshot rows (not `[]`) and `wayback_snapshot_count > 0` lands in `competitor_activity_observations`.
- [ ] Same for a wikipedia pageviews JobDef if any are currently scheduled in prod.
- [ ] Cockpit activity score will still show 0 until a SECOND observation exists per competitor (delta needs two data points) — that's a cadence concern, not a code bug. Manual: trigger 2 \`run-now\` calls per competitor with a 24h+ gap, or wait for next Monday cron.

## Out of scope

Backfilling existing zero-count observations: the 8 wayback rows in the patroltech cluster (and equivalent in other projects) were written with `snapshot_count=0` against the wrong date format. They stay in place — the next cron tick (or a manual `run-now`) overwrites with real data once this PR lands.

Closes the actual data-loss part of #179.