### PR TITLE
fix(search-console-insights): aggregate cockpit widgets per GSC property

### DIFF
--- a/apps/web/src/lib/gsc-property.ts
+++ b/apps/web/src/lib/gsc-property.ts
@@ -1,0 +1,28 @@
+/**
+ * Helpers for rendering cockpit rows grouped by their GSC property.
+ *
+ * The cockpit read-model returns one row per (property, query) so a project
+ * with several linked properties shows each property's opportunities instead
+ * of letting the dominant one mask the siblings (#196). The SPA sections the
+ * rows by `siteUrl`; these helpers keep that logic in one place.
+ */
+
+/** `sc-domain:patroltech.online` → `patroltech.online`; strips protocol/trailing slash for URL-prefix properties. */
+export const siteHost = (siteUrl: string): string =>
+	siteUrl
+		.replace(/^sc-domain:/, '')
+		.replace(/^https?:\/\//, '')
+		.replace(/\/$/, '');
+
+/** Groups rows by `siteUrl`, preserving the incoming order within each group and across groups (first-seen). */
+export const groupBySiteUrl = <T extends { siteUrl: string }>(
+	rows: readonly T[],
+): Array<{ siteUrl: string; rows: T[] }> => {
+	const groups = new Map<string, T[]>();
+	for (const row of rows) {
+		const bucket = groups.get(row.siteUrl);
+		if (bucket) bucket.push(row);
+		else groups.set(row.siteUrl, [row]);
+	}
+	return [...groups.entries()].map(([siteUrl, groupRows]) => ({ siteUrl, rows: groupRows }));
+};

--- a/apps/web/src/pages/cockpit.page.tsx
+++ b/apps/web/src/pages/cockpit.page.tsx
@@ -33,6 +33,7 @@ import { type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppShell } from '../components/app-shell.js';
 import { api } from '../lib/api.js';
+import { siteHost } from '../lib/gsc-property.js';
 
 /**
  * Issue #117 — Decision Cockpit landing.
@@ -290,12 +291,13 @@ export const CockpitPage = () => {
 							<ul className="flex flex-col gap-1.5 text-sm">
 								{lostOpportunity.rows.slice(0, 5).map((row) => (
 									<li
-										key={`${row.query}-${row.page ?? ''}`}
+										key={`${row.siteUrl}-${row.query}-${row.page ?? ''}`}
 										className="flex items-center justify-between gap-2"
 									>
 										<span className="min-w-0 break-words">
 											<span className="font-medium">{row.query}</span>{' '}
 											<span className="text-xs text-muted-foreground">#{row.currentPosition.toFixed(1)}</span>
+											<span className="block text-[10px] text-muted-foreground">{siteHost(row.siteUrl)}</span>
 										</span>
 										<span className="font-mono text-xs text-rose-600">+{formatNumber(row.lostClicks)}</span>
 									</li>
@@ -322,12 +324,13 @@ export const CockpitPage = () => {
 							<ul className="flex flex-col gap-1.5 text-sm">
 								{quickWins.rows.slice(0, 5).map((row) => (
 									<li
-										key={`${row.query}-${row.page ?? ''}`}
+										key={`${row.siteUrl}-${row.query}-${row.page ?? ''}`}
 										className="flex items-center justify-between gap-2"
 									>
 										<span className="min-w-0 break-words">
 											<span className="font-medium">{row.query}</span>{' '}
 											<span className="text-xs text-muted-foreground">#{row.currentPosition.toFixed(1)}</span>
+											<span className="block text-[10px] text-muted-foreground">{siteHost(row.siteUrl)}</span>
 										</span>
 										<span className="font-mono text-xs text-amber-700">
 											+{formatNumber(row.projectedClickGain)}
@@ -355,10 +358,14 @@ export const CockpitPage = () => {
 						) : (
 							<ul className="flex flex-col gap-1.5 text-sm">
 								{ctrAnomalies.anomalies.slice(0, 5).map((row) => (
-									<li key={row.query} className="flex items-center justify-between gap-2">
+									<li
+										key={`${row.siteUrl}-${row.query}-${row.page ?? ''}`}
+										className="flex items-center justify-between gap-2"
+									>
 										<span className="min-w-0 break-words">
 											<span className="font-medium">{row.query}</span>{' '}
 											<span className="text-xs text-muted-foreground">#{row.avgPosition.toFixed(1)}</span>
+											<span className="block text-[10px] text-muted-foreground">{siteHost(row.siteUrl)}</span>
 										</span>
 										<span className="font-mono text-xs text-rose-600">
 											{formatNumber(row.impressions)} impr · 0 clicks

--- a/apps/web/src/pages/ctr-anomalies.page.tsx
+++ b/apps/web/src/pages/ctr-anomalies.page.tsx
@@ -11,12 +11,14 @@ import {
 } from '@rankpulse/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
-import { ArrowLeft, ExternalLink, MousePointerClick } from 'lucide-react';
+import { ArrowLeft, ExternalLink, Globe, MousePointerClick } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AppShell } from '../components/app-shell.js';
 import { api } from '../lib/api.js';
+import { groupBySiteUrl, siteHost } from '../lib/gsc-property.js';
 
 interface AnomalyRow {
+	siteUrl: string;
 	query: string;
 	page: string | null;
 	impressions: number;
@@ -130,20 +132,28 @@ export const CtrAnomaliesPage = () => {
 						description={t('cockpit:widgets.ctrAnomaly.emptyDescription')}
 					/>
 				) : (
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-base">{t('cockpit:ctrAnomaliesPage.tableTitle')}</CardTitle>
-							<p className="text-xs text-muted-foreground">{t('cockpit:ctrAnomaliesPage.tableHint')}</p>
-						</CardHeader>
-						<CardContent>
-							<DataTable
-								columns={columns}
-								rows={rows}
-								rowKey={(row) => `${row.query}-${row.page ?? ''}`}
-								empty={t('cockpit:ctrAnomaliesPage.empty')}
-							/>
-						</CardContent>
-					</Card>
+					<div className="flex flex-col gap-4">
+						<p className="text-xs text-muted-foreground">{t('cockpit:ctrAnomaliesPage.tableHint')}</p>
+						{groupBySiteUrl(rows).map((group) => (
+							<Card key={group.siteUrl}>
+								<CardHeader>
+									<CardTitle className="flex items-center gap-2 text-base">
+										<Globe size={14} className="shrink-0 text-muted-foreground" />
+										<span className="break-all">{siteHost(group.siteUrl)}</span>
+										<span className="text-xs font-normal text-muted-foreground">({group.rows.length})</span>
+									</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<DataTable
+										columns={columns}
+										rows={group.rows}
+										rowKey={(row) => `${row.query}-${row.page ?? ''}`}
+										empty={t('cockpit:ctrAnomaliesPage.empty')}
+									/>
+								</CardContent>
+							</Card>
+						))}
+					</div>
 				)}
 			</div>
 		</AppShell>

--- a/apps/web/src/pages/lost-opportunity.page.tsx
+++ b/apps/web/src/pages/lost-opportunity.page.tsx
@@ -11,12 +11,14 @@ import {
 } from '@rankpulse/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
-import { ArrowLeft, ExternalLink, TrendingDown } from 'lucide-react';
+import { ArrowLeft, ExternalLink, Globe, TrendingDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AppShell } from '../components/app-shell.js';
 import { api } from '../lib/api.js';
+import { groupBySiteUrl, siteHost } from '../lib/gsc-property.js';
 
 interface LostOpportunityRow {
+	siteUrl: string;
 	query: string;
 	page: string | null;
 	impressions: number;
@@ -150,20 +152,28 @@ export const LostOpportunityPage = () => {
 						description={t('cockpit:widgets.lostOpportunity.emptyDescription')}
 					/>
 				) : (
-					<Card>
-						<CardHeader>
-							<CardTitle className="text-base">{t('cockpit:lostOpportunityPage.tableTitle')}</CardTitle>
-							<p className="text-xs text-muted-foreground">{t('cockpit:lostOpportunityPage.tableHint')}</p>
-						</CardHeader>
-						<CardContent>
-							<DataTable
-								columns={columns}
-								rows={rows}
-								rowKey={(row) => `${row.query}-${row.page ?? ''}`}
-								empty={t('cockpit:lostOpportunityPage.empty')}
-							/>
-						</CardContent>
-					</Card>
+					<div className="flex flex-col gap-4">
+						<p className="text-xs text-muted-foreground">{t('cockpit:lostOpportunityPage.tableHint')}</p>
+						{groupBySiteUrl(rows).map((group) => (
+							<Card key={group.siteUrl}>
+								<CardHeader>
+									<CardTitle className="flex items-center gap-2 text-base">
+										<Globe size={14} className="shrink-0 text-muted-foreground" />
+										<span className="break-all">{siteHost(group.siteUrl)}</span>
+										<span className="text-xs font-normal text-muted-foreground">({group.rows.length})</span>
+									</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<DataTable
+										columns={columns}
+										rows={group.rows}
+										rowKey={(row) => `${row.query}-${row.page ?? ''}`}
+										empty={t('cockpit:lostOpportunityPage.empty')}
+									/>
+								</CardContent>
+							</Card>
+						))}
+					</div>
 				)}
 			</div>
 		</AppShell>

--- a/packages/application/src/search-console-insights/lib/top-n-per-property.ts
+++ b/packages/application/src/search-console-insights/lib/top-n-per-property.ts
@@ -1,0 +1,26 @@
+/**
+ * Groups scored rows by their GSC property and keeps the top-N of each, so a
+ * project with several linked properties surfaces every property's
+ * opportunities instead of letting the highest-volume one monopolise a single
+ * global top-N list (#196). Returns the union re-sorted by score descending for
+ * a stable default order; callers that section by property regroup client-side.
+ */
+export const topNPerProperty = <T extends { siteUrl: string }>(
+	rows: readonly T[],
+	perPropertyLimit: number,
+	score: (row: T) => number,
+): T[] => {
+	const byProperty = new Map<string, T[]>();
+	for (const row of rows) {
+		const bucket = byProperty.get(row.siteUrl);
+		if (bucket) bucket.push(row);
+		else byProperty.set(row.siteUrl, [row]);
+	}
+	const kept: T[] = [];
+	for (const bucket of byProperty.values()) {
+		bucket.sort((a, b) => score(b) - score(a));
+		kept.push(...bucket.slice(0, perPropertyLimit));
+	}
+	kept.sort((a, b) => score(b) - score(a));
+	return kept;
+};

--- a/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.spec.ts
@@ -7,8 +7,10 @@ import { QueryCtrAnomaliesUseCase } from './query-ctr-anomalies.use-case.js';
 const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
 
+type FakeRow = Omit<SearchConsoleInsights.QueryAggregateRow, 'siteUrl'> & { siteUrl?: string };
+
 class FakeCockpit implements SearchConsoleInsights.GscCockpitReadModel {
-	rows: SearchConsoleInsights.QueryAggregateRow[] = [];
+	rows: FakeRow[] = [];
 	requested: { windowDays: number; minImpressions: number | undefined } | null = null;
 	async aggregateByQuery(
 		_projectId: ProjectManagement.ProjectId,
@@ -16,7 +18,7 @@ class FakeCockpit implements SearchConsoleInsights.GscCockpitReadModel {
 		options?: { minImpressions?: number; limit?: number },
 	): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
 		this.requested = { windowDays, minImpressions: options?.minImpressions };
-		return this.rows;
+		return this.rows.map((r) => ({ siteUrl: 'sc-domain:controlrondas.com', ...r }));
 	}
 	async weeklyClicksByQuery(): Promise<readonly SearchConsoleInsights.WeeklyClicksByQueryRow[]> {
 		return [];
@@ -68,6 +70,31 @@ describe('QueryCtrAnomaliesUseCase', () => {
 		];
 		const result = await useCase.execute({ projectId: PROJECT_ID });
 		expect(result.anomalies.map((a) => a.query)).toEqual(['big', 'mid', 'small']);
+	});
+
+	it('attributes each anomaly to its GSC property and surfaces siblings (#196)', async () => {
+		cockpit.rows = [
+			{
+				siteUrl: 'sc-domain:patroltech.online',
+				query: 'control de acceso a hospitales',
+				totalImpressions: 500,
+				totalClicks: 0,
+				avgPosition: 18,
+				bestPage: 'https://patroltech.online/',
+			},
+			{
+				siteUrl: 'sc-domain:guardtour.app',
+				query: 'guard tour verification',
+				totalImpressions: 120,
+				totalClicks: 0,
+				avgPosition: 22,
+				bestPage: 'https://guardtour.app/',
+			},
+		];
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+		const bySite = new Map(result.anomalies.map((a) => [a.siteUrl, a]));
+		expect(bySite.has('sc-domain:patroltech.online')).toBe(true);
+		expect(bySite.has('sc-domain:guardtour.app')).toBe(true);
 	});
 
 	it('passes minImpressions through to the read model with default 50', async () => {

--- a/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.ts
@@ -8,6 +8,7 @@ export interface QueryCtrAnomaliesCommand {
 }
 
 export interface CtrAnomalyDto {
+	siteUrl: string;
 	query: string;
 	page: string | null;
 	impressions: number;
@@ -54,6 +55,7 @@ export class QueryCtrAnomaliesUseCase {
 			if (r.totalClicks > 0) continue;
 			if (r.avgPosition <= 0 || r.avgPosition > POSITION_CAP) continue;
 			anomalies.push({
+				siteUrl: r.siteUrl,
 				query: r.query,
 				page: r.bestPage,
 				impressions: r.totalImpressions,

--- a/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.spec.ts
@@ -7,10 +7,14 @@ import { QueryLostOpportunityUseCase } from './query-lost-opportunity.use-case.j
 const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
 
+type FakeRow = Omit<SearchConsoleInsights.QueryAggregateRow, 'siteUrl'> & { siteUrl?: string };
+
 class FakeCockpit implements SearchConsoleInsights.GscCockpitReadModel {
-	rows: SearchConsoleInsights.QueryAggregateRow[] = [];
+	rows: FakeRow[] = [];
 	async aggregateByQuery(): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
-		return this.rows;
+		// Default siteUrl for the single-property cases; multi-property tests
+		// set it explicitly per row.
+		return this.rows.map((r) => ({ siteUrl: 'sc-domain:controlrondas.com', ...r }));
 	}
 	async weeklyClicksByQuery(): Promise<readonly SearchConsoleInsights.WeeklyClicksByQueryRow[]> {
 		return [];
@@ -69,7 +73,7 @@ describe('QueryLostOpportunityUseCase', () => {
 		expect(result.totalLostClicks).toBeGreaterThan(0);
 	});
 
-	it('honours the limit parameter', async () => {
+	it('honours the limit parameter (per property)', async () => {
 		cockpit.rows = Array.from({ length: 100 }, (_, i) => ({
 			query: `kw-${i}`,
 			totalImpressions: 1000 - i,
@@ -79,6 +83,65 @@ describe('QueryLostOpportunityUseCase', () => {
 		}));
 		const result = await useCase.execute({ projectId: PROJECT_ID, limit: 5 });
 		expect(result.rows).toHaveLength(5);
+	});
+
+	it('does not let a high-volume property mask the opportunities of its siblings', async () => {
+		// Regression for #196: a project with several linked GSC properties
+		// must surface each property's opportunities. The dominant property
+		// (patroltech.online) has many high-lostClicks queries; the sibling
+		// (guardtour.app) has a single, smaller one. Under a global top-N the
+		// sibling falls off the list entirely.
+		const dominant = Array.from({ length: 60 }, (_, i) => ({
+			siteUrl: 'sc-domain:patroltech.online',
+			query: `brand-kw-${i}`,
+			totalImpressions: 1000,
+			totalClicks: 0,
+			avgPosition: 8,
+			bestPage: '/p',
+		}));
+		const sibling = {
+			siteUrl: 'sc-domain:guardtour.app',
+			query: 'guard tour',
+			totalImpressions: 300,
+			totalClicks: 0,
+			avgPosition: 8,
+			bestPage: 'https://guardtour.app/',
+		};
+		cockpit.rows = [...dominant, sibling];
+
+		const result = await useCase.execute({ projectId: PROJECT_ID, limit: 50 });
+
+		const siteUrls = new Set(result.rows.map((r) => r.siteUrl));
+		expect(siteUrls.has('sc-domain:guardtour.app')).toBe(true);
+		expect(siteUrls.has('sc-domain:patroltech.online')).toBe(true);
+		// Every row is attributed to a property.
+		expect(result.rows.every((r) => typeof r.siteUrl === 'string' && r.siteUrl.length > 0)).toBe(true);
+	});
+
+	it('does not blend positions across properties (each row keeps its own siteUrl)', async () => {
+		cockpit.rows = [
+			{
+				siteUrl: 'sc-domain:patroltech.online',
+				query: 'guard tour',
+				totalImpressions: 500,
+				totalClicks: 0,
+				avgPosition: 4,
+				bestPage: 'https://patroltech.online/',
+			},
+			{
+				siteUrl: 'sc-domain:guardtour.app',
+				query: 'guard tour',
+				totalImpressions: 500,
+				totalClicks: 0,
+				avgPosition: 20,
+				bestPage: 'https://guardtour.app/',
+			},
+		];
+		const result = await useCase.execute({ projectId: PROJECT_ID });
+		// The same query string on two domains stays as two distinct rows —
+		// the pos-20 sibling opportunity is NOT diluted by the pos-4 one.
+		const sibling = result.rows.find((r) => r.siteUrl === 'sc-domain:guardtour.app');
+		expect(sibling?.currentPosition).toBe(20);
 	});
 
 	it('throws NotFoundError when the project does not exist', async () => {

--- a/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.ts
@@ -1,6 +1,7 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
 import { ctrForPosition, DEFAULT_TARGET_POSITION } from '../lib/ctr-curve.js';
+import { topNPerProperty } from '../lib/top-n-per-property.js';
 
 export interface QueryLostOpportunityCommand {
 	projectId: string;
@@ -8,10 +9,12 @@ export interface QueryLostOpportunityCommand {
 	minImpressions?: number;
 	/** Position used as the "what would top-X earn" baseline. Default = 3. */
 	targetPosition?: number;
+	/** Max rows returned PER linked GSC property (not a single global cap). */
 	limit?: number;
 }
 
 export interface LostOpportunityDto {
+	siteUrl: string;
 	query: string;
 	page: string | null;
 	impressions: number;
@@ -28,12 +31,16 @@ export interface QueryLostOpportunityResponse {
 }
 
 const DEFAULT_WINDOW_DAYS = 28;
-const DEFAULT_MIN_IMPRESSIONS = 100;
+// Low impression floor (just noise suppression): the `lostClicks >= 1` filter
+// below is the real significance gate (~14 impressions at pos 8). A high floor
+// here would hide low-traffic GSC properties entirely in multi-property
+// projects, which was the visible half of #196.
+const DEFAULT_MIN_IMPRESSIONS = 10;
 const DEFAULT_LIMIT = 50;
 
 /**
  * Quantifies the click volume left on the table per keyword: for each
- * (query) tuple we compute `lostClicks = impressions × (CTR_at_target -
+ * (property, query) tuple we compute `lostClicks = impressions × (CTR_at_target -
  * CTR_at_current)` using the AWR-2024 position-CTR curve. The issue's
  * formula is `vol × Δ-CTR × CPC`; the CPC factor is deferred until the
  * DataForSEO keyword-volume table lands (sub-issue), so the MVP returns
@@ -77,6 +84,7 @@ export class QueryLostOpportunityUseCase {
 			if (lostClicks < 1) continue;
 			totalLost += lostClicks;
 			out.push({
+				siteUrl: r.siteUrl,
 				query: r.query,
 				page: r.bestPage,
 				impressions: r.totalImpressions,
@@ -87,8 +95,12 @@ export class QueryLostOpportunityUseCase {
 				lostClicks: Math.round(lostClicks),
 			});
 		}
-		out.sort((a, b) => b.lostClicks - a.lostClicks);
-		return { rows: out.slice(0, limit), totalLostClicks: Math.round(totalLost) };
+		// Top-N PER PROPERTY (not a single global top-N): a project with
+		// several linked GSC properties must surface each property's
+		// opportunities; otherwise the highest-volume property monopolises the
+		// list and masks the market-specific siblings (#196).
+		const topRows = topNPerProperty(out, limit, (r) => r.lostClicks);
+		return { rows: topRows, totalLostClicks: Math.round(totalLost) };
 	}
 }
 

--- a/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.spec.ts
@@ -7,10 +7,12 @@ import { QueryQuickWinRoiUseCase } from './query-quick-win-roi.use-case.js';
 const ORG_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Uuid as IdentityAccess.OrganizationId;
 const PROJECT_ID = '11111111-1111-1111-1111-111111111111' as Uuid as ProjectManagement.ProjectId;
 
+type FakeRow = Omit<SearchConsoleInsights.QueryAggregateRow, 'siteUrl'> & { siteUrl?: string };
+
 class FakeCockpit implements SearchConsoleInsights.GscCockpitReadModel {
-	rows: SearchConsoleInsights.QueryAggregateRow[] = [];
+	rows: FakeRow[] = [];
 	async aggregateByQuery(): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
-		return this.rows;
+		return this.rows.map((r) => ({ siteUrl: 'sc-domain:controlrondas.com', ...r }));
 	}
 	async weeklyClicksByQuery(): Promise<readonly SearchConsoleInsights.WeeklyClicksByQueryRow[]> {
 		return [];
@@ -73,7 +75,7 @@ describe('QueryQuickWinRoiUseCase', () => {
 		expect(result.rows).toHaveLength(0);
 	});
 
-	it('respects custom limit', async () => {
+	it('respects custom limit (per property)', async () => {
 		cockpit.rows = Array.from({ length: 30 }, (_, i) => ({
 			query: `kw-${i}`,
 			totalImpressions: 1000,
@@ -83,6 +85,32 @@ describe('QueryQuickWinRoiUseCase', () => {
 		}));
 		const result = await useCase.execute({ projectId: PROJECT_ID, limit: 5 });
 		expect(result.rows).toHaveLength(5);
+	});
+
+	it('does not let a high-volume property mask its siblings (#196)', async () => {
+		const dominant = Array.from({ length: 30 }, (_, i) => ({
+			siteUrl: 'sc-domain:patroltech.online',
+			query: `brand-kw-${i}`,
+			totalImpressions: 1000,
+			totalClicks: 5,
+			avgPosition: 12,
+			bestPage: '/p',
+		}));
+		const sibling = {
+			siteUrl: 'sc-domain:guardtour.app',
+			query: 'guard tour',
+			totalImpressions: 300,
+			totalClicks: 1,
+			avgPosition: 12,
+			bestPage: 'https://guardtour.app/',
+		};
+		cockpit.rows = [...dominant, sibling];
+
+		const result = await useCase.execute({ projectId: PROJECT_ID, limit: 25 });
+
+		const siteUrls = new Set(result.rows.map((r) => r.siteUrl));
+		expect(siteUrls.has('sc-domain:guardtour.app')).toBe(true);
+		expect(siteUrls.has('sc-domain:patroltech.online')).toBe(true);
 	});
 
 	it('throws NotFoundError for unknown project', async () => {

--- a/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.ts
@@ -1,15 +1,18 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
 import { ctrForPosition } from '../lib/ctr-curve.js';
+import { topNPerProperty } from '../lib/top-n-per-property.js';
 
 export interface QueryQuickWinRoiCommand {
 	projectId: string;
 	windowDays?: number;
 	minImpressions?: number;
+	/** Max rows returned PER linked GSC property (not a single global cap). */
 	limit?: number;
 }
 
 export interface QuickWinRoiDto {
+	siteUrl: string;
 	query: string;
 	page: string | null;
 	impressions: number;
@@ -24,7 +27,10 @@ export interface QueryQuickWinRoiResponse {
 }
 
 const DEFAULT_WINDOW_DAYS = 28;
-const DEFAULT_MIN_IMPRESSIONS = 100;
+// Low impression floor (noise suppression only): a high floor hid low-traffic
+// GSC properties entirely in multi-property projects (#196). Per-property
+// top-N (below) keeps the output bounded regardless.
+const DEFAULT_MIN_IMPRESSIONS = 10;
 const DEFAULT_LIMIT = 25;
 const QUICK_WIN_MIN_POS = 11;
 const QUICK_WIN_MAX_POS = 30;
@@ -80,6 +86,7 @@ export class QueryQuickWinRoiUseCase {
 			// keyword at #28 with 100 projected clicks.
 			const roiScore = (projectedGain * (31 - r.avgPosition)) / 20;
 			out.push({
+				siteUrl: r.siteUrl,
 				query: r.query,
 				page: r.bestPage,
 				impressions: r.totalImpressions,
@@ -89,8 +96,10 @@ export class QueryQuickWinRoiUseCase {
 				roiScore: Number(roiScore.toFixed(2)),
 			});
 		}
-		out.sort((a, b) => b.roiScore - a.roiScore);
-		return { rows: out.slice(0, limit) };
+		// Top-N PER PROPERTY so a dominant property doesn't crowd the siblings
+		// out of a single global list (#196).
+		const topRows = topNPerProperty(out, limit, (r) => r.roiScore);
+		return { rows: topRows };
 	}
 }
 

--- a/packages/contracts/src/search-console-insights/index.ts
+++ b/packages/contracts/src/search-console-insights/index.ts
@@ -58,6 +58,7 @@ export const CtrAnomaliesQuery = CockpitWindowQuery.extend({
 export type CtrAnomaliesQuery = z.infer<typeof CtrAnomaliesQuery>;
 
 export const CtrAnomalyDto = z.object({
+	siteUrl: z.string(),
 	query: z.string(),
 	page: z.string().nullable(),
 	impressions: z.number().int(),
@@ -79,6 +80,7 @@ export const LostOpportunityQuery = CockpitWindowQuery.extend({
 export type LostOpportunityQuery = z.infer<typeof LostOpportunityQuery>;
 
 export const LostOpportunityRowDto = z.object({
+	siteUrl: z.string(),
 	query: z.string(),
 	page: z.string().nullable(),
 	impressions: z.number().int(),
@@ -103,6 +105,7 @@ export const QuickWinRoiQuery = CockpitWindowQuery.extend({
 export type QuickWinRoiQuery = z.infer<typeof QuickWinRoiQuery>;
 
 export const QuickWinRoiRowDto = z.object({
+	siteUrl: z.string(),
 	query: z.string(),
 	page: z.string().nullable(),
 	impressions: z.number().int(),

--- a/packages/domain/src/search-console-insights/ports/gsc-cockpit-read-model.ts
+++ b/packages/domain/src/search-console-insights/ports/gsc-cockpit-read-model.ts
@@ -15,11 +15,18 @@ import type { ProjectId } from '../../project-management/value-objects/identifie
  */
 export interface GscCockpitReadModel {
 	/**
-	 * One row per distinct GSC query (search term) within the rolling
+	 * One row per distinct (GSC property, query) pair within the rolling
 	 * window, with summed impressions/clicks and impression-weighted average
 	 * position. Used by the CTR-Anomaly / Lost-Opportunity / Quick-Win
 	 * widgets that all need the same primitive view of "which keywords
 	 * matter, how big are they, where do we rank?"
+	 *
+	 * Aggregation is per-property (not collapsed to the bare query) so a
+	 * project with several linked GSC properties doesn't blend domains: a
+	 * dominant property (e.g. the main brand site) must not mask the
+	 * market-specific siblings, and a query that ranks well on one domain
+	 * must not dilute the same query ranking poorly on another. Each row
+	 * carries its `siteUrl` so callers can group/section by property.
 	 */
 	aggregateByQuery(
 		projectId: ProjectId,
@@ -48,6 +55,8 @@ export interface GscCockpitReadModel {
 }
 
 export interface QueryAggregateRow {
+	/** The GSC property (site URL) this aggregate belongs to. */
+	readonly siteUrl: string;
 	readonly query: string;
 	readonly totalImpressions: number;
 	readonly totalClicks: number;

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.spec.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.spec.ts
@@ -12,6 +12,48 @@ const stubDbReturning = (rows: unknown[]): DrizzleDatabase => {
 };
 
 describe('DrizzleGscCockpitReadModel', () => {
+	describe('aggregateByQuery', () => {
+		// The query aggregates per (gsc_property_id, query) and returns the
+		// property `site_url` per row so the cockpit widgets can section by
+		// property instead of blending domains (#196).
+		it('maps site_url → siteUrl and coerces numeric columns', async () => {
+			const db = stubDbReturning([
+				{
+					site_url: 'sc-domain:guardtour.app',
+					query: 'guard tour',
+					total_impressions: '300',
+					total_clicks: '0',
+					avg_position: '20',
+					best_page: 'https://guardtour.app/',
+				},
+			]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const [row] = await repo.aggregateByQuery(PROJECT_ID, 28, { minImpressions: 100, limit: 100 });
+			expect(row?.siteUrl).toBe('sc-domain:guardtour.app');
+			expect(row?.query).toBe('guard tour');
+			expect(row?.totalImpressions).toBe(300);
+			expect(row?.totalClicks).toBe(0);
+			expect(row?.avgPosition).toBe(20);
+			expect(row?.bestPage).toBe('https://guardtour.app/');
+		});
+
+		it('maps an empty best_page to null', async () => {
+			const db = stubDbReturning([
+				{
+					site_url: 'sc-domain:x.com',
+					query: 'q',
+					total_impressions: 10,
+					total_clicks: 0,
+					avg_position: 5,
+					best_page: '',
+				},
+			]);
+			const repo = new DrizzleGscCockpitReadModel(db);
+			const [row] = await repo.aggregateByQuery(PROJECT_ID, 28);
+			expect(row?.bestPage).toBeNull();
+		});
+	});
+
 	// postgres-js (3.4.x) returns timestamptz as ISO strings — not Date —
 	// for raw `db.execute()` queries. The two methods below feed those
 	// values to use cases that call `.toISOString()` / `.getTime()`, so

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
@@ -18,7 +18,14 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 		// same weight, which under-weights high-traffic pages. The bestPage
 		// is whichever URL produced the most clicks for the query (tie-break
 		// on impressions) — used as the deep-link target in the SPA.
+		//
+		// Aggregation is keyed by (gsc_property_id, query) — NOT the bare
+		// query — so a project with several linked properties never blends
+		// domains: a query ranking well on the main brand site can't dilute
+		// the same query ranking poorly on a market sibling, and the dominant
+		// property can't mask the siblings (#196).
 		const result = await this.db.execute(sql<{
+			site_url: string;
 			query: string;
 			total_impressions: number;
 			total_clicks: number;
@@ -27,6 +34,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 		}>`
 			WITH per_page AS (
 				SELECT
+					gsc_property_id,
 					query,
 					page,
 					SUM(clicks)::bigint AS clicks,
@@ -47,23 +55,26 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					)
 					AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 					AND query <> ''
-				GROUP BY query, page
+				GROUP BY gsc_property_id, query, page
 			)
 			SELECT
-				query,
-				SUM(impressions)::bigint AS total_impressions,
-				SUM(clicks)::bigint AS total_clicks,
-				CASE WHEN SUM(impressions) > 0
-				     THEN SUM(weighted_position * impressions) / SUM(impressions)
+				p.site_url AS site_url,
+				pp.query,
+				SUM(pp.impressions)::bigint AS total_impressions,
+				SUM(pp.clicks)::bigint AS total_clicks,
+				CASE WHEN SUM(pp.impressions) > 0
+				     THEN SUM(pp.weighted_position * pp.impressions) / SUM(pp.impressions)
 				     ELSE 0 END AS avg_position,
-				(ARRAY_AGG(page ORDER BY clicks DESC, impressions DESC))[1] AS best_page
-			FROM per_page
-			GROUP BY query
-			HAVING SUM(impressions) >= ${minImpr}
+				(ARRAY_AGG(pp.page ORDER BY pp.clicks DESC, pp.impressions DESC))[1] AS best_page
+			FROM per_page pp
+			JOIN gsc_properties p ON p.id = pp.gsc_property_id
+			GROUP BY pp.gsc_property_id, p.site_url, pp.query
+			HAVING SUM(pp.impressions) >= ${minImpr}
 			ORDER BY total_impressions DESC
 			LIMIT ${limit}
 		`);
 		type Row = {
+			site_url: string;
 			query: string;
 			total_impressions: number;
 			total_clicks: number;
@@ -72,6 +83,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 		};
 		const rows = unwrap<Row>(result);
 		return rows.map((r) => ({
+			siteUrl: r.site_url,
 			query: r.query,
 			totalImpressions: Number(r.total_impressions),
 			totalClicks: Number(r.total_clicks),


### PR DESCRIPTION
## Qué arregla

`Closes #196`.

Los widgets del Decision Cockpit (**Lost-Opportunity**, **Quick-Win ROI**,
**CTR-Anomaly**) comparten el read-model `aggregateByQuery`, que agrupaba
`gsc_observations` por `query` sobre **todas** las properties del proyecto.
En proyectos multi-property la property dominante (`patroltech.online`, ~90%
de impresiones, con sus queries *healthcare*/hospitales) **tapaba** a las
hermanas de mercado: sus queries de alto volumen llenaban el top-N y el filtro
`minImpressions=100` eliminaba a las hermanas por completo.

> No era un fallo del pipeline de datos (sync GSC sano) ni recaída de #194.

## Cambios

- **Read-model** (`gsc-cockpit-read-model.ts`): agrega por `(gsc_property_id, query)`
  y devuelve `siteUrl`; sin blending de posición/página entre dominios.
- **Use cases**: top-N **por property** (`top-n-per-property.ts`) + `minImpressions`
  por defecto a 10 en lost-opportunity/quick-win (el filtro `lostClicks >= 1` es el
  umbral real de significancia). CTR-Anomaly mantiene 50 (su bug real era el merge
  cross-dominio, ya resuelto por la agrupación por property).
- **Contracts**: `siteUrl` en las 3 row DTOs (el SDK es type-driven y el OpenAPI usa
  los schemas Zod → se propagan solos).
- **Web**: secciones por property en las páginas de detalle de Lost-Opportunity y
  CTR-Anomaly; etiqueta de dominio en los mini-widgets del cockpit.

## Verificación

- TDD: tests de regresión rojo→verde (hermana no enmascarada, sin blending de
  posición, `siteUrl` por fila) en los 3 use cases + mapping del read-model.
- Gate completo: `lint` · `typecheck` (27/27) · `test` (435) · `build` (24/24).
- **Prod (read-only)**: con el SQL nuevo el proyecto EN muestra `patroltech.online`
  (43 filas), `guardtour.app` (4), `securityguardtour.com` (4), `rondasoffline.com`
  (2), y `guard tour` aparece como **2 filas separadas** (pos 67.5 y 77.0) en vez de
  una mezclada.

## Notas

- Verificación visual de móvil (375px) pendiente; el cambio es estructuralmente
  mobile-safe (Cards apiladas con `flex-col`, `DataTable` ya gestiona móvil).
