### PR TITLE
fix(provider-connectivity): unique BullMQ Job Scheduler per definition (#194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,4 +689,45 @@ mover el bloque rompe el orden.
 del bloque "compose modules" si añades un consumer nuevo arriba. No
 asumas orden histórico.
 
-_Última actualización: 2026-05-09. Mantén este archivo vivo._
+### 13.7 Scheduler collapse: N JobDefinitions con (provider, cron) idéntico ejecutan solo 1
+
+**Síntoma**: varias `ProviderJobDefinition` del mismo provider con el
+mismo cron quedan congeladas mientras una sola sigue corriendo. Caso
+real (#194): la propiedad GSC `sc-domain:patroltech.online` enlazada a
+4 proyectos (ES/EN/FR/MX) — solo ES recibía datos frescos; EN/FR/MX se
+congelaron a principios de mayo. En producción: **15 defs GSC con cron
+`0 5 * * *` → 1 sola repeatable en Redis** (`ZCARD
+bull:provider-google-search-console:repeat = 1`). El mismo colapso
+afectaba a TODOS los providers (dataforseo ~390 defs → 20 repeatables,
+anthropic 52 → 1, openai 51 → 1, …): el nº de repeatables ≈ nº de crons
+distintos, no de defs.
+
+**Causa raíz**: `BullMqJobScheduler.register` encolaba la repeatable con
+`queue.add(name, data, { repeat: { pattern } })` **sin `jobId`**. BullMQ
+identifica una repeatable por `(queue, name, schedulerId | cron)`; al
+omitir el id, todas las defs que comparten `providerId` (misma cola) +
+mismo `name` (`provider-fetch`) + mismo `cron` colapsan a **una** entrada.
+El `definitionId` viajaba solo en `data`, que NO entra en la clave. El
+aislamiento de datos aguas abajo (requestHash, ingest, PK del read-model)
+era correcto — el bug era puramente que las defs nunca se encolaban.
+
+**Fix permanente** (#194): migrar a **Job Schedulers** de BullMQ —
+`queue.upsertJobScheduler(definition.id, { pattern }, { name, data, opts })`
+y `queue.removeJobScheduler(definition.id)`. Cada def tiene su propio
+scheduler keyeado por `definition.id`. Test de regresión: 2 defs con
+mismo provider+cron y distinto id → 2 schedulers (no colapso).
+
+**Recuperación de estado** (irrenunciable tras el deploy): el estado ya
+colapsado en Redis NO se auto-cura — **no hay reconciliación en boot**.
+Ejecutar `pnpm --filter @rankpulse/api reconcile:schedules` (re-registra
+todas las defs habilitadas + limpia las repeatables legacy). Idempotente
+y seguro en cada deploy.
+
+**Para el agente**: si añades scheduling, NUNCA encoles repeatables sin
+una identidad única por definición. Si N entidades comparten provider y
+cron, deben producir N schedulers. Verifica en Redis con `ZCARD
+bull:provider-<id>:repeat` que el nº de repeatables = nº de defs
+habilitadas de ese provider, no el nº de crons. Sigue pendiente (gap
+conocido): reconciliación automática en boot ante pérdida de estado Redis.
+
+_Última actualización: 2026-05-30. Mantén este archivo vivo._

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
 		"dev": "node --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=../../.env.local --import @swc-node/register/esm-register --watch src/main.ts",
 		"start:prod": "node --env-file-if-exists=../../.env --env-file-if-exists=../../.env.local dist/main.js",
 		"repair:job-definitions": "node --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=../../.env.local --import @swc-node/register/esm-register scripts/repair-job-definitions.ts",
+		"reconcile:schedules": "node --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=../../.env.local --import @swc-node/register/esm-register scripts/reconcile-schedules.ts",
 		"build": "tsc -p tsconfig.build.json",
 		"typecheck": "tsc --noEmit",
 		"test:unit": "vitest run --passWithNoTests",

--- a/apps/api/scripts/reconcile-schedules.ts
+++ b/apps/api/scripts/reconcile-schedules.ts
@@ -1,0 +1,141 @@
+/**
+ * Reconcile BullMQ Job Schedulers with the ENABLED JobDefinitions in the DB.
+ *
+ * Background (#194): until the Job Scheduler migration, `BullMqJobScheduler`
+ * registered repeatables WITHOUT a per-definition id, so every definition that
+ * shared a provider + cron collapsed onto ONE BullMQ repeatable. Verified in
+ * production: 15 GSC defs on "0 5 * * *" => a single repeatable, so only one
+ * definition ran per day and the rest (EN/FR/MX patroltech.online + every
+ * satellite domain) silently froze. The same collapse hit every provider
+ * (dataforseo, anthropic, openai, ...).
+ *
+ * The code fix keys each scheduler by `definition.id`, but the already-collapsed
+ * Redis state does not self-heal — there is no boot-time reconciliation. This
+ * script rebuilds the schedulers from the DB (the source of truth):
+ *
+ *   1. Re-register every ENABLED definition (idempotent upsert, one scheduler
+ *      per `definition.id`). This never removes a valid schedule, so there is no
+ *      window where an enabled definition is left unscheduled.
+ *   2. Drop any remaining scheduler whose key is NOT a current enabled
+ *      definition id — i.e. the legacy collapsed/auto-keyed repeatables and any
+ *      stale (disabled/deleted) leftovers.
+ *
+ * Idempotent and safe to run on every deploy.
+ *
+ * Usage from repo root:
+ *   pnpm --filter @rankpulse/api reconcile:schedules [--dry-run]
+ *
+ * Requires DATABASE_URL and REDIS_URL in env (loaded via the api package's
+ * standard `--env-file-if-exists` chain — see package.json scripts).
+ */
+import { type ProjectManagement, ProviderConnectivity } from '@rankpulse/domain';
+import { DrizzlePersistence, Queue as QueueAdapters } from '@rankpulse/infrastructure';
+
+interface DefinitionRow {
+	id: string;
+	project_id: string;
+	provider_id: string;
+	endpoint_id: string;
+	params: Record<string, unknown> | null;
+	cron: string;
+	credential_override_id: string | null;
+	enabled: boolean;
+	last_run_at: Date | null;
+	created_at: Date;
+}
+
+function toDefinition(row: DefinitionRow): ProviderConnectivity.ProviderJobDefinition {
+	return ProviderConnectivity.ProviderJobDefinition.rehydrate({
+		id: row.id as ProviderConnectivity.ProviderJobDefinitionId,
+		projectId: row.project_id as ProjectManagement.ProjectId,
+		providerId: ProviderConnectivity.ProviderId.create(row.provider_id),
+		endpointId: ProviderConnectivity.EndpointId.create(row.endpoint_id),
+		params: row.params ?? {},
+		cron: ProviderConnectivity.CronExpression.create(row.cron),
+		credentialOverrideId:
+			(row.credential_override_id as ProviderConnectivity.ProviderCredentialId | null) ?? null,
+		enabled: row.enabled,
+		lastRunAt: row.last_run_at,
+		createdAt: row.created_at,
+	});
+}
+
+async function main(): Promise<void> {
+	const dryRun = process.argv.includes('--dry-run');
+	const connectionString = process.env.DATABASE_URL;
+	const redisUrl = process.env.REDIS_URL;
+	if (!connectionString) {
+		console.error('DATABASE_URL is not set');
+		process.exit(1);
+	}
+	if (!redisUrl) {
+		console.error('REDIS_URL is not set');
+		process.exit(1);
+	}
+
+	const client = DrizzlePersistence.createDrizzleClient({ connectionString });
+	const sql = client.sql;
+	const scheduler = new QueueAdapters.BullMqJobScheduler({ connection: { url: redisUrl } });
+
+	const report = {
+		enabledRegistered: 0,
+		providersScanned: 0,
+		staleSchedulersRemoved: 0,
+	};
+
+	console.log(`[reconcile-schedules] mode=${dryRun ? 'DRY RUN' : 'EXECUTE'}`);
+
+	try {
+		const enabledRows = await sql<DefinitionRow[]>`
+			SELECT id, project_id, provider_id, endpoint_id, params, cron,
+			       credential_override_id, enabled, last_run_at, created_at
+			FROM provider_job_definitions
+			WHERE enabled = true
+		`;
+
+		// Enabled definition ids grouped by provider — used both to register and
+		// to recognise which schedulers are legitimate during cleanup.
+		const enabledIdsByProvider = new Map<string, Set<string>>();
+		for (const row of enabledRows) {
+			const set = enabledIdsByProvider.get(row.provider_id) ?? new Set<string>();
+			set.add(row.id);
+			enabledIdsByProvider.set(row.provider_id, set);
+		}
+
+		// 1) Register every enabled definition (idempotent, never leaves a gap).
+		for (const row of enabledRows) {
+			console.log(`[reconcile] register def=${row.id} provider=${row.provider_id} cron='${row.cron}'`);
+			if (!dryRun) await scheduler.register(toDefinition(row));
+			report.enabledRegistered += 1;
+		}
+
+		// 2) Drop legacy/stale schedulers (key is not a current enabled def id).
+		const providerRows = await sql<{ provider_id: string }[]>`
+			SELECT DISTINCT provider_id FROM provider_job_definitions
+		`;
+		for (const { provider_id: providerId } of providerRows) {
+			report.providersScanned += 1;
+			const queue = scheduler.getQueue(providerId);
+			const valid = enabledIdsByProvider.get(providerId) ?? new Set<string>();
+			const existing = await queue.getJobSchedulers(0, -1);
+			for (const s of existing) {
+				if (valid.has(s.key)) continue;
+				console.log(`[reconcile] remove stale scheduler key=${s.key} provider=${providerId}`);
+				if (!dryRun) await queue.removeJobScheduler(s.key);
+				report.staleSchedulersRemoved += 1;
+			}
+		}
+
+		console.log('\n=== RECONCILE REPORT ===');
+		console.log(JSON.stringify(report, null, 2));
+		if (dryRun) console.log('(DRY RUN — no changes written)');
+	} finally {
+		await scheduler.close();
+		await client.close();
+	}
+}
+
+main().catch((err) => {
+	console.error('reconcile-schedules failed:', err);
+	process.exit(1);
+});

--- a/packages/domain/src/provider-connectivity/ports/job-scheduler.ts
+++ b/packages/domain/src/provider-connectivity/ports/job-scheduler.ts
@@ -1,13 +1,13 @@
 import type { ProviderJobDefinition } from '../entities/provider-job-definition.js';
 
 /**
- * Adapter port over BullMQ's repeatable jobs. Implementations register cron
- * triggers that emit fetch jobs for the worker to consume.
+ * Adapter port over BullMQ's Job Schedulers. Implementations register cron
+ * triggers that emit fetch jobs for the worker to consume — one scheduler per
+ * definition, keyed by `definition.id`, so definitions that share a provider +
+ * cron never collapse onto one schedule (issue #194).
  *
- * Note that {@link unregister} takes the full definition (not just an id):
- * BullMQ's `removeRepeatable` reads the cron pattern + job options from the
- * arguments to identify which repeatable to drop, so the caller must hand
- * back what was originally scheduled.
+ * {@link unregister} takes the full definition (not just an id) to keep the
+ * port symmetric with {@link register}; implementations only need the id.
  */
 export interface JobScheduler {
 	register(definition: ProviderJobDefinition): Promise<void>;

--- a/packages/infrastructure/src/queue/bullmq-job-scheduler.spec.ts
+++ b/packages/infrastructure/src/queue/bullmq-job-scheduler.spec.ts
@@ -1,8 +1,18 @@
 import { ProviderConnectivity } from '@rankpulse/domain';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// The mock models BullMQ's Job Scheduler identity: schedulers are keyed by
+// their `jobSchedulerId`. Two upserts with the same id update one entry;
+// different ids coexist. This is exactly the dedup semantics that issue #194
+// violated — the previous code registered repeatables with NO per-definition
+// id, so every definition sharing a provider + cron collapsed onto a single
+// cron-keyed repeatable (prod: 15 GSC defs on "0 5 * * *" => 1 repeatable).
+const schedulers = new Map<string, { repeat: unknown; template: unknown }>();
 const queueAdd = vi.fn(async () => {});
-const queueRemoveRepeatable = vi.fn(async () => {});
+const upsertJobScheduler = vi.fn(async (id: string, repeat: unknown, template: unknown) => {
+	schedulers.set(id, { repeat, template });
+});
+const removeJobScheduler = vi.fn(async (id: string) => schedulers.delete(id));
 const queueClose = vi.fn(async () => {});
 
 vi.mock('bullmq', () => ({
@@ -12,18 +22,21 @@ vi.mock('bullmq', () => ({
 			this.name = name;
 		}
 		add = queueAdd;
-		removeRepeatable = queueRemoveRepeatable;
+		upsertJobScheduler = upsertJobScheduler;
+		removeJobScheduler = removeJobScheduler;
 		close = queueClose;
 	},
 }));
 
-const { BullMqJobScheduler, providerQueueName } = await import('./bullmq-job-scheduler.js');
+const { BullMqJobScheduler, providerQueueName, PROVIDER_FETCH_JOB } = await import(
+	'./bullmq-job-scheduler.js'
+);
 
 const buildDefinition = (
-	overrides: Partial<{ providerId: string; cron: string; enabled: boolean }> = {},
+	overrides: Partial<{ id: string; providerId: string; cron: string }> = {},
 ): ProviderConnectivity.ProviderJobDefinition =>
 	ProviderConnectivity.ProviderJobDefinition.schedule({
-		id: 'def-1' as ProviderConnectivity.ProviderJobDefinitionId,
+		id: (overrides.id ?? 'def-1') as ProviderConnectivity.ProviderJobDefinitionId,
 		projectId: 'proj-1' as never,
 		providerId: ProviderConnectivity.ProviderId.create(overrides.providerId ?? 'dataforseo'),
 		endpointId: ProviderConnectivity.EndpointId.create('serp-google-organic-live'),
@@ -33,6 +46,15 @@ const buildDefinition = (
 		now: new Date('2026-05-04T00:00:00Z'),
 	});
 
+const connection = { host: 'localhost', port: 6379 };
+
+beforeEach(() => {
+	schedulers.clear();
+	queueAdd.mockClear();
+	upsertJobScheduler.mockClear();
+	removeJobScheduler.mockClear();
+});
+
 describe('BullMqJobScheduler', () => {
 	it('queue name uses "-" as separator (BullMQ rejects ":" in queue names)', () => {
 		expect(providerQueueName('dataforseo')).toBe('provider-dataforseo');
@@ -40,8 +62,7 @@ describe('BullMqJobScheduler', () => {
 	});
 
 	it('enqueueOnce uses jobId of shape "manual-<runId>", never with ":" (BACKLOG #6)', async () => {
-		queueAdd.mockClear();
-		const scheduler = new BullMqJobScheduler({ connection: { host: 'localhost', port: 6379 } });
+		const scheduler = new BullMqJobScheduler({ connection });
 
 		await scheduler.enqueueOnce(buildDefinition(), 'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
 
@@ -51,35 +72,63 @@ describe('BullMqJobScheduler', () => {
 		expect(opts.jobId).not.toContain(':');
 	});
 
-	it('register installs a repeatable job with the cron pattern', async () => {
-		queueAdd.mockClear();
-		const scheduler = new BullMqJobScheduler({ connection: { host: 'localhost', port: 6379 } });
+	it('register upserts a Job Scheduler keyed by the definition id', async () => {
+		const scheduler = new BullMqJobScheduler({ connection });
 
-		await scheduler.register(buildDefinition({ cron: '0 12 * * *' }));
+		await scheduler.register(buildDefinition({ id: 'def-A', cron: '0 12 * * *' }));
 
-		expect(queueAdd).toHaveBeenCalledTimes(1);
-		const opts = (
-			queueAdd.mock.calls[0] as unknown as [string, unknown, { repeat?: { pattern: string } }]
-		)[2];
-		expect(opts.repeat?.pattern).toBe('0 12 * * *');
+		expect(upsertJobScheduler).toHaveBeenCalledTimes(1);
+		const [id, repeat, template] = upsertJobScheduler.mock.calls[0] as unknown as [
+			string,
+			{ pattern: string },
+			{ name: string; data: { definitionId: string } },
+		];
+		expect(id).toBe('def-A');
+		expect(repeat).toEqual({ pattern: '0 12 * * *' });
+		expect(template.name).toBe(PROVIDER_FETCH_JOB);
+		expect(template.data).toEqual({ definitionId: 'def-A' });
 	});
 
-	it('register on a disabled definition unregisters instead of registering', async () => {
-		queueAdd.mockClear();
-		queueRemoveRepeatable.mockClear();
-		const scheduler = new BullMqJobScheduler({ connection: { host: 'localhost', port: 6379 } });
+	it('does NOT collapse two definitions that share provider + cron (regression #194)', async () => {
+		const scheduler = new BullMqJobScheduler({ connection });
+
+		// Same provider, same cron, different definition ids — the exact shape
+		// that froze EN/FR/MX: many GSC defs on "0 5 * * *" collapsed to one
+		// repeatable, so only one ran per day.
+		await scheduler.register(
+			buildDefinition({ id: 'def-A', providerId: 'google-search-console', cron: '0 5 * * *' }),
+		);
+		await scheduler.register(
+			buildDefinition({ id: 'def-B', providerId: 'google-search-console', cron: '0 5 * * *' }),
+		);
+
+		expect(schedulers.size).toBe(2);
+		expect([...schedulers.keys()].sort()).toEqual(['def-A', 'def-B']);
+	});
+
+	it('unregister removes the Job Scheduler by definition id', async () => {
+		const scheduler = new BullMqJobScheduler({ connection });
+
+		await scheduler.register(buildDefinition({ id: 'def-A' }));
+		await scheduler.unregister(buildDefinition({ id: 'def-A' }));
+
+		expect(removeJobScheduler).toHaveBeenCalledWith('def-A');
+		expect(schedulers.size).toBe(0);
+	});
+
+	it('register on a disabled definition unregisters instead of scheduling', async () => {
+		const scheduler = new BullMqJobScheduler({ connection });
 		const def = buildDefinition();
 		def.disable();
 
 		await scheduler.register(def);
 
-		expect(queueAdd).not.toHaveBeenCalled();
-		expect(queueRemoveRepeatable).toHaveBeenCalledTimes(1);
+		expect(upsertJobScheduler).not.toHaveBeenCalled();
+		expect(removeJobScheduler).toHaveBeenCalledTimes(1);
 	});
 
 	it('caches the Queue instance per provider — no new queue on repeated calls', async () => {
-		queueAdd.mockClear();
-		const scheduler = new BullMqJobScheduler({ connection: { host: 'localhost', port: 6379 } });
+		const scheduler = new BullMqJobScheduler({ connection });
 
 		await scheduler.enqueueOnce(buildDefinition(), 'run-1');
 		await scheduler.enqueueOnce(buildDefinition(), 'run-2');

--- a/packages/infrastructure/src/queue/bullmq-job-scheduler.ts
+++ b/packages/infrastructure/src/queue/bullmq-job-scheduler.ts
@@ -35,17 +35,25 @@ export class BullMqJobScheduler implements ProviderConnectivity.JobScheduler {
 			return;
 		}
 		const queue = this.queueFor(definition.providerId.value);
-		const data: ProviderFetchJobData = { definitionId: definition.id };
-		await queue.add(PROVIDER_FETCH_JOB, data, {
-			repeat: this.repeatOptsFor(definition),
-			removeOnComplete: { count: 100 },
-			removeOnFail: { count: 500 },
-		});
+		// One BullMQ Job Scheduler per definition, keyed by `definition.id`.
+		// The id MUST be unique per definition: BullMQ identifies a repeatable
+		// by (queue, name, schedulerId | cron pattern), so omitting it collapses
+		// every definition that shares a provider + cron onto a single
+		// repeatable — only one ran per day and the rest silently froze (#194).
+		await queue.upsertJobScheduler(
+			definition.id,
+			{ pattern: definition.cron.value },
+			{
+				name: PROVIDER_FETCH_JOB,
+				data: { definitionId: definition.id } satisfies ProviderFetchJobData,
+				opts: { removeOnComplete: { count: 100 }, removeOnFail: { count: 500 } },
+			},
+		);
 	}
 
 	async unregister(definition: ProviderConnectivity.ProviderJobDefinition): Promise<void> {
 		const queue = this.queueFor(definition.providerId.value);
-		await queue.removeRepeatable(PROVIDER_FETCH_JOB, this.repeatOptsFor(definition));
+		await queue.removeJobScheduler(definition.id);
 	}
 
 	async enqueueOnce(definition: ProviderConnectivity.ProviderJobDefinition, runId: string): Promise<void> {
@@ -56,13 +64,6 @@ export class BullMqJobScheduler implements ProviderConnectivity.JobScheduler {
 			removeOnComplete: { count: 100 },
 			removeOnFail: { count: 500 },
 		});
-	}
-
-	private repeatOptsFor(definition: ProviderConnectivity.ProviderJobDefinition): { pattern: string } {
-		// BullMQ identifies a repeatable by the hash of (name + opts). Pass only
-		// the cron pattern so register/unregister produce the same hash for the
-		// same definition.
-		return { pattern: definition.cron.value };
 	}
 
 	getQueue(providerId: string): Queue {


### PR DESCRIPTION
## Summary

`ProviderJobDefinition`s that share a **provider + cron** collapsed onto a single BullMQ repeatable, so only one ran per day and the rest silently froze. Surfaced via #194 (GSC `sc-domain:patroltech.online` linked to 4 projects — only ES stayed fresh; EN/FR/MX froze in early May), but the bug is **system-wide**.

### Root cause

`BullMqJobScheduler.register` enqueued repeatables with `queue.add(name, data, { repeat: { pattern } })` and **no `jobId`**. BullMQ identifies a repeatable by `(queue, name, schedulerId | cron)`; the `definitionId` traveled only in `data` (not part of the key), so every definition sharing `providerId` (same queue) + `name` (`provider-fetch`) + `cron` collapsed to one entry.

Data isolation downstream (`requestHash`, ingest, read-model PK — all keyed by the per-link-unique `gscPropertyId`) was correct; the defs simply never got enqueued.

### Production evidence

```
bull:provider-google-search-console:repeat  => ZCARD 1   (15 enabled defs, all "0 5 * * *")
bull:provider-google-search-console:delayed => 1
```

Per provider the repeatable count ≈ number of distinct crons, not defs: dataforseo ~390 defs → 20, anthropic 52 → 1, openai 51 → 1, ga4 3 → 2, …

## Changes

- **Fix**: migrate to BullMQ Job Schedulers keyed by `definition.id` — `upsertJobScheduler` / `removeJobScheduler`.
- **Test**: regression — two defs with same provider + cron, different ids → two schedulers.
- **Recovery**: `pnpm --filter @rankpulse/api reconcile:schedules [--dry-run]` rebuilds schedulers from the DB and clears legacy collapsed repeatables (already-collapsed Redis state does not self-heal — there is no boot-time reconciliation).
- **Docs**: CLAUDE.md §13.7.

## Deploy / recovery

The code fix stops *future* collapse. To recover the currently-frozen state, run `reconcile:schedules` on the host **after deploy** (idempotent).

> Note: the GSC `patroltech.online` properties for EN/FR/MX were unlinked on 2026-05-12, so they also need re-linking to ingest again — separate from this fix.

Closes #194
