### PR TITLE
chore(search-console-insights): cockpit per-property TIL + drop dead i18n keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -730,4 +730,37 @@ bull:provider-<id>:repeat` que el nº de repeatables = nº de defs
 habilitadas de ese provider, no el nº de crons. Sigue pendiente (gap
 conocido): reconciliación automática en boot ante pérdida de estado Redis.
 
-_Última actualización: 2026-05-30. Mantén este archivo vivo._
+### 13.8 Cockpit: agregaciones por proyecto que cruzan varias GSC properties
+
+**Síntoma**: en proyectos con varias GSC properties enlazadas, los
+widgets del Decision Cockpit (Lost-Opportunity, Quick-Win ROI,
+CTR-Anomaly) muestran casi solo las queries de la property dominante por
+volumen y **ocultan** las de las hermanas. Caso real (#196): PatrolTech
+EN con `sc-domain:patroltech.online` (~90% de impresiones, incluidas sus
+queries healthcare/hospitales) tapando a `guardtour.app` /
+`securityguardtour.com` / `rondasoffline.com`.
+
+**Causa raíz**: el read-model compartido
+`GscCockpitReadModel.aggregateByQuery` agregaba `gsc_observations` sobre
+**todas** las properties del proyecto y hacía `GROUP BY query` —
+mezclando dominios. Dos efectos: (1) el top-N global + `minImpressions`
+alto (100) filtraba a las hermanas de bajo tráfico por completo; (2) la
+posición impression-weighted se fundía entre dominios y `bestPage`
+apuntaba al de más clics. **No** era un fallo del pipeline de datos ni
+del scheduler (#194) — era puramente la capa de lectura del cockpit.
+
+**Fix permanente** (#196): `aggregateByQuery` agrupa por
+`(gsc_property_id, query)` y devuelve `siteUrl`; los use cases hacen
+top-N **por property** (`application/.../lib/top-n-per-property.ts`) con
+un `minImpressions` bajo (el filtro `lostClicks >= 1` es el umbral real);
+las 3 row DTOs llevan `siteUrl` y la web secciona por property.
+
+**Para el agente**: cualquier agregación read-model por proyecto que
+cruce varias GSC properties (o, en general, varias entidades del mismo
+tipo) debe agrupar **por la entidad**, no colapsar a la dimensión de
+negocio (`query`). Si un proyecto puede tener N properties, el widget
+debe representar a las N — nunca dejar que la de mayor volumen monopolice
+un top-N global. Verifícalo con un proyecto multi-property (PatrolTech EN
+= 5 properties): cada property debe aparecer con sus propias filas.
+
+_Última actualización: 2026-06-03. Mantén este archivo vivo._

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -655,7 +655,6 @@ const en = {
 			title: 'CTR Anomalies',
 			subtitle:
 				'Keywords ranking but earning zero clicks — likely broken snippet, AI Overviews takeover, or canonical drift.',
-			tableTitle: 'Anomalies sorted by impression volume',
 			tableHint:
 				'Each row is a search query that returned ≥ 50 impressions and 0 clicks at position ≤ 30 in the last 28 days.',
 			query: 'Query',
@@ -673,7 +672,6 @@ const en = {
 		lostOpportunityPage: {
 			title: 'Lost Opportunity Score',
 			subtitle: 'Click volume left on the table per keyword if you reached the top-3.',
-			tableTitle: 'Top opportunities by lost clicks',
 			tableHint:
 				'Lost clicks ≈ impressions × (CTR_top3 - CTR_current) using the AWR-2024 position-CTR curve.',
 			query: 'Query',
@@ -1628,7 +1626,6 @@ const es = {
 			title: 'Anomalías de CTR',
 			subtitle:
 				'Keywords posicionadas pero sin clicks — probablemente snippet roto, AI Overviews o canonical drift.',
-			tableTitle: 'Anomalías ordenadas por volumen de impresiones',
 			tableHint:
 				'Cada fila es una query con ≥ 50 impresiones y 0 clicks en posición ≤ 30 los últimos 28 días.',
 			query: 'Query',
@@ -1646,7 +1643,6 @@ const es = {
 		lostOpportunityPage: {
 			title: 'Lost Opportunity Score',
 			subtitle: 'Volumen de clicks que dejas sobre la mesa por keyword si llegaras al top-3.',
-			tableTitle: 'Top oportunidades por clicks perdidos',
 			tableHint:
 				'Lost clicks ≈ impresiones × (CTR_top3 - CTR_actual) usando la curva AWR-2024 de CTR por posición.',
 			query: 'Query',


### PR DESCRIPTION
Follow-ups a #196 (ya mergeado en #197).

- **CLAUDE.md §13.8**: TIL documentando por qué las agregaciones read-model por proyecto que cruzan varias GSC properties deben agrupar **por property**, no colapsar a `query` (si no, la dominante tapa a las hermanas).
- **i18n**: elimino las claves muertas `lostOpportunityPage.tableTitle` y `ctrAnomaliesPage.tableTitle` (en + es) — las páginas de detalle ahora usan cabeceras por property, así que el título único sobraba.

Sin cambios de runtime. `typecheck` + `lint` verdes.

Refs #196