### PR TITLE
fix(rank-tracking): raise SERP live depth default 20→100

### DIFF
--- a/apps/web/src/components/schedule-fetch-drawer.tsx
+++ b/apps/web/src/components/schedule-fetch-drawer.tsx
@@ -12,7 +12,7 @@ export interface ScheduleFetchDrawerProps {
 
 const DEFAULT_PARAMS_HINT: Record<string, string> = {
 	'serp-google-organic-live': JSON.stringify(
-		{ keyword: 'control de rondas', locationCode: 2724, languageCode: 'es', device: 'desktop', depth: 20 },
+		{ keyword: 'control de rondas', locationCode: 2724, languageCode: 'es', device: 'desktop', depth: 100 },
 		null,
 		2,
 	),

--- a/apps/web/src/pages/onboarding.page.tsx
+++ b/apps/web/src/pages/onboarding.page.tsx
@@ -164,7 +164,7 @@ export const OnboardingPage = () => {
 						locationCode: country.dataforseoCode,
 						languageCode: country.defaultLanguage,
 						device: 'desktop',
-						depth: 20,
+						depth: 100,
 					},
 				},
 			});

--- a/packages/providers/dataforseo/src/endpoints/serp-google-organic-live.ts
+++ b/packages/providers/dataforseo/src/endpoints/serp-google-organic-live.ts
@@ -7,7 +7,11 @@ export const SerpGoogleOrganicLiveParams = z.object({
 	locationCode: z.number().int().min(1).max(99_999_999),
 	languageCode: z.string().regex(/^[a-z]{2}(?:-[A-Z]{2})?$/),
 	device: z.enum(['desktop', 'mobile']).default('desktop'),
-	depth: z.number().int().min(10).max(100).default(20),
+	// Depth 100 (DataForSEO's max for one request, same cost tier) so
+	// rank-tracking catches domains ranking 31-100. depth 20-30 made new,
+	// low-authority domains (e.g. the English/French satellites) show as
+	// `null` even when they rank deep in the SERP (#200).
+	depth: z.number().int().min(10).max(100).default(100),
 });
 export type SerpGoogleOrganicLiveParams = z.infer<typeof SerpGoogleOrganicLiveParams>;
 


### PR DESCRIPTION
Parte 1 de #200 (el depth; la posición-GSC va aparte).

## Qué
Rank-tracking solo lee el top-`depth` del SERP. Con depth 20-30, los dominios nuevos (satélites EN/FR) salían `null` aunque rankeen en 31-100 — **PatrolTech EN: 5/1292** observaciones con posición vs **381/1192 en ES**. Subo el default a 100 (máx de DataForSEO en una request, mismo tramo de coste).

- schema `serp-google-organic-live` default 20→100
- defaults de onboarding + hint del drawer 20→100

## Defs existentes (post-deploy)
Las JobDefinitions ya creadas conservan su `depth`. Tras el deploy, un update único:
```sql
UPDATE provider_job_definitions
SET params = jsonb_set(params, '{depth}', '100')
WHERE endpoint_id = 'serp-google-organic-live' AND (params->>'depth')::int < 100;
```
(luego `run-now` o esperar al cron diario 06:00 UTC). Lo ejecuto con tu OK, como el reconcile de #194.

## Nota
depth=100 no garantiza ver la pos-24 de GSC (fuentes distintas); para eso va la 2ª parte de #200 (posición derivada de GSC). Pero hará visibles los rankings profundos que hoy salen null.

`lint`/`typecheck`/`test` (dataforseo 67) verdes.

Refs #200