### PR TITLE
feat(search-console-insights): capture GSC country dimension (#199 phase 1)

### DIFF
--- a/packages/application/src/search-console-insights/event-handlers/auto-schedule.config.spec.ts
+++ b/packages/application/src/search-console-insights/event-handlers/auto-schedule.config.spec.ts
@@ -43,7 +43,7 @@ describe('searchConsoleInsightsAutoScheduleConfigs', () => {
 			siteUrl: SITE_URL,
 			startDate: '{{today-30}}',
 			endDate: '{{today-2}}',
-			dimensions: ['date', 'query', 'page'],
+			dimensions: ['date', 'query', 'page', 'country'],
 			rowLimit: 25_000,
 		});
 	});

--- a/packages/application/src/search-console-insights/event-handlers/auto-schedule.config.ts
+++ b/packages/application/src/search-console-insights/event-handlers/auto-schedule.config.ts
@@ -20,7 +20,11 @@ export const GSC_AUTO_SCHEDULE_DEFAULTS = {
 	providerId: 'google-search-console',
 	endpointId: 'gsc-search-analytics',
 	cron: '0 5 * * *',
-	dimensions: ['date', 'query', 'page'] as const,
+	// `country` (#199) lets the cockpit segment a property's traffic by the
+	// project's target market — without it, a shared hub linked to several
+	// market projects shows the same (dominant-country) data everywhere. GSC
+	// allows up to 4 dimensions; this is exactly 4.
+	dimensions: ['date', 'query', 'page', 'country'] as const,
 	rowLimit: 25_000,
 	startDateToken: '{{today-30}}',
 	endDateToken: '{{today-2}}',


### PR DESCRIPTION
Fase 1 de #199 (segmentar GSC por país). **Neutra hoy**, fundacional.

## Qué
Añade `country` a las dimensiones del fetch GSC (`date,query,page,country` = 4, el máximo). Las observaciones pasan a guardarse por país. El cockpit **no cambia** (los read-models siguen sumando entre países → mismos totales). Es la base para la Fase 2 (filtrar por el país objetivo del proyecto), de modo que cuando llegue, la ventana de 30 días ya tendrá datos de país y no habrá hueco.

## Backfill (post-deploy)
Las JobDefinitions GSC existentes conservan sus dimensiones. Tras el deploy:
```sql
UPDATE provider_job_definitions
SET params = jsonb_set(params, '{dimensions}', '["date","query","page","country"]')
WHERE provider_id='google-search-console' AND endpoint_id='gsc-search-analytics'
  AND NOT (params->'dimensions' ? 'country');
```
+ `run-now` de las 15 defs GSC (gratis) para rellenar la ventana de 30 días con país. Lo ejecuto con tu OK.

## Fase 2 (siguiente)
Filtrar `aggregateByQuery` / `weeklyClicksByQuery` / `dailyTotalsForProject` por los países del proyecto (`project_locations` + mapeo ISO-2→ISO-3) + UI. Ahí es donde FR deja de ver las queries en castellano del hub.

`lint`/`typecheck`/`test` verdes (config spec incluido).

Refs #199