### PR TITLE
feat(search-console-insights): scope cockpit by project country (#199 phase 2)

### DIFF
--- a/packages/application/src/search-console-insights/lib/gsc-country.spec.ts
+++ b/packages/application/src/search-console-insights/lib/gsc-country.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGscCountries } from './gsc-country.js';
+
+describe('resolveGscCountries', () => {
+	it('maps a single-market project to its alpha-3 GSC country', () => {
+		expect(resolveGscCountries([{ country: 'FR' }])).toEqual(['fra']);
+		expect(resolveGscCountries([{ country: 'ES' }])).toEqual(['esp']);
+	});
+
+	it('maps a multi-market project to distinct alpha-3 codes', () => {
+		expect([...resolveGscCountries([{ country: 'GB' }, { country: 'US' }])].sort()).toEqual(['gbr', 'usa']);
+	});
+
+	it('is case-insensitive on the alpha-2 input', () => {
+		expect(resolveGscCountries([{ country: 'mx' }])).toEqual(['mex']);
+	});
+
+	it('returns [] (no filter) when there are no locations', () => {
+		expect(resolveGscCountries([])).toEqual([]);
+	});
+
+	it('returns [] (no filter) when ANY location is unmapped, to avoid hiding that market', () => {
+		expect(resolveGscCountries([{ country: 'GB' }, { country: 'ZZ' }])).toEqual([]);
+	});
+});

--- a/packages/application/src/search-console-insights/lib/gsc-country.ts
+++ b/packages/application/src/search-console-insights/lib/gsc-country.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps a project's target locations (ISO-3166 alpha-2, e.g. `GB`) to the
+ * country codes GSC reports in its `country` dimension (ISO-3166 alpha-3
+ * lowercase, e.g. `gbr`). Used to scope the cockpit read-models to the
+ * project's market so a shared hub property doesn't show another market's
+ * traffic (#199).
+ *
+ * Focused map of the markets RankPulse serves (extensible one line at a time,
+ * like DATAFORSEO_LOCATION_CODES). Resolution is all-or-nothing: if ANY
+ * location is unmapped we return `[]` (no filter) rather than risk silently
+ * hiding that market's data.
+ */
+const ISO2_TO_ISO3: Record<string, string> = {
+	ES: 'esp',
+	US: 'usa',
+	GB: 'gbr',
+	FR: 'fra',
+	MX: 'mex',
+	DE: 'deu',
+	IT: 'ita',
+	PT: 'prt',
+	NL: 'nld',
+	BE: 'bel',
+	IE: 'irl',
+	CH: 'che',
+	AT: 'aut',
+	PL: 'pol',
+	SE: 'swe',
+	CA: 'can',
+	AU: 'aus',
+	AR: 'arg',
+	CO: 'col',
+	CL: 'chl',
+	PE: 'per',
+	BR: 'bra',
+	UY: 'ury',
+	EC: 'ecu',
+};
+
+/**
+ * Distinct GSC (alpha-3 lowercase) country codes for the project's locations,
+ * or `[]` when there are no locations or any location is unmapped — `[]` means
+ * "do not filter by country" to the read-models.
+ */
+export const resolveGscCountries = (locations: readonly { country: string }[]): readonly string[] => {
+	if (locations.length === 0) return [];
+	const mapped = locations.map((l) => ISO2_TO_ISO3[l.country.toUpperCase()]);
+	if (mapped.some((c) => c === undefined)) return [];
+	return [...new Set(mapped as string[])];
+};

--- a/packages/application/src/search-console-insights/use-cases/query-brand-decay.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-brand-decay.use-case.ts
@@ -1,5 +1,6 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
+import { resolveGscCountries } from '../lib/gsc-country.js';
 
 export interface QueryBrandDecayCommand {
 	projectId: string;
@@ -62,7 +63,11 @@ export class QueryBrandDecayUseCase {
 		const dropAlertPct = Math.max(1, cmd.dropAlertPct ?? DEFAULT_DROP_ALERT_PCT);
 
 		const brandTokens = this.brandTokensFor(project);
-		const rows = await this.cockpit.weeklyClicksByQuery(projectId, windowDays);
+		const rows = await this.cockpit.weeklyClicksByQuery(
+			projectId,
+			windowDays,
+			resolveGscCountries(project.locations),
+		);
 
 		// Group by week → branded/non-branded bucket.
 		const byWeek = new Map<

--- a/packages/application/src/search-console-insights/use-cases/query-clicks-forecast.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-clicks-forecast.use-case.ts
@@ -58,6 +58,9 @@ export class QueryClicksForecastUseCase {
 		}
 		const historyDays = cmd.historyDays ?? DEFAULT_HISTORY_DAYS;
 		const forecastDays = cmd.forecastDays ?? DEFAULT_FORECAST_DAYS;
+		// NOT country-scoped: the forecast needs 90d of history but country data
+		// only goes back as far as the daily fetch window (~30d), so filtering
+		// would truncate the series. Forecast = project total traffic (#199).
 		const rows = await this.cockpit.dailyTotalsForProject(project.id, historyDays);
 
 		const observedSeries = fillDailyGaps(rows, historyDays);

--- a/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-ctr-anomalies.use-case.ts
@@ -1,5 +1,6 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
+import { resolveGscCountries } from '../lib/gsc-country.js';
 
 export interface QueryCtrAnomaliesCommand {
 	projectId: string;
@@ -49,6 +50,7 @@ export class QueryCtrAnomaliesUseCase {
 		const rows = await this.cockpit.aggregateByQuery(projectId, windowDays, {
 			minImpressions,
 			limit: 1000,
+			countries: resolveGscCountries(project.locations),
 		});
 		const anomalies: CtrAnomalyDto[] = [];
 		for (const r of rows) {

--- a/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.spec.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.spec.ts
@@ -11,7 +11,13 @@ type FakeRow = Omit<SearchConsoleInsights.QueryAggregateRow, 'siteUrl'> & { site
 
 class FakeCockpit implements SearchConsoleInsights.GscCockpitReadModel {
 	rows: FakeRow[] = [];
-	async aggregateByQuery(): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
+	lastOptions: { minImpressions?: number; limit?: number; countries?: readonly string[] } | undefined;
+	async aggregateByQuery(
+		_projectId: ProjectManagement.ProjectId,
+		_windowDays: number,
+		options?: { minImpressions?: number; limit?: number; countries?: readonly string[] },
+	): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
+		this.lastOptions = options;
 		// Default siteUrl for the single-property cases; multi-property tests
 		// set it explicitly per row.
 		return this.rows.map((r) => ({ siteUrl: 'sc-domain:controlrondas.com', ...r }));
@@ -148,5 +154,22 @@ describe('QueryLostOpportunityUseCase', () => {
 		await expect(
 			useCase.execute({ projectId: '99999999-9999-9999-9999-999999999999' }),
 		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('scopes the GSC aggregate to the project target countries (#199)', async () => {
+		const FR_ID = '44444444-4444-4444-4444-444444444444' as Uuid as ProjectManagement.ProjectId;
+		await projects.save(
+			ProjectManagement.Project.create({
+				id: FR_ID,
+				organizationId: ORG_ID,
+				portfolioId: null,
+				name: 'PatrolTech FR',
+				primaryDomain: ProjectManagement.DomainName.create('patroltech.online'),
+				initialLocations: [ProjectManagement.LocationLanguage.create({ country: 'FR', language: 'fr-FR' })],
+				now: new Date('2026-04-01T00:00:00Z'),
+			}),
+		);
+		await useCase.execute({ projectId: FR_ID });
+		expect(cockpit.lastOptions?.countries).toEqual(['fra']);
 	});
 });

--- a/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-lost-opportunity.use-case.ts
@@ -1,6 +1,7 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
 import { ctrForPosition, DEFAULT_TARGET_POSITION } from '../lib/ctr-curve.js';
+import { resolveGscCountries } from '../lib/gsc-country.js';
 import { topNPerProperty } from '../lib/top-n-per-property.js';
 
 export interface QueryLostOpportunityCommand {
@@ -71,6 +72,7 @@ export class QueryLostOpportunityUseCase {
 		const rows = await this.cockpit.aggregateByQuery(projectId, windowDays, {
 			minImpressions,
 			limit: 2000,
+			countries: resolveGscCountries(project.locations),
 		});
 
 		const out: LostOpportunityDto[] = [];

--- a/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.ts
+++ b/packages/application/src/search-console-insights/use-cases/query-quick-win-roi.use-case.ts
@@ -1,6 +1,7 @@
 import type { ProjectManagement, SearchConsoleInsights } from '@rankpulse/domain';
 import { NotFoundError } from '@rankpulse/shared';
 import { ctrForPosition } from '../lib/ctr-curve.js';
+import { resolveGscCountries } from '../lib/gsc-country.js';
 import { topNPerProperty } from '../lib/top-n-per-property.js';
 
 export interface QueryQuickWinRoiCommand {
@@ -71,6 +72,7 @@ export class QueryQuickWinRoiUseCase {
 		const rows = await this.cockpit.aggregateByQuery(projectId, windowDays, {
 			minImpressions,
 			limit: 2000,
+			countries: resolveGscCountries(project.locations),
 		});
 
 		const out: QuickWinRoiDto[] = [];

--- a/packages/domain/src/search-console-insights/ports/gsc-cockpit-read-model.ts
+++ b/packages/domain/src/search-console-insights/ports/gsc-cockpit-read-model.ts
@@ -31,7 +31,16 @@ export interface GscCockpitReadModel {
 	aggregateByQuery(
 		projectId: ProjectId,
 		windowDays: number,
-		options?: { minImpressions?: number; limit?: number },
+		options?: {
+			minImpressions?: number;
+			limit?: number;
+			/**
+			 * GSC country codes (ISO-3166 alpha-3 lowercase, e.g. `fra`) to scope
+			 * the aggregate to. Empty/undefined = all countries. Lets the cockpit
+			 * show a market project only its country's traffic (#199).
+			 */
+			countries?: readonly string[];
+		},
 	): Promise<readonly QueryAggregateRow[]>;
 
 	/**
@@ -39,7 +48,11 @@ export interface GscCockpitReadModel {
 	 * Brand-vs-No-Brand decay alert: the use case classifies each query as
 	 * branded or not, sums weekly, and compares week-over-week.
 	 */
-	weeklyClicksByQuery(projectId: ProjectId, windowDays: number): Promise<readonly WeeklyClicksByQueryRow[]>;
+	weeklyClicksByQuery(
+		projectId: ProjectId,
+		windowDays: number,
+		countries?: readonly string[],
+	): Promise<readonly WeeklyClicksByQueryRow[]>;
 
 	/**
 	 * Project-level daily totals (clicks + impressions) over the trailing
@@ -51,6 +64,7 @@ export interface GscCockpitReadModel {
 	dailyTotalsForProject(
 		projectId: ProjectId,
 		windowDays: number,
+		countries?: readonly string[],
 	): Promise<readonly DailyClicksImpressionsRow[]>;
 }
 

--- a/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
+++ b/packages/infrastructure/src/persistence/drizzle/repositories/search-console-insights/gsc-cockpit-read-model.ts
@@ -3,13 +3,26 @@ import { sql } from 'drizzle-orm';
 import type { DrizzleDatabase } from '../../client.js';
 import { toDate, unwrap } from '../../utils/postgres-js-coercions.js';
 
+/**
+ * `AND country IN (...)` when countries are given (GSC alpha-3 lowercase, e.g.
+ * `fra`), else an empty fragment. Scopes the cockpit to a project's market so a
+ * shared hub property doesn't surface another market's traffic (#199).
+ */
+const countryFilterSql = (countries?: readonly string[]) =>
+	countries && countries.length > 0
+		? sql`AND country IN (${sql.join(
+				countries.map((c) => sql`${c}`),
+				sql`, `,
+			)})`
+		: sql``;
+
 export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCockpitReadModel {
 	constructor(private readonly db: DrizzleDatabase) {}
 
 	async aggregateByQuery(
 		projectId: ProjectManagement.ProjectId,
 		windowDays: number,
-		options?: { minImpressions?: number; limit?: number },
+		options?: { minImpressions?: number; limit?: number; countries?: readonly string[] },
 	): Promise<readonly SearchConsoleInsights.QueryAggregateRow[]> {
 		const minImpr = Math.max(0, options?.minImpressions ?? 0);
 		const limit = Math.min(Math.max(options?.limit ?? 500, 1), 5000);
@@ -55,6 +68,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					)
 					AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 					AND query <> ''
+					${countryFilterSql(options?.countries)}
 				GROUP BY gsc_property_id, query, page
 			)
 			SELECT
@@ -95,6 +109,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 	async weeklyClicksByQuery(
 		projectId: ProjectManagement.ProjectId,
 		windowDays: number,
+		countries?: readonly string[],
 	): Promise<readonly SearchConsoleInsights.WeeklyClicksByQueryRow[]> {
 		const result = await this.db.execute(sql<{
 			week_start: string;
@@ -114,6 +129,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
 				AND query <> ''
+				${countryFilterSql(countries)}
 			GROUP BY week_start, query
 			ORDER BY week_start ASC, clicks DESC
 		`);
@@ -135,6 +151,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 	async dailyTotalsForProject(
 		projectId: ProjectManagement.ProjectId,
 		windowDays: number,
+		countries?: readonly string[],
 	): Promise<readonly SearchConsoleInsights.DailyClicksImpressionsRow[]> {
 		// One row per UTC day, summed across every dimension (query, page,
 		// country, device, GSC property). We DON'T filter `query <> ''` here
@@ -155,6 +172,7 @@ export class DrizzleGscCockpitReadModel implements SearchConsoleInsights.GscCock
 					SELECT id FROM gsc_properties WHERE project_id = ${projectId}::uuid AND unlinked_at IS NULL
 				)
 				AND observed_at >= now() - (${windowDays}::int * interval '1 day')
+				${countryFilterSql(countries)}
 			GROUP BY day
 			ORDER BY day ASC
 		`);


### PR DESCRIPTION
Fase 2 de #199 — **el fix visible** de los bugs 1 y 2. `Closes #199`.

## Qué
El hub `patroltech.online` (enlazado a los 4 mercados) dominaba el cockpit de cada proyecto → brand-decay/lost-opportunity/quick-win/ctr-anomaly devolvían los mismos datos (en castellano) para ES/EN/FR/MX. `projectId` siempre se respetó; faltaba **segmentar por país**.

- **read-models** (`aggregateByQuery`/`weeklyClicksByQuery`/`dailyTotalsForProject`): aceptan `countries` (GSC ISO-3 minúsculas, p.ej. `fra`) → `AND country IN (...)`.
- **lib** `resolveGscCountries`: mapea las locations del proyecto (ISO-2) → GSC ISO-3, todo-o-nada (si alguna no mapea → sin filtro, nunca oculta un mercado).
- **use cases**: lost-opp/quick-win/ctr/brand-decay filtran por el país del proyecto (`project.locations`). **Forecast NO** (necesita 90d y el país solo cubre ~30d).

## Dependencias / datos
- Construye sobre la dimensión `country` de #203 (Fase 1, ya desplegada + backfill hecho).
- Limpieza única en prod de las filas `''` duplicadas pre-country tras el backfill (**7718 borradas**, EXISTS-based sin pérdida; el cron diario ya escribe solo filas con país → sin recurrencia). Verificado: dup-check = 0.

## Verificación post-merge
Tras el deploy, compruebo en vivo que FR/MX/EN dejan de devolver las queries de hospitales en castellano y ven su mercado.

`lint`/`typecheck` (27/27)/`test` (27/27)/`build` (24/24) verdes. Nuevos tests: `gsc-country` + scoping en lost-opportunity.

Closes #199